### PR TITLE
Fix: Add missing useCallback import in FieldPositioner.jsx

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react'; // Added useCallback
 import {
   Box,
   Typography,


### PR DESCRIPTION
Resolved a runtime error 'ReferenceError: useCallback is not defined' by adding 'useCallback' to the list of named imports from 'react' in src/components/FieldPositioner.jsx.

This component was using useCallback for memoizing handlers but was missing the necessary import, leading to the runtime error.