### PR TITLE
feat: Adiciona botão para baixar CSV de exemplo

### DIFF
--- a/public/exemplo_posts.csv
+++ b/public/exemplo_posts.csv
@@ -1,0 +1,5 @@
+Titulo;Texto Principal;Ponte para o Próximo
+✨ Dica Incrível;"Descubra como a organização pode transformar sua rotina diária e aumentar sua produtividade. Você já parou para pensar no impacto de um ambiente organizado?";➡️ Próximo: Ferramentas Essenciais
+🚀 Comece Agora;"Não espere mais para mudar seus hábitos! Pequenos passos levam a grandes resultados. Qual será sua primeira ação hoje?";➡️ Continue para mais dicas!
+💡 Segredo Revelado;"Muitos não sabem, mas o planejamento é a chave para o sucesso em qualquer projeto. Está pronto para desbloquear seu potencial?";👇 Veja o último passo!
+🎯 Foco Total;"Aprenda a técnica Pomodoro para manter a concentração e evitar distrações. Já experimentou dividir seu tempo em blocos focados?";🏁 Conclua com chave de ouro!

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -629,6 +629,14 @@ function App() {
     setAnchorElMenu(null);
   };
 
+  const handleDownloadExampleCSV = useCallback(() => {
+    const link = document.createElement("a");
+    link.href = "/exemplo_posts.csv"; // Caminho para o arquivo na pasta public
+    link.download = "exemplo_posts.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, []);
 
   const handleLoadTemplateClick = () => {
     handleMenuClose();
@@ -1292,20 +1300,29 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
                           </Typography>
                           <CsvInfobox />
                         </Box>
-                        <Button
-                          variant="contained"
-                          component="label"
-                          sx={{ borderRadius: 2 }}
-                        >
-                          Selecionar Arquivo
-                          <input
-                            type="file"
-                            accept=".csv"
-                            hidden
-                            ref={fileInputRef}
-                            onChange={handleCSVUpload}
-                          />
-                        </Button>
+                        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
+                          <Button
+                            variant="contained"
+                            component="label"
+                            sx={{ borderRadius: 2 }}
+                          >
+                            Selecionar Arquivo
+                            <input
+                              type="file"
+                              accept=".csv"
+                              hidden
+                              ref={fileInputRef}
+                              onChange={handleCSVUpload}
+                            />
+                          </Button>
+                          <Button
+                            variant="contained"
+                            onClick={handleDownloadExampleCSV}
+                            sx={{ borderRadius: 2 }}
+                          >
+                            Baixar CSV Exemplo
+                          </Button>
+                        </Box>
                       </Card>
                     </Grid>
 


### PR DESCRIPTION
Este commit implementa a funcionalidade de download de um arquivo CSV de exemplo. Um novo botão "Baixar CSV Exemplo" foi adicionado à interface de upload de CSV, permitindo que você obtenha um modelo de como os dados devem ser estruturados.

- Criação do arquivo `public/exemplo_posts.csv` com dados demonstrativos.
- Adição da função `handleDownloadExampleCSV` em `src/App.jsx` para gerenciar o download.
- Inclusão do botão "Baixar CSV Exemplo" na interface, estilizado de forma consistente com os botões existentes.