### PR TITLE
fix: Correct text positioning for portrait images

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -296,10 +296,10 @@ const ImageGeneratorFrontendOnly = ({
             // Aplicar configurações de texto
             applyTextEffects(ctx, { ...style, fontSize: fontSize });
 
-            // O padding do editor (8px) precisa ser dimensionado para o tamanho real da imagem.
-            // A referência para a escala é o tamanho em que o editor foi exibido.
-            const editorReferenceWidth = displayedImageSize.width > 0 ? displayedImageSize.width : 1080; // um fallback razoável
-            const paddingScaleFactor = img.width / editorReferenceWidth;
+            const isPortrait = originalImageSize && originalImageSize.height > originalImageSize.width;
+            const editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+            const imageReferenceSize = isPortrait ? img.height : img.width;
+            const paddingScaleFactor = editorReferenceSize > 0 ? imageReferenceSize / editorReferenceSize : 0;
             const scaledPadding = 8 * paddingScaleFactor;
 
             // Área efetiva para o texto dentro da caixa
@@ -592,8 +592,10 @@ const ImageGeneratorFrontendOnly = ({
         const fontSize = style.fontSize || 24;
         applyTextEffects(ctx, { ...style, fontSize: fontSize });
 
-        const editorReferenceWidth = displayedImageSize.width > 0 ? displayedImageSize.width : 1080;
-        const paddingScaleFactor = img.width / editorReferenceWidth;
+        const isPortrait = originalImageSize && originalImageSize.height > originalImageSize.width;
+        const editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+        const imageReferenceSize = isPortrait ? img.height : img.width;
+        const paddingScaleFactor = editorReferenceSize > 0 ? imageReferenceSize / editorReferenceSize : 0;
         const scaledPadding = 8 * paddingScaleFactor;
 
         const effectiveTextWidth = Math.max(0, posPx.width - (2 * scaledPadding));


### PR DESCRIPTION
This commit fixes an issue where text positioning and size were not being correctly applied to portrait-oriented images during rendering.

The problem was that the scaling factor for padding was always calculated based on the width of the image, which is incorrect for portrait images.

The fix involves:
- Determining if the image is in portrait orientation by comparing its height and width.
- Using the appropriate dimension (height for portrait, width for landscape) as the reference for calculating the padding scale factor.
- This ensures that the text is rendered with the correct positioning and size, regardless of the image's orientation.