### PR TITLE
fix: Correct word wrapping for textboxes

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -297,7 +297,10 @@ const ImageGeneratorFrontendOnly = ({
             applyTextEffects(ctx, { ...style, fontSize: fontSize });
 
             const isPortrait = originalImageSize && originalImageSize.height > originalImageSize.width;
-            const editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+            let editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+            if (!editorReferenceSize || editorReferenceSize <= 0) {
+              editorReferenceSize = isPortrait ? originalImageSize.height : originalImageSize.width;
+            }
             const imageReferenceSize = isPortrait ? img.height : img.width;
             const paddingScaleFactor = editorReferenceSize > 0 ? imageReferenceSize / editorReferenceSize : 0;
             const scaledPadding = 8 * paddingScaleFactor;
@@ -593,7 +596,10 @@ const ImageGeneratorFrontendOnly = ({
         applyTextEffects(ctx, { ...style, fontSize: fontSize });
 
         const isPortrait = originalImageSize && originalImageSize.height > originalImageSize.width;
-        const editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+        let editorReferenceSize = isPortrait ? displayedImageSize.height : displayedImageSize.width;
+        if (!editorReferenceSize || editorReferenceSize <= 0) {
+          editorReferenceSize = isPortrait ? originalImageSize.height : originalImageSize.width;
+        }
         const imageReferenceSize = isPortrait ? img.height : img.width;
         const paddingScaleFactor = editorReferenceSize > 0 ? imageReferenceSize / editorReferenceSize : 0;
         const scaledPadding = 8 * paddingScaleFactor;


### PR DESCRIPTION
This commit fixes an issue where the word wrapping mechanism was not working correctly, causing text to overflow the textboxes.

The problem was that the `editorReferenceSize` could be 0, which would cause the `paddingScaleFactor` to be 0, and the `scaledPadding` to be 0. This would cause the `effectiveTextWidth` to be equal to `posPx.width`, which would not account for the padding, and could cause the text to overflow.

The fix involves:
- Adding a fallback to the `editorReferenceSize` to prevent it from being 0. The `originalImageSize` is used as a fallback.
- This ensures that the `scaledPadding` is always calculated correctly, and the text is wrapped correctly within the textboxes.