### PR TITLE
Fix: Resolve render loop by refactoring callback logic for data editing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -728,16 +728,7 @@ function App() {
                       onChange={handleCSVUpload}
                     />
                   </Button>
-                  <Button
-                    variant="outlined"
-                    size="large"
-                    startIcon={<Edit />}
-                    sx={{ mb: 2, ml: 2 }}
-                    // onClick={handleOpenGerenciadorRegistros} // Removido - A navegação para edição é via botão "Próximo"
-                    onClick={() => setActiveStep(1)} // Alternativamente, um botão dedicado para ir para edição
-                  >
-                    Revisar/Editar Dados
-                  </Button>
+                  {/* Botão "Revisar/Editar Dados" removido. A navegação para a próxima etapa (edição) será feita pelo botão "Próximo" global. */}
                   
                   <Typography variant="body2" color="textSecondary">
                     {steps[0].description}


### PR DESCRIPTION
- Removed the explicit button for 'Revisar/Editar Dados' from Step 0 in App.jsx; navigation to the editing step is now handled by the main 'Next' button.
- Refactored how `onDadosAlterados` is invoked in `GerenciadorRegistros.jsx`:
  - Removed the `useEffect` hook that previously watched for changes in internal `registros` and `colunas` state to call `onDadosAlterados`.
  - `onDadosAlterados` is now called directly from within the CRUD operations (`handleSalvarRegistro`, `handleConfirmarExclusao`) after the internal state is updated.
  - `onDadosAlterados` is also called once from the initialization `useEffect` (which processes `registrosIniciais` and `colunasIniciais`) to ensure the parent `App.jsx` is synchronized with the initial state derived from props.
- The `handleDadosAlterados` function in `App.jsx` remains memoized with `useCallback`, and its dependencies were reviewed.

This new approach aims to break the feedback cycle that was causing a render loop when transitioning to or interacting with the data editing step, by ensuring `onDadosAlterados` is called more controllably.