### PR TITLE
fix: Improve instructions text legibility in dark mode

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -487,8 +487,8 @@ const FieldPositioner = ({
             )}
 
             {/* Instruções */}
-            <Box sx={{ mt: 2, p: 2, backgroundColor: '#f5f5f5', borderRadius: 1 }}>
-              <Typography variant="body2" color="textSecondary">
+            <Box sx={{ mt: 2, p: 2, borderRadius: 1 }}>
+              <Typography variant="body2" color="text.primary">
                 <strong>Instruções:</strong>
                 <br />
                 • Clique em um campo para selecioná-lo e editar suas propriedades


### PR DESCRIPTION
Removed the fixed background color from the instructions Box in FieldPositioner.jsx and changed the Typography color to text.primary. This allows the text color to adapt to the current theme, making it legible in both light and dark modes.