### PR TITLE
fix: Resolve transparent background in RecordModal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,6 +217,11 @@ function App() {
 
   useEffect(() => {
     localStorage.setItem('darkMode', JSON.stringify(darkMode));
+    if (darkMode) {
+      document.documentElement.classList.add('dark-mode-active');
+    } else {
+      document.documentElement.classList.remove('dark-mode-active');
+    }
   }, [darkMode]);
 
   const steps = [

--- a/src/features/RecordManager/components/RecordForm/RecordForm.module.css
+++ b/src/features/RecordManager/components/RecordForm/RecordForm.module.css
@@ -15,7 +15,8 @@
     --background: hsl(0 0% 100%);
 }
 
-.darkMode:root {
+/* Updated to use the class on :root */
+:root.dark-mode-active {
     --foreground: hsl(0 0% 98%);
     --muted-foreground: hsl(0 0% 63.9%);
     --primary: hsl(0 72.2% 50.6%);


### PR DESCRIPTION
I ensured the RecordModal background is opaque and respects the application theme. This was achieved by:
1. Synchronizing the App.jsx `darkMode` state with a class ('dark-mode-active') on the `<html>` element.
2. Updating the CSS variable definitions in RecordForm.module.css to use `:root.dark-mode-active` for dark theme styles. This ensures that `var(--background)` used in RecordModal.module.css resolves to the correct opaque color based on the selected theme.