### PR TITLE
Diag: Add console logs for thumbnail configuration flow

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -96,6 +96,10 @@ const FieldPositioner = ({
   // Effect to initialize or update field positions and styles based on csvHeaders and props.
   // This ensures that every field in csvHeaders has a corresponding position and a complete style object.
   useEffect(() => {
+    console.log("FieldPositioner -- Received Props -- fieldPositions:", JSON.stringify(fieldPositions, null, 2));
+    console.log("FieldPositioner -- Received Props -- fieldStyles:", JSON.stringify(fieldStyles, null, 2));
+    // console.log("FieldPositioner -- Received Props -- csvHeaders:", JSON.stringify(csvHeaders, null, 2)); // Optional
+
     if (csvHeaders.length > 0) {
       const newCombinedPositions = {};
       const newCombinedStyles = {};

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -66,6 +66,10 @@ const GeneratedImageEditor = ({
   }, []); // setEditedRecord is stable
 
   useEffect(() => {
+    console.log("GeneratedImageEditor -- Received Props -- initialFieldPositions:", JSON.stringify(initialFieldPositions, null, 2));
+    console.log("GeneratedImageEditor -- Received Props -- initialFieldStyles:", JSON.stringify(initialFieldStyles, null, 2));
+    // console.log("GeneratedImageEditor -- Received Props -- imageData:", JSON.stringify(imageData, null, 2)); // Optional
+
     if (imageData && initialFieldPositions && initialFieldStyles) {
       setSelectedFieldInternal(null);
       setEditedPositions(JSON.parse(JSON.stringify(initialFieldPositions)));
@@ -126,6 +130,11 @@ const GeneratedImageEditor = ({
   // Use editedRecord for the preview data if it's available
   const editorCsvData = editedRecord ? [editedRecord] : (imageData ? [imageData.record] : []);
 
+  // Log state before passing to FieldPositioner
+  if (stylesAreInitialized && currentBackgroundImageForEditor) { // Only log if we are about to render FieldPositioner
+    console.log("GeneratedImageEditor -- Passing to FieldPositioner -- editedPositions:", JSON.stringify(editedPositions, null, 2));
+    console.log("GeneratedImageEditor -- Passing to FieldPositioner -- editedStyles:", JSON.stringify(editedStyles, null, 2));
+  }
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth scroll="body">

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -1193,6 +1193,14 @@ const ImageGeneratorFrontendOnly = ({
             ? imageToEdit.customFieldStyles
             : fieldStyles;    // global fieldStyles prop from App.jsx
 
+          console.log("IGFO -- For Editor -- imageToEdit:", JSON.stringify(imageToEdit, null, 2));
+          console.log("IGFO -- For Editor -- imageToEdit.customFieldPositions:", JSON.stringify(imageToEdit?.customFieldPositions, null, 2));
+          console.log("IGFO -- For Editor -- imageToEdit.customFieldStyles:", JSON.stringify(imageToEdit?.customFieldStyles, null, 2));
+          console.log("IGFO -- For Editor -- global fieldPositions (prop):", JSON.stringify(fieldPositions, null, 2));
+          console.log("IGFO -- For Editor -- global fieldStyles (prop):", JSON.stringify(fieldStyles, null, 2));
+          console.log("IGFO -- For Editor -- positionsToLoad:", JSON.stringify(positionsToLoad, null, 2));
+          console.log("IGFO -- For Editor -- stylesToLoad:", JSON.stringify(stylesToLoad, null, 2));
+
           return (
             <GeneratedImageEditor
               open={showGeneratedImageEditor}


### PR DESCRIPTION
Added console.log statements to key components involved in the thumbnail editing data flow:
- ImageGeneratorFrontendOnly.jsx: Logs data used to initialize GeneratedImageEditor.
- GeneratedImageEditor.jsx: Logs initial props received and state passed to its FieldPositioner.
- FieldPositioner.jsx: Logs props received for positions and styles.

These logs are intended to help diagnose an issue where custom thumbnail configurations (positions/styles) are not correctly loading into the editor, despite appearing correct in the thumbnail list and text content loading correctly.