### PR TITLE
Refatorei o dimensionamento da fonte para ser proporcional ao tamanho…

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -391,6 +391,7 @@ const FieldPositioner = ({
                       onContentChange={handleContentChange}
                       rotation={position.rotation}
                       originalImageSize={originalImageSize}
+                      fontScale={(imageSize.width && originalImageSize?.width) ? imageSize.width / originalImageSize.width : 1}
                     />
                   );
                 })

--- a/src/components/TextBox.jsx
+++ b/src/components/TextBox.jsx
@@ -14,7 +14,8 @@ const TextBox = ({
   onContentChange,
   rotation,
   setIsMoving,
-  originalImageSize
+  originalImageSize,
+  fontScale: fontScaleProp
 }) => {
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
@@ -564,37 +565,31 @@ const TextBox = ({
     return lines;
   };
 
-  const scale = (originalImageSize?.width && containerSize?.width)
-    ? containerSize.width / originalImageSize.width
-    : 1;
+  const fontScale = fontScaleProp || 1;
 
   const baseFontSize = style.fontSize || 24;
+  const scaledFontSize = baseFontSize * fontScale;
   const lineHeight = baseFontSize * (style.lineHeightMultiplier || 1.2);
+  const scaledLineHeight = lineHeight * fontScale;
 
-  // Para o wrap, usamos a largura da caixa em pixels no tamanho original da imagem
-  const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
+  // Para o wrap, usamos a largura da caixa em pixels no tamanho renderizado
+  const renderedBoxWidth = (position.width / 100) * (containerSize.width || 1);
   const paddingInPixels = 8 * 2; // 8px de cada lado
-  const textLines = wrapText(editedContent, originalBoxWidth - paddingInPixels, baseFontSize);
+  const textLines = wrapText(editedContent, renderedBoxWidth - paddingInPixels, scaledFontSize);
 
   const handleSize = isMobile ? 24 : 12; // Aumentado o tamanho do handle
 
   // Estilo para o conteúdo do texto, que será escalado
   const textContentStyle = {
     fontFamily: style.fontFamily || 'Arial',
-    fontSize: `${baseFontSize}px`,
+    fontSize: `${scaledFontSize}px`,
     fontWeight: style.fontWeight || 'normal',
     fontStyle: style.fontStyle || 'normal',
     color: style.color || '#000000',
     textDecoration: style.textDecoration || 'none',
-    lineHeight: `${lineHeight}px`,
+    lineHeight: `${scaledLineHeight}px`,
     textShadow: style.textShadow ? `${style.shadowOffsetX || 2}px ${style.shadowOffsetY || 2}px ${style.shadowBlur || 4}px ${style.shadowColor || '#000000'}` : 'none',
     WebkitTextStroke: style.textStroke ? `${style.strokeWidth || 2}px ${style.strokeColor || '#ffffff'}` : 'none',
-    // A escala é aplicada aqui para que a renderização do texto (wrap) não seja afetada,
-    // mas o resultado visual corresponda ao tamanho do preview.
-    transform: `scale(${scale})`,
-    transformOrigin: 'top left',
-    width: `${100 / scale}%`,
-    height: `${100 / scale}%`,
     pointerEvents: 'none',
   };
 
@@ -656,11 +651,11 @@ const TextBox = ({
               width: '100%',
               height: '100%',
               fontFamily: style.fontFamily || 'Arial',
-              fontSize: `${baseFontSize * scale}px`, // A fonte no textarea precisa ser escalada visualmente
+              fontSize: `${scaledFontSize}px`, // A fonte no textarea precisa ser escalada visualmente
               fontWeight: style.fontWeight || 'normal',
               fontStyle: style.fontStyle || 'normal',
               color: style.color || '#000000',
-              lineHeight: `${lineHeight * scale}px`, // A altura da linha também
+              lineHeight: `${scaledLineHeight}px`, // A altura da linha também
               textDecoration: style.textDecoration || 'none',
               border: 'none',
               outline: 'none',


### PR DESCRIPTION
… da imagem

- Centralizei a lógica de cálculo da escala da fonte no FieldPositioner.jsx.
- O TextBox.jsx agora recebe a escala da fonte como uma prop, tornando-o um componente mais reutilizável.
- Removi o uso de `transform: scale()` para o dimensionamento da fonte, aplicando a escala diretamente ao `fontSize` para uma renderização mais consistente.