### PR TITLE
Fix: Sync thumbnail edits with main CSV and reconcile generated images

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -604,7 +604,32 @@ function App() {
     // setShowGerenciadorRegistros(false); // Removido
     // A lógica de avançar o passo foi removida daqui, será controlada pelos botões globais Next/Back
     // e pela lógica em canProceedToStep.
-  }, [darkMode, fieldPositions, fieldStyles, setCsvData, setCsvHeaders, setFieldPositions, setFieldStyles]);
+
+    // Reconcile generatedImagesData with the new csvData (novosRegistros)
+    setGeneratedImagesData(prevGeneratedImages => {
+      if (prevGeneratedImages.length !== novosRegistros.length) {
+        // Lengths are different, rebuild generatedImagesData from scratch
+        // This will reset any individual thumbnail customizations
+        return novosRegistros.map((record, index) => ({
+          index,
+          record,
+          blob: null,
+          url: null,
+          filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
+          backgroundImage: backgroundImage, // Use global background
+          // customFieldPositions and customFieldStyles will be undefined, relying on global defaults
+        }));
+      } else {
+        // Lengths are the same, update records while trying to preserve customizations
+        return prevGeneratedImages.map((oldImage, index) => ({
+          ...oldImage,
+          record: novosRegistros[index], // Update the record to match new csvData
+          index: index,                  // Ensure index is current
+        }));
+      }
+    });
+
+  }, [darkMode, fieldPositions, fieldStyles, setCsvData, setCsvHeaders, setFieldPositions, setFieldStyles, backgroundImage, generatedImagesData.length]); // Added backgroundImage and generatedImagesData.length
 
 
   // Callback for FieldPositioner to update csvData when text is edited in-place


### PR DESCRIPTION
This commit addresses two main issues:
1.  Ensures text edited in a thumbnail updates the main `csvData` in `App.jsx`.
    - Implemented a callback from `ImageGeneratorFrontendOnly` to `App.jsx` (`handleThumbnailRecordTextUpdate`) to update the correct record in `csvData`.

2.  Improves consistency between `csvData` and `generatedImagesData` by adding reconciliation logic in `App.jsx`'s `handleDadosAlterados` function.
    - If the number of rows in `csvData` changes, `generatedImagesData` is rebuilt, which resets individual thumbnail customizations (positions, styles, backgrounds) to ensure index integrity.
    - If the number of rows remains the same, existing thumbnail customizations are preserved while their underlying `record` data is updated from `csvData`.

These changes aim to make the application state more robust, particularly regarding the correspondence between the main CSV data and the data associated with generated thumbnails, which should help with persistence of text edits and configurations under specific conditions.