### PR TITLE
Fix: Prevent TextBox from re-selecting itself on blur

### DIFF
--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -287,7 +287,9 @@ const TextBox = ({
             onContentChange(field, editedContent); // Commit content if changed
         }
         setIsEditing(false); // Exit editing mode
-        onSelect(field);     // Explicitly try to select this field
+        // The onSelect(field) call has been removed.
+        // Selection will now be handled by the click event on other elements (another field or the background)
+        // or by the Enter key handler if that's how editing was concluded.
     }
   };
 


### PR DESCRIPTION
Removes the unconditional `onSelect(field)` call from the `handleTextareaBlur` method in `TextBox.jsx`.

This resolves an issue where finishing an edit by clicking another field or the background would cause the edited field to incorrectly re-select itself or interfere with the new selection state.

The `handleTextareaBlur` method now correctly focuses on committing changes and exiting the editing state, leaving selection management to the specific user interaction (e.g., click on another field, click on background, or Enter key press).