### PR TITLE
Fix: Correct import path for deepSeekCredentials and JSX syntax

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,7 +51,7 @@ import FieldPositioner from './components/FieldPositioner';
 import ImageGeneratorFrontendOnly from './components/ImageGeneratorFrontendOnly';
 import GerenciadorRegistros from '../GerenciadorRegistros/GerenciadorRegistros'; // Importar o GerenciadorRegistros
 import DeepSeekAuthSetup from './components/DeepSeekAuthSetup'; // Importar o componente de configuração da API DeepSeek
-import { getDeepSeekApiKey } from '../utils/deepSeekCredentials'; // Importar utilitário para verificar a chave
+import { getDeepSeekApiKey } from './utils/deepSeekCredentials'; // Caminho corrigido
 import VpnKeyIcon from '@mui/icons-material/VpnKey'; // Ícone para a chave da API
 import './App.css';
 


### PR DESCRIPTION
- Corrected the import path for `deepSeekCredentials` in `src/App.jsx` to `./utils/deepSeekCredentials`, resolving a module resolution error during build/dev.
- Addressed various JSX syntax errors in `src/App.jsx` by ensuring proper nesting and closing of Material UI tags (Card, CardContent, Grid) within the conditional rendering logic of Step 0 and at the end of the main component structure. This resolves build failures and linting issues.
- Removed an empty CSS ruleset from `GerenciadorRegistros/LinhaRegistro/LinhaRegistro.module.css`.