### PR TITLE
Fix: Preserve custom positions/styles in regenerateSingleImage

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -674,7 +674,9 @@ const ImageGeneratorFrontendOnly = ({
         record: record,
         index: index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
-        backgroundImage: currentBackgroundImage // Store the background image used for this specific image
+        backgroundImage: currentBackgroundImage, // Store the background image used for this specific image
+        customFieldPositions: positionsToUse,   // Preserve the positions used for this regeneration
+        customFieldStyles: stylesToUse          // Preserve the styles used for this regeneration
       };
 
       setGeneratedImages(prevImages => {


### PR DESCRIPTION
Modified the `regenerateSingleImage` function in
`ImageGeneratorFrontendOnly.jsx`. When the `newImageData` object is created after regenerating the image blob/url, it now explicitly includes the `customFieldPositions: positionsToUse` and
`customFieldStyles: stylesToUse` key-value pairs.

The `positionsToUse` and `stylesToUse` are parameters passed into `regenerateSingleImage` and represent the configurations that were used for drawing the image (these are the custom settings if an image was just edited and saved).

This ensures that when a thumbnail's visual is regenerated, its structural customization data (specific positions and styles) is retained in the component's state, preventing the issue where these customizations would be lost and subsequent edits would incorrectly default to global settings.