### PR TITLE
Cleanup: Remove diagnostic console.log statements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -163,14 +163,14 @@ function App() {
     localStorage.setItem('darkMode', JSON.stringify(darkMode));
   }, [darkMode]);
 
-  // Diagnostic log for generatedImagesData changes
-  useEffect(() => {
-    console.log("App.jsx - generatedImagesData STATE CHANGED:", JSON.stringify(generatedImagesData, null, 2));
-    // To inspect a specific item, e.g., index 7 if it exists:
-    // if (generatedImagesData && generatedImagesData.length > 7) {
-    //   console.log("App.jsx - generatedImagesData[7]:", JSON.stringify(generatedImagesData[7], null, 2));
-    // }
-  }, [generatedImagesData]);
+  // Diagnostic log for generatedImagesData changes // LOG REMOVED
+  // useEffect(() => {
+  //   console.log("App.jsx - generatedImagesData STATE CHANGED:", JSON.stringify(generatedImagesData, null, 2));
+  //   // To inspect a specific item, e.g., index 7 if it exists:
+  //   // if (generatedImagesData && generatedImagesData.length > 7) {
+  //   //   console.log("App.jsx - generatedImagesData[7]:", JSON.stringify(generatedImagesData[7], null, 2));
+  //   // }
+  // }, [generatedImagesData]);
 
   const steps = [
     {
@@ -482,14 +482,14 @@ function App() {
                   };
                 })
               );
-              console.log("App.jsx - handleLoadStateFromFile - BEFORE setGeneratedImagesData - restoredGeneratedImages:", JSON.stringify(restoredGeneratedImages, null, 2));
+              // console.log("App.jsx - handleLoadStateFromFile - BEFORE setGeneratedImagesData - restoredGeneratedImages:", JSON.stringify(restoredGeneratedImages, null, 2)); // LOG REMOVED
               // Example to check a specific item if you know its expected index, e.g., 7 for thumbnail #8
               // if (restoredGeneratedImages && restoredGeneratedImages.length > 7) {
               //   console.log("App.jsx - handleLoadStateFromFile - restoredGeneratedImages[7]:", JSON.stringify(restoredGeneratedImages[7], null, 2));
               // }
               setGeneratedImagesData(restoredGeneratedImages);
             } else {
-              console.log("App.jsx - handleLoadStateFromFile - No generatedImages in JSON or old version, clearing generatedImagesData.");
+              // console.log("App.jsx - handleLoadStateFromFile - No generatedImages in JSON or old version, clearing generatedImagesData."); // LOG REMOVED
               setGeneratedImagesData([]); // Limpar se não houver dados ou for versão antiga
             }
             
@@ -621,11 +621,11 @@ function App() {
     // e pela lógica em canProceedToStep.
 
     // Reconcile generatedImagesData with the new csvData (novosRegistros)
-    console.log("App.jsx - handleDadosAlterados - ENTERED. novosRegistros count:", novosRegistros.length, "Current generatedImagesData count:", generatedImagesData.length);
+    // console.log("App.jsx - handleDadosAlterados - ENTERED. novosRegistros count:", novosRegistros.length, "Current generatedImagesData count:", generatedImagesData.length); // LOG REMOVED
     setGeneratedImagesData(prevGeneratedImages => {
-      console.log("App.jsx - handleDadosAlterados - INSIDE setGeneratedImagesData callback. prevGeneratedImages count:", prevGeneratedImages.length);
+      // console.log("App.jsx - handleDadosAlterados - INSIDE setGeneratedImagesData callback. prevGeneratedImages count:", prevGeneratedImages.length); // LOG REMOVED
       if (prevGeneratedImages.length !== novosRegistros.length) {
-        console.log("App.jsx - handleDadosAlterados - Lengths DIFFER, rebuilding generatedImagesData. This will RESET custom props.");
+        // console.log("App.jsx - handleDadosAlterados - Lengths DIFFER, rebuilding generatedImagesData. This will RESET custom props."); // LOG REMOVED
         const rebuiltGeneratedImages = novosRegistros.map((record, index) => ({
           index,
           record,
@@ -637,7 +637,7 @@ function App() {
         // console.log("App.jsx - handleDadosAlterados - REBUILT generatedImagesData:", JSON.stringify(rebuiltGeneratedImages, null, 2));
         return rebuiltGeneratedImages;
       } else {
-        console.log("App.jsx - handleDadosAlterados - Lengths SAME, preserving custom props in generatedImagesData.");
+        // console.log("App.jsx - handleDadosAlterados - Lengths SAME, preserving custom props in generatedImagesData."); // LOG REMOVED
         const updatedGeneratedImages = prevGeneratedImages.map((oldImage, index) => ({
           ...oldImage,
           record: novosRegistros[index],

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -96,8 +96,8 @@ const FieldPositioner = ({
   // Effect to initialize or update field positions and styles based on csvHeaders and props.
   // This ensures that every field in csvHeaders has a corresponding position and a complete style object.
   useEffect(() => {
-    console.log("FieldPositioner -- Received Props -- fieldPositions:", JSON.stringify(fieldPositions, null, 2));
-    console.log("FieldPositioner -- Received Props -- fieldStyles:", JSON.stringify(fieldStyles, null, 2));
+    // console.log("FieldPositioner -- Received Props -- fieldPositions:", JSON.stringify(fieldPositions, null, 2)); // LOG REMOVED
+    // console.log("FieldPositioner -- Received Props -- fieldStyles:", JSON.stringify(fieldStyles, null, 2)); // LOG REMOVED
     // console.log("FieldPositioner -- Received Props -- csvHeaders:", JSON.stringify(csvHeaders, null, 2)); // Optional
 
     if (csvHeaders.length > 0) {

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -66,8 +66,8 @@ const GeneratedImageEditor = ({
   }, []); // setEditedRecord is stable
 
   useEffect(() => {
-    console.log("GeneratedImageEditor -- Received Props -- initialFieldPositions:", JSON.stringify(initialFieldPositions, null, 2));
-    console.log("GeneratedImageEditor -- Received Props -- initialFieldStyles:", JSON.stringify(initialFieldStyles, null, 2));
+    // console.log("GeneratedImageEditor -- Received Props -- initialFieldPositions:", JSON.stringify(initialFieldPositions, null, 2)); // LOG REMOVED
+    // console.log("GeneratedImageEditor -- Received Props -- initialFieldStyles:", JSON.stringify(initialFieldStyles, null, 2)); // LOG REMOVED
     // console.log("GeneratedImageEditor -- Received Props -- imageData:", JSON.stringify(imageData, null, 2)); // Optional is fine to keep commented
 
     if (imageData && initialFieldPositions && initialFieldStyles) {

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -1203,14 +1203,6 @@ const ImageGeneratorFrontendOnly = ({
             ? imageToEdit.customFieldStyles
             : fieldStyles;    // global fieldStyles prop from App.jsx
 
-          console.log("IGFO -- For Editor -- imageToEdit:", JSON.stringify(imageToEdit, null, 2));
-          console.log("IGFO -- For Editor -- imageToEdit.customFieldPositions:", JSON.stringify(imageToEdit?.customFieldPositions, null, 2));
-          console.log("IGFO -- For Editor -- imageToEdit.customFieldStyles:", JSON.stringify(imageToEdit?.customFieldStyles, null, 2));
-          console.log("IGFO -- For Editor -- global fieldPositions (prop):", JSON.stringify(fieldPositions, null, 2));
-          console.log("IGFO -- For Editor -- global fieldStyles (prop):", JSON.stringify(fieldStyles, null, 2));
-          console.log("IGFO -- For Editor -- positionsToLoad:", JSON.stringify(positionsToLoad, null, 2));
-          console.log("IGFO -- For Editor -- stylesToLoad:", JSON.stringify(stylesToLoad, null, 2));
-
           return (
             <GeneratedImageEditor
               open={showGeneratedImageEditor}


### PR DESCRIPTION
Removed all temporary console.log statements that were added to ImageGeneratorFrontendOnly.jsx, GeneratedImageEditor.jsx, FieldPositioner.jsx, and App.jsx for debugging the thumbnail configuration loading issue. The main bug has been addressed, and these logs are no longer needed.