### PR TITLE
Refactor: Make data editing an explicit step in the main workflow

### DIFF
--- a/GerenciadorRegistros/GerenciadorRegistros.jsx
+++ b/GerenciadorRegistros/GerenciadorRegistros.jsx
@@ -9,8 +9,8 @@ import ModalConfirmacao from './ModalConfirmacao/ModalConfirmacao';
 const GerenciadorRegistros = ({
     registrosIniciais = [],
     colunasIniciais = [],
-    onConcluirEdicao,
-    darkMode = false // Nova prop para modo escuro
+    onDadosAlterados, // Renomeado de onConcluirEdicao
+    darkMode = false
 }) => {
     const [registros, setRegistros] = useState([]);
     const [colunas, setColunas] = useState([]);
@@ -137,13 +137,18 @@ const GerenciadorRegistros = ({
     //     }
     // };
 
-    const handleConcluir = () => {
-        if (onConcluirEdicao) {
-            onConcluirEdicao(JSON.parse(JSON.stringify(registros)), [...colunas]);
+    // Efeito para chamar onDadosAlterados quando registros ou colunas mudam
+    useEffect(() => {
+        if (onDadosAlterados) {
+            onDadosAlterados(JSON.parse(JSON.stringify(registros)), [...colunas]);
         }
-        // console.log('Concluir Edição. Dados atuais:', registros, colunas);
-        // alert('Dados prontos para serem salvos pela aplicação principal. Ver console.');
-    };
+    }, [registros, colunas, onDadosAlterados]);
+
+    // const handleConcluir = () => { // Removido - botão de concluir foi removido
+    //     if (onConcluirEdicao) { // Agora onDadosAlterados
+    //         onConcluirEdicao(JSON.parse(JSON.stringify(registros)), [...colunas]);
+    //     }
+    // };
 
   const containerClasses = `${styles.container} ${darkMode ? styles.darkMode : ''}`;
 
@@ -205,12 +210,12 @@ const GerenciadorRegistros = ({
                 />
             )}
 
-      {/* Botão de concluir edição sempre visível para permitir sair mesmo sem registros */}
-      <div className={styles.actionsFooter}>
+      {/* Botão de concluir edição removido, pois a navegação é feita pelo App.jsx */}
+      {/* <div className={styles.actionsFooter}>
         <button onClick={handleConcluir} className={`${styles.btn} ${styles.btnSuccess}`}>
           Concluir Edição e Retornar Dados
         </button>
-      </div>
+      </div> */}
         </div>
     );
 };


### PR DESCRIPTION
- Restructured the application flow in App.jsx to include five distinct steps:
  1. Define Initial Data (CSV upload or manual preparation)
  2. Edit Data (using GerenciadorRegistros)
  3. Upload Image
  4. Position & Format
  5. Generate Images
- GerenciadorRegistros is now rendered directly as the content for the "Edit Data" step, replacing the previous modal-based approach.
- Removed the `showGerenciadorRegistros` state from App.jsx.
- The prop `onConcluirEdicao` for GerenciadorRegistros was renamed to `onDadosAlterados` and is now called by GerenciadorRegistros whenever its internal data (registros or colunas) changes, ensuring App.jsx state is always synchronized.
- Removed the internal "Concluir Edição" button from GerenciadorRegistros; step navigation is now exclusively handled by App.jsx's main navigation buttons.
- Adjusted `handleCSVUpload` in App.jsx to no longer automatically advance the step.
- Updated the `canProceedToStep` logic in App.jsx to accommodate the new five-step structure and its specific conditions (e.g., requiring data to proceed from editing to image upload).
- Modified UI text and button actions in Step 0 to guide the user towards the new "Edit Data" step.