### PR TITLE
Fix: Resolve render loop in data editing step

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react'; // Correção: Restaurar importação completa
 import { useIsMobile } from './hooks/use-mobile'; // Importa o hook
 import {
   Container,
@@ -33,6 +33,9 @@ import {
 } from '@mui/icons-material';
 import Papa from 'papaparse';
 import ColorThief from 'colorthief';
+// import React, { useState, useRef, useEffect, useCallback } from 'react'; // Removido, pois já está no topo
+import { useIsMobile } from './hooks/use-mobile'; // Importa o hook
+// ... (outros imports)
 // Adicionar Menu e MenuItem para o menu de ações
 import { Menu, MenuItem } from '@mui/material';
 // Imports para Theming
@@ -492,7 +495,7 @@ function App() {
   };
 
   // Renomeado de handleConcluirEdicaoRegistros para handleDadosAlterados
-  const handleDadosAlterados = (novosRegistros, novasColunas) => {
+  const handleDadosAlterados = useCallback((novosRegistros, novasColunas) => {
     setCsvData(novosRegistros);
     setCsvHeaders(novasColunas);
 
@@ -535,7 +538,7 @@ function App() {
     // setShowGerenciadorRegistros(false); // Removido
     // A lógica de avançar o passo foi removida daqui, será controlada pelos botões globais Next/Back
     // e pela lógica em canProceedToStep.
-  };
+  }, [darkMode, fieldPositions, fieldStyles, setCsvData, setCsvHeaders, setFieldPositions, setFieldStyles]);
 
 
   const currentTheme = darkMode ? darkTheme : lightTheme;


### PR DESCRIPTION
- Applied `useCallback` to the `handleDadosAlterados` function in `App.jsx`.
- This prevents the function from being recreated on every render of `App.jsx`, thus providing a stable reference to the `GerenciadorRegistros` component.
- The stable reference for the `onDadosAlterados` prop (passed to `GerenciadorRegistros`) stops an infinite loop that was occurring due to the `useEffect` hook in `GerenciadorRegistros` (which depends on this prop) being triggered连锁ly by state updates in `App.jsx`.
- Ensured React and `useCallback` imports are correctly placed and not duplicated.