### PR TITLE
Fix: Ensure editor loads specific thumbnail configurations correctly

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -448,8 +448,18 @@ const ImageGeneratorFrontendOnly = ({
       : fieldStyles;
     
     // console.log('[handleOpenGeneratedImageEditor] imageToEdit.backgroundImage:', imageToEdit.backgroundImage ? imageToEdit.backgroundImage.substring(0, 100) + '...' : 'undefined');
-    setIndividualFieldPositions(JSON.parse(JSON.stringify(currentPositions)));
-    setIndividualFieldStyles(JSON.parse(JSON.stringify(currentStyles))); // This will be initialFieldStyles in GeneratedImageEditor
+
+  // If customFieldPositions exists (even if it's an empty object {}), use it. Otherwise, use global.
+  const positionsToLoad = imageToEditFromArg.customFieldPositions !== undefined
+    ? imageToEditFromArg.customFieldPositions
+    : fieldPositions;
+
+  const stylesToLoad = imageToEditFromArg.customFieldStyles !== undefined
+    ? imageToEditFromArg.customFieldStyles
+    : fieldStyles;
+
+  setIndividualFieldPositions(JSON.parse(JSON.stringify(positionsToLoad)));
+  setIndividualFieldStyles(JSON.parse(JSON.stringify(stylesToLoad))); // This will be initialFieldStyles in GeneratedImageEditor
     setShowGeneratedImageEditor(true);
   };
 


### PR DESCRIPTION
Changed the logic in `ImageGeneratorFrontendOnly.jsx`'s `handleOpenGeneratedImageEditor` function to correctly prioritize a thumbnail's `customFieldPositions` and `customFieldStyles` when they exist (i.e., are not `undefined`), even if they are empty objects (`{}`).

Previously, an empty custom configuration object would cause the editor to fall back to global/template settings. With this change, if a thumbnail has an explicit (even if empty) custom configuration saved, that specific configuration will be loaded into the `GeneratedImageEditor`. This addresses the issue where editing a customized thumbnail would incorrectly show the general model's layout in the editor.