### PR TITLE
Fix: Prevent input loss during typing in GerenciadorRegistros

### DIFF
--- a/GerenciadorRegistros/GerenciadorRegistros.jsx
+++ b/GerenciadorRegistros/GerenciadorRegistros.jsx
@@ -59,14 +59,10 @@ const GerenciadorRegistros = ({
             setColunas(currentCols);
         }
 
-        if (onDadosAlterados) {
-            // Assegurar que onDadosAlterados seja chamado após o estado ser realmente definido.
-            // No entanto, como setColunas e setRegistros são assíncronos,
-            // os valores de colunas e registros podem não estar atualizados aqui imediatamente.
-            // A chamada a onDadosAlterados aqui é para sincronizar o estado inicial.
-            onDadosAlterados(JSON.parse(JSON.stringify(dadosProcessados)), [...currentCols]);
-        }
-    }, [registrosIniciais, colunasIniciais, gerarIdUnico, onDadosAlterados]);
+        // if (onDadosAlterados) { // Removida a chamada de onDadosAlterados daqui
+        //     onDadosAlterados(JSON.parse(JSON.stringify(dadosProcessados)), [...currentCols]);
+        // }
+    }, [registrosIniciais, colunasIniciais, gerarIdUnico]); // Removido onDadosAlterados das dependências aqui
 
 
     // Handlers para abrir modais


### PR DESCRIPTION
- Modified `GerenciadorRegistros.jsx` to prevent premature state resets that caused loss of user input during typing in the edit/add modal.
- Removed the call to `onDadosAlterados` from the main `useEffect` hook that processes `registrosIniciais` and `colunasIniciais` (the initialization effect).
- `onDadosAlterados` is now exclusively called after explicit user actions that modify data (saving or deleting a record).
- This change ensures that the internal state of `GerenciadorRegistros` (and consequently the state of the form in `ModalRegistro`) is not reset by prop changes from `App.jsx` while the user is actively editing, resolving the issue of typed content being lost or the cursor jumping.