### PR TITLE
Fix: Allow TextBox drag/resize after blur-save

### DIFF
--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -287,7 +287,7 @@ const TextBox = ({
             onContentChange(field, editedContent); // Commit content if changed
         }
         setIsEditing(false); // Exit editing mode
-        onSelect(field);     // Explicitly try to select this field
+        // onSelect(field) removed
     }
   };
 


### PR DESCRIPTION
Removes the onSelect(field) call from handleTextareaBlur in TextBox.jsx. This change aims to resolve an issue where a field becomes non-draggable and non-resizable after its content is saved via a blur event.

By simplifying the blur handler, the selection state is more cleanly determined by subsequent explicit user interactions. This should allow the field to be properly selected and then dragged/resized after a blur-induced save.