### PR TITLE
Fix: Preserve custom thumbnail data during regeneration

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -358,12 +358,20 @@ const ImageGeneratorFrontendOnly = ({
           canvas.toBlob(resolve, 'image/png', 1.0);
         });
 
+        // Try to find existing custom data for this index to preserve it
+        const existingImageDataItem = generatedImages.find(img => img.index === i);
+
         const imageData = {
           blob: blob,
           url: URL.createObjectURL(blob),
           record: record,
           index: i,
-          filename: `midiator_${String(i + 1).padStart(3, '0')}.png`
+          filename: `midiator_${String(i + 1).padStart(3, '0')}.png`,
+          // Preserve existing custom properties if they exist
+          customFieldPositions: existingImageDataItem?.customFieldPositions,
+          customFieldStyles: existingImageDataItem?.customFieldStyles,
+          // Use existing custom background if present, otherwise the global one used for this generation pass
+          backgroundImage: existingImageDataItem?.backgroundImage || backgroundImage
         };
 
         images.push(imageData);


### PR DESCRIPTION
Modified the `generateImages` function in `ImageGeneratorFrontendOnly.jsx`. When this function is called (e.g., by clicking 'Gerar Imagens'), it now attempts to find existing data for each thumbnail being regenerated (based on its index) in the current `generatedImages` state.

If found, it preserves the `customFieldPositions`, `customFieldStyles`, and custom `backgroundImage` from the existing item and applies them to the newly regenerated thumbnail object. The `blob` and `url` are updated, and the `record` and `index` are ensured to be current.

This prevents the 'Gerar Imagens' action from wiping out customizations that were previously loaded from a JSON file or set by editing an individual thumbnail. This should resolve the issue where the editor would load global settings because the custom properties were being stripped from the state after a regeneration event.