### PR TITLE
Refactor: Improve focus management in TextBox for inline editing

### DIFF
--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -32,6 +32,14 @@ const TextBox = ({
     }
   }, [content, isEditing]);
 
+  // Effect to focus and select text when entering edit mode
+  useEffect(() => {
+    if (isEditing && isSelected && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [isEditing, isSelected]);
+
   const pixelPosition = {
     x: (position.x / 100) * containerSize.width,
     y: (position.y / 100) * containerSize.height,
@@ -256,11 +264,7 @@ const TextBox = ({
   const handleDoubleClick = () => {
     if (isSelected) {
       setIsEditing(true);
-      // Focus the textarea after a short delay to ensure it's rendered
-      setTimeout(() => {
-        textareaRef.current?.focus();
-        textareaRef.current?.select();
-      }, 0);
+      // Focus is now handled by the useEffect hook
     }
   };
 


### PR DESCRIPTION
- Moved textarea focus and text selection logic into a useEffect hook in TextBox.jsx, triggered by changes to `isEditing` and `isSelected` states.
- Removed explicit focus call from `handleDoubleClick` as it's now handled by the effect.

This change aims to make focus handling more robust and aligned with React's declarative patterns, further addressing issues related to the inline editing experience.