### PR TITLE
feat: remove long press functionality from text boxes

### DIFF
--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -19,7 +19,6 @@ const TextBox = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
-  const longPressTimeout = useRef(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(content);
   const [resizeHandle, setResizeHandle] = useState(null);
@@ -282,14 +281,6 @@ const TextBox = ({
 
     if (setIsMoving) setIsMoving(true);
 
-    longPressTimeout.current = setTimeout(() => {
-      if (onLongPress) {
-        onLongPress(field);
-      }
-      // NÃ£o inicie o arraste se for um clique longo
-      longPressTimeout.current = null;
-    }, 500); // 500ms para um clique longo
-
     onSelect(field);
     setDragStart({ x: e.clientX, y: e.clientY });
 
@@ -319,13 +310,6 @@ const TextBox = ({
     if (setIsMoving) setIsMoving(true);
     document.body.style.overflow = 'hidden';
     document.body.style.touchAction = 'none';
-
-    longPressTimeout.current = setTimeout(() => {
-      if (onLongPress) {
-        onLongPress(field);
-      }
-      longPressTimeout.current = null;
-    }, 500);
 
     onSelect(field);
     const touch = e.touches[0];
@@ -477,22 +461,12 @@ const TextBox = ({
 
   const handleMouseUp = () => {
     if (setIsMoving) setIsMoving(false);
-    if (longPressTimeout.current) {
-      clearTimeout(longPressTimeout.current);
-      longPressTimeout.current = null;
-      // Se o temporizador foi cancelado, Ã© um clique curto
-      // A aÃ§Ã£o de clique (onSelect) jÃ¡ foi chamada no mouseDown
-    }
     setIsDragging(false); setIsResizing(false); setIsRotating(false);
     setResizeHandle(null);
   };
 
   const handleTouchEnd = () => {
     if (setIsMoving) setIsMoving(false);
-    if (longPressTimeout.current) {
-      clearTimeout(longPressTimeout.current);
-      longPressTimeout.current = null;
-    }
     document.body.style.overflow = '';
     document.body.style.touchAction = '';
     setIsDragging(false); setIsResizing(false); setIsRotating(false);
@@ -621,10 +595,6 @@ const TextBox = ({
       onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
       onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}
       onClick={(e) => {
-        if (longPressTimeout.current) {
-          clearTimeout(longPressTimeout.current);
-          longPressTimeout.current = null;
-        }
         if (!isEditing || e.target !== textareaRef.current) {
           onSelect(field);
         }


### PR DESCRIPTION
The long press functionality to open the properties panel has been removed. The panel can now only be opened by the button in the lower right corner.