### PR TITLE
fix: Ensure progress indicators are contained with margin

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1666,7 +1666,7 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
               Anterior
             </Button>
 
-            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center' }}>
+            <Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>
               {steps.map((_, index) => (
                 <Box
                   key={index}


### PR DESCRIPTION
- Updated the CSS for the progress bar container to use flex-grow and horizontal margins.
- This prevents the progress indicators from causing a horizontal scrollbar on small screens and ensures they are properly contained within their layout.