### PR TITLE
Chore: Remove console.logs após investigação da imagem de fundo indiv…

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -56,6 +56,8 @@ const GeneratedImageEditor = ({
 
   useEffect(() => {
     if (imageData && initialFieldPositions && initialFieldStyles) { // Added null checks for robustness
+      // console.log('[GeneratedImageEditor useEffect] imageData.backgroundImage:', imageData.backgroundImage ? imageData.backgroundImage.substring(0, 100) + '...' : 'undefined');
+      // console.log('[GeneratedImageEditor useEffect] globalBackgroundImage:', globalBackgroundImage ? globalBackgroundImage.substring(0, 100) + '...' : 'undefined');
       setSelectedFieldInternal(null); // Reseta o campo selecionado ao abrir/mudar imagem
       // Deep copy for positions
       setEditedPositions(JSON.parse(JSON.stringify(initialFieldPositions)));
@@ -96,6 +98,7 @@ const GeneratedImageEditor = ({
   // Prioriza uma imagem de fundo específica da imageData (se existir, ex: após substituição individual)
   // Caso contrário, usa a imagem de fundo global.
   const currentBackgroundImageForEditor = imageData.backgroundImage || globalBackgroundImage;
+  // console.log('[GeneratedImageEditor render] currentBackgroundImageForEditor:', currentBackgroundImageForEditor ? currentBackgroundImageForEditor.substring(0, 100) + '...' : 'undefined');
 
   // Os cabeçalhos CSV para este editor devem ser os da linha específica sendo editada.
   // FieldPositioner e FormattingPanel esperam uma lista de todos os cabeçalhos para popular seletores, etc.

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -446,6 +446,7 @@ const ImageGeneratorFrontendOnly = ({
       ? imageToEdit.customFieldStyles
       : fieldStyles;
     
+    // console.log('[handleOpenGeneratedImageEditor] imageToEdit.backgroundImage:', imageToEdit.backgroundImage ? imageToEdit.backgroundImage.substring(0, 100) + '...' : 'undefined');
     setIndividualFieldPositions(JSON.parse(JSON.stringify(currentPositions)));
     setIndividualFieldStyles(JSON.parse(JSON.stringify(currentStyles))); // This will be initialFieldStyles in GeneratedImageEditor
     setShowGeneratedImageEditor(true);
@@ -481,10 +482,14 @@ const ImageGeneratorFrontendOnly = ({
     // Regerar a imagem específica com as novas posições/estilos
     const imageToRegenerate = updatedImages.find(im => im.index === imageIndex);
     if (imageToRegenerate) {
+      const bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
+      // console.log('[handleSaveIndividualModifications] imageToRegenerate.backgroundImage:', imageToRegenerate.backgroundImage ? imageToRegenerate.backgroundImage.substring(0, 100) + '...' : 'undefined');
+      // console.log('[handleSaveIndividualModifications] backgroundImage (global):', backgroundImage ? backgroundImage.substring(0, 100) + '...' : 'undefined');
+      // console.log('[handleSaveIndividualModifications] bgToUse for regenerateSingleImage:', bgToUse ? bgToUse.substring(0, 100) + '...' : 'undefined');
       regenerateSingleImage(
         imageIndex,
         csvRecord, // Dados CSV originais da imagem
-        imageToRegenerate.backgroundImage || backgroundImage, // BG atual da imagem
+        bgToUse, // BG atual da imagem
         newPositions, // Novas posições
         newStyles // Novos estilos
       );
@@ -600,10 +605,17 @@ const ImageGeneratorFrontendOnly = ({
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
         backgroundImage: currentBackgroundImage // Store the background image used for this specific image
       };
+      // console.log('[regenerateSingleImage] newImageData.backgroundImage:', newImageData.backgroundImage ? newImageData.backgroundImage.substring(0, 100) + '...' : 'undefined'); // Log a snippet
 
-      setGeneratedImages(prevImages =>
-        prevImages.map(img => (img.index === index ? newImageData : img))
-      );
+      setGeneratedImages(prevImages => {
+        const updatedImages = prevImages.map(img => (img.index === index ? newImageData : img));
+        // Log para verificar a imagem específica após a atualização do estado
+        // const updatedImageForLog = updatedImages.find(img => img.index === index);
+        // if (updatedImageForLog) {
+        //   console.log(`[regenerateSingleImage - setGeneratedImages callback] Image index ${index} updated. backgroundImage:`, updatedImageForLog.backgroundImage ? updatedImageForLog.backgroundImage.substring(0,100) + '...' : 'undefined');
+        // }
+        return updatedImages;
+      });
 
     } catch (error) {
       console.error('Erro na regeneração da imagem:', error);


### PR DESCRIPTION
…idual

A investigação e os testes manuais confirmaram que a funcionalidade de imagem de fundo individual está operando corretamente, incluindo definição, edição, salvamento e recarregamento do template.

Este commit remove os console.logs adicionados para fins de depuração durante a investigação.