### PR TITLE
Fix: Resolve issues with inline text editing in TextBox

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -46,12 +46,12 @@ const FieldPositioner = ({
                    ('ontouchstart' in window) || 
                    (navigator.maxTouchPoints > 0);
 
-  const handleFieldSelectInternal = (field) => {
-    setSelectedField(field);
+  const handleFieldSelectInternal = useCallback((fieldToSelect) => {
+    setSelectedField(fieldToSelect);
     if (onSelectFieldExternal) {
-      onSelectFieldExternal(field);
+      onSelectFieldExternal(fieldToSelect);
     }
-  };
+  }, [onSelectFieldExternal]); // setSelectedField is stable
 
   useEffect(() => {
     const container = containerRef.current;
@@ -201,7 +201,7 @@ const FieldPositioner = ({
     setIsInteracting(false);
   };
 
-  const handleContentChange = (field, newText) => {
+  const handleContentChange = useCallback((field, newText) => {
     if (!csvData || csvData.length === 0) return;
 
     const updatedCsvData = csvData.map((row, index) => {
@@ -221,7 +221,7 @@ const FieldPositioner = ({
     if (onCsvDataUpdate) {
       onCsvDataUpdate(updatedCsvData);
     }
-  };
+  }, [csvData, currentPreviewIndex, onCsvDataUpdate]);
 
   // Navigation handlers
   const handleNextPreview = () => {

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react'; // Import useCallback
 import {
   Dialog,
   DialogTitle,
@@ -55,6 +55,15 @@ const GeneratedImageEditor = ({
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null); // Estado para o campo selecionado internamente
   const [stylesAreInitialized, setStylesAreInitialized] = useState(false); // New state for initialization tracking
 
+  const handleInternalFieldSelection = useCallback((fieldToSelect) => {
+    setSelectedFieldInternal(fieldToSelect);
+  }, []); // setSelectedFieldInternal is stable
+
+  const handleFieldPositionerCsvDataUpdate = useCallback((updatedDataArray) => {
+    if (updatedDataArray && updatedDataArray.length > 0) {
+      setEditedRecord(updatedDataArray[0]);
+    }
+  }, []); // setEditedRecord is stable
 
   useEffect(() => {
     if (imageData && initialFieldPositions && initialFieldStyles) {
@@ -150,16 +159,9 @@ const GeneratedImageEditor = ({
                 csvData={editorCsvData} // Dados CSV desta imagem para preview
                 onImageDisplayedSizeChange={setDisplayedEditorImageSize} // Para o editor interno
                 colorPalette={colorPalette}
-                onSelectFieldExternal={setSelectedFieldInternal} // Atualizar o estado interno
+                onSelectFieldExternal={handleInternalFieldSelection} // Use memoized handler
                 showFormattingPanel={false} // Adicionado para não duplicar o painel
-                // Pass the content change handler to FieldPositioner, which will pass it to TextBox
-                onCsvDataUpdate={(updatedDataArray) => {
-                  // FieldPositioner's onCsvDataUpdate gives the whole array.
-                  // We only care about the first (and only) record in this context.
-                  if (updatedDataArray && updatedDataArray.length > 0) {
-                    setEditedRecord(updatedDataArray[0]);
-                  }
-                }}
+                onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
               />
             </Grid>
             <Grid item xs={12} md={4}>

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -268,10 +268,30 @@ const TextBox = ({
     setEditedContent(e.target.value);
   };
 
-  const handleTextareaBlur = () => {
-    setIsEditing(false);
-    if (onContentChange && content !== editedContent) {
+  const commitChanges = () => {
+    // Only call onContentChange if the content has actually changed
+    if (isEditing && onContentChange && content !== editedContent) {
       onContentChange(field, editedContent);
+    }
+    setIsEditing(false); // Ensure isEditing is set to false after committing
+                         // This should happen regardless of content change to exit edit mode.
+  };
+
+  const handleTextareaBlur = () => {
+    commitChanges();
+  };
+
+  const handleTextareaKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      commitChanges();
+      // Explicitly blur after committing via Enter key to ensure focus shifts correctly.
+      textareaRef.current?.blur();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setEditedContent(content); // Revert to original prop content
+      setIsEditing(false);
+      textareaRef.current?.blur(); // Ensure blur on escape too
     }
   };
 
@@ -411,12 +431,7 @@ const TextBox = ({
           value={editedContent}
           onChange={handleTextareaChange}
           onBlur={handleTextareaBlur}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              textareaRef.current?.blur();
-            }
-          }}
+          onKeyDown={handleTextareaKeyDown} // Use the dedicated handler
           style={{ // Inline styles for the textarea
             width: '100%',
             height: '100%',


### PR DESCRIPTION
- Content not saving: Ensured edit commit logic in TextBox directly calls onContentChange and updates editing state robustly for both Enter key and blur events. Added explicit blur() call after Enter commit.
- Field unselectable after edit: Stabilized selection and content change callbacks in FieldPositioner and GeneratedImageEditor using useCallback to ensure consistent function references and prevent stale closures.
- Added Escape key handling in TextBox to cancel edits and revert content.

These changes address the problems where edited text was not consistently saved and fields became unselectable after an editing operation.