### PR TITLE
Feat: Replace stylized M in header with new SVG logo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1014,30 +1014,12 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
             <Box sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 2,
+              gap: 1, // Adjusted gap to accommodate the wider logo text
               flexGrow: 1
             }}>
-              <Box sx={{
-                width: 32,
-                height: 32,
-                borderRadius: 2,
-                background: 'rgba(255,255,255,0.2)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center'
-              }}>
-                <Typography variant="h6" sx={{ color: 'white', fontWeight: 'bold' }}>
-                  M
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="h6" sx={{ color: 'white', fontWeight: 'bold' }}>
-                  Midiator
-                </Typography>
-                <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.8)' }}>
-                  Social Media Generator
-                </Typography>
-              </Box>
+              {/* New SVG Logo */}
+              <img src="/src/assets/logo.svg" alt="Midiator Logo" style={{ height: '40px' }} />
+              {/* Text is now part of the SVG, so no separate text elements needed here. */}
             </Box>
 
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,51 @@
+<svg viewBox="0 0 200 60" xmlns="http://www.w3.org/2000/svg">
+  <!-- Gradient definitions -->
+  <defs>
+    <linearGradient id="primaryGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="secondaryGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f093fb;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f5576c;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Logo icon representing image generation with overlaid text -->
+  <g transform="translate(8, 8)">
+    <!-- Background image representation -->
+    <rect x="0" y="4" width="28" height="20" rx="3" fill="url(#primaryGradient)" opacity="0.3"/>
+    <rect x="2" y="6" width="24" height="16" rx="2" fill="none" stroke="url(#primaryGradient)" stroke-width="2"/>
+
+    <!-- Overlaid text fields -->
+    <rect x="4" y="8" width="12" height="2" rx="1" fill="url(#secondaryGradient)"/>
+    <rect x="4" y="11" width="8" height="2" rx="1" fill="url(#secondaryGradient)" opacity="0.7"/>
+    <rect x="4" y="14" width="16" height="2" rx="1" fill="url(#secondaryGradient)" opacity="0.5"/>
+    <rect x="4" y="17" width="6" height="2" rx="1" fill="url(#secondaryGradient)" opacity="0.3"/>
+
+    <!-- Arrow showing transformation -->
+    <path d="M 32 14 L 36 14 M 34 12 L 36 14 L 34 16" stroke="url(#primaryGradient)" stroke-width="2" fill="none"/>
+
+    <!-- Generated image stack -->
+    <rect x="40" y="2" width="8" height="10" rx="1" fill="url(#secondaryGradient)" opacity="0.3"/>
+    <rect x="42" y="4" width="8" height="10" rx="1" fill="url(#secondaryGradient)" opacity="0.6"/>
+    <rect x="44" y="6" width="8" height="10" rx="1" fill="url(#secondaryGradient)"/>
+  </g>
+
+  <!-- Logo text -->
+  <text x="65" y="35" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="url(#primaryGradient)">
+    Midiator
+  </text>
+
+  <!-- Tagline -->
+  <text x="65" y="50" font-family="Arial, sans-serif" font-size="10" fill="#666" opacity="0.8">
+    Social Media Generator
+  </text>
+</svg>


### PR DESCRIPTION
- Added new SVG logo to src/assets/logo.svg.
- Updated App.jsx to display the new SVG logo in the header AppBar.
- Removed the old text-based 'M' icon and associated 'Midiator' and 'Social Media Generator' Typography components as this text is now part of the SVG logo itself.