### PR TITLE
Feature: Prevent edit panel while moving

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -62,6 +62,7 @@ const FieldPositioner = ({
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
   const [isInteracting, setIsInteracting] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false); // State for the drawer
+  const [isMoving, setIsMoving] = useState(false);
   const containerRef = useRef(null);
   const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0);
 
@@ -417,6 +418,7 @@ const FieldPositioner = ({
                       onContentChange={handleContentChange}
                       rotation={position.rotation}
                       onLongPress={handleFieldLongPress}
+                      setIsMoving={setIsMoving}
                     />
                   );
                 })
@@ -472,7 +474,7 @@ const FieldPositioner = ({
         </Grid>
       )}
 
-      {isMobile && (
+      {isMobile && !isMoving && (
         <>
           <Fab
             color="primary"

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -13,7 +13,8 @@ const TextBox = ({
   containerSize,
   onContentChange,
   rotation,
-  onLongPress
+  onLongPress,
+  setIsMoving
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
@@ -279,6 +280,8 @@ const TextBox = ({
     e.preventDefault();
     e.stopPropagation();
 
+    if (setIsMoving) setIsMoving(true);
+
     longPressTimeout.current = setTimeout(() => {
       if (onLongPress) {
         onLongPress(field);
@@ -313,6 +316,7 @@ const TextBox = ({
   const handleTouchStart = (e, type, handle = null) => {
     e.preventDefault();
     e.stopPropagation();
+    if (setIsMoving) setIsMoving(true);
     document.body.style.overflow = 'hidden';
     document.body.style.touchAction = 'none';
 
@@ -472,6 +476,7 @@ const TextBox = ({
   };
 
   const handleMouseUp = () => {
+    if (setIsMoving) setIsMoving(false);
     if (longPressTimeout.current) {
       clearTimeout(longPressTimeout.current);
       longPressTimeout.current = null;
@@ -483,6 +488,7 @@ const TextBox = ({
   };
 
   const handleTouchEnd = () => {
+    if (setIsMoving) setIsMoving(false);
     if (longPressTimeout.current) {
       clearTimeout(longPressTimeout.current);
       longPressTimeout.current = null;


### PR DESCRIPTION
- The editing panel is now hidden while a text box is being moved or resized.
- This prevents the editing panel from interfering with your actions.