### PR TITLE
Fix: Editor correctly loads specific thumbnail configurations

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -73,12 +73,12 @@ const GeneratedImageEditor = ({
 
       // Initialize editedStyles
       const newEditedStyles = {};
-      const fieldsToStyle = Object.keys(initialFieldPositions); // Fields present in the current image layout
-
-      fieldsToStyle.forEach(field => {
+      // Iterate over all possible headers to ensure FormattingPanel has complete style info
+      // and that FieldPositioner receives a style object for every field it might render.
+      globalCsvHeaders.forEach(field => {
         newEditedStyles[field] = {
-          ...COMPLETE_DEFAULT_STYLE, // Start with all defaults
-          ...(initialFieldStyles[field] || {}), // Override with any specific styles for this field
+          ...COMPLETE_DEFAULT_STYLE, // Start with all defaults defined in GeneratedImageEditor
+          ...(initialFieldStyles && initialFieldStyles[field] ? initialFieldStyles[field] : {}), // Override with specific styles for this field from prop
         };
       });
       setEditedStyles(newEditedStyles);
@@ -87,7 +87,7 @@ const GeneratedImageEditor = ({
       // If essential data is missing, ensure we are not in an initialized state.
       setStylesAreInitialized(false); 
     }
-  }, [imageData, initialFieldPositions, initialFieldStyles]);
+  }, [imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders]); // Added globalCsvHeaders
 
   if (!imageData) {
     return null;


### PR DESCRIPTION
This commit implements fixes across ImageGeneratorFrontendOnly, GeneratedImageEditor, and FieldPositioner to ensure that when a thumbnail with custom position/style configurations is edited, the GeneratedImageEditor correctly loads and displays these specific configurations, rather than defaulting to the general model's layout.

Changes include:
1.  ImageGeneratorFrontendOnly: Ensured `handleOpenGeneratedImageEditor` re-fetches the most current image data from state.
2.  GeneratedImageEditor: Modified its `useEffect` to initialize styles for all `globalCsvHeaders`, correctly merging with `initialFieldStyles`.
3.  FieldPositioner: Modified its `useEffect` to prevent it from overwriting an intentionally empty `fieldPositions={{}}` prop (received from GeneratedImageEditor) by calling back to parent with defaults. It now also correctly merges partial configurations with defaults before updating the parent state, only if changes are detected, preventing infinite loops.