### PR TITLE
Feat: Enable in-place text editing in preview areas

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -606,6 +606,13 @@ function App() {
     // e pela lógica em canProceedToStep.
   }, [darkMode, fieldPositions, fieldStyles, setCsvData, setCsvHeaders, setFieldPositions, setFieldStyles]);
 
+
+  // Callback for FieldPositioner to update csvData when text is edited in-place
+  const handleCsvRecordContentUpdate = useCallback((newCsvData) => {
+    setCsvData(newCsvData);
+    // No need to update headers or fieldPositions/Styles here, as only content changes.
+  }, [setCsvData]);
+
   const handleGenerateIAContent = async () => {
     setIsGenerating(true);
 
@@ -1321,6 +1328,7 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
               csvData={csvData}
               onImageDisplayedSizeChange={setDisplayedImageSize}
               colorPalette={colorPalette}
+              onCsvDataUpdate={handleCsvRecordContentUpdate} // Pass the callback here
             />
           )}
 

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -32,7 +32,8 @@ const FieldPositioner = ({
   onImageDisplayedSizeChange,
   colorPalette,
   onSelectFieldExternal,
-  showFormattingPanel = true
+  showFormattingPanel = true,
+  onCsvDataUpdate // New prop to notify App.jsx of changes
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
@@ -200,6 +201,28 @@ const FieldPositioner = ({
     setIsInteracting(false);
   };
 
+  const handleContentChange = (field, newText) => {
+    if (!csvData || csvData.length === 0) return;
+
+    const updatedCsvData = csvData.map((row, index) => {
+      if (index === currentPreviewIndex) {
+        return {
+          ...row,
+          [field]: newText,
+        };
+      }
+      return row;
+    });
+
+    // If FieldPositioner is responsible for its own state:
+    // setCsvData(updatedCsvData); // Assuming csvData is also a state here, if not passed down directly
+
+    // Propagate change upwards
+    if (onCsvDataUpdate) {
+      onCsvDataUpdate(updatedCsvData);
+    }
+  };
+
   // Navigation handlers
   const handleNextPreview = () => {
     setCurrentPreviewIndex(prevIndex => Math.min(prevIndex + 1, csvData.length - 1));
@@ -360,6 +383,7 @@ const FieldPositioner = ({
                       onPositionChange={handlePositionChange}
                       onSizeChange={handleSizeChange}
                       containerSize={imageSize}
+                      onContentChange={handleContentChange} // Pass the handler to TextBox
                     />
                   );
                 })


### PR DESCRIPTION
- Modified TextBox.jsx to allow in-place text editing:
    - Added isEditing state and onContentChange callback.
    - Text content becomes a textarea on double-click when selected.
    - Changes are committed on blur or Enter key.
    - Styling applied to textarea for visual consistency.
    - Dragging/resizing disabled and handles hidden during edit mode.

- Updated FieldPositioner.jsx:
    - Added onCsvDataUpdate prop to propagate changes to App.jsx.
    - Implemented handleContentChange to update csvData via this prop.
    - Passed onContentChange to TextBox instances.

- Updated GeneratedImageEditor.jsx:
    - Added editedRecord state to manage text content for the specific image.
    - FieldPositioner within the editor now uses editedRecord for preview.
    - Text changes in the editor update editedRecord locally.
    - On save, the updated editedRecord is passed up for image regeneration.

- Updated App.jsx:
    - Added handleCsvRecordContentUpdate callback.
    - Passed this callback to FieldPositioner as onCsvDataUpdate to update the main csvData state.