### PR TITLE
Fix: Prevent loss of all records when deleting one

### DIFF
--- a/GerenciadorRegistros/GerenciadorRegistros.jsx
+++ b/GerenciadorRegistros/GerenciadorRegistros.jsx
@@ -127,14 +127,18 @@ const GerenciadorRegistros = ({
     };
 
     const handleConfirmarExclusao = () => {
-        let novosRegistros = registros;
         if (registroSelecionado && registroSelecionado.id !== undefined) {
-            novosRegistros = registros.filter(reg => String(reg.id) !== String(registroSelecionado.id));
-            setRegistros(novosRegistros);
-        }
+            const registrosAposExclusao = registros.filter(
+                reg => String(reg.id) !== String(registroSelecionado.id)
+            );
+            setRegistros(registrosAposExclusao);
 
-        if (onDadosAlterados) {
-            onDadosAlterados(JSON.parse(JSON.stringify(novosRegistros)), [...colunas]);
+            if (onDadosAlterados) {
+                onDadosAlterados(
+                    JSON.parse(JSON.stringify(registrosAposExclusao)),
+                    [...colunas]
+                );
+            }
         }
         handleFecharModal();
     };


### PR DESCRIPTION
- Corrected the logic in `handleConfirmarExclusao` in `GerenciadorRegistros.jsx`.
- Ensured that when a record is deleted, only the selected record is removed from the internal state (`registros`).
- The `onDadosAlterados` callback is now correctly invoked with the accurately filtered list of remaining records and the current columns.
- This resolves a critical bug where deleting a single record would erroneously cause all records to be lost or an incorrect state to be propagated to the parent App.jsx component.