### PR TITLE
Fix: Correct video thumbnail positioning and scaling

### DIFF
--- a/src/components/VideoGenerator/Preview.jsx
+++ b/src/components/VideoGenerator/Preview.jsx
@@ -15,27 +15,38 @@ const Preview = ({
   videoScale,
   useChromaKey,
   chromaKeyColor,
+  displayedImageSize,
 }) => {
   const [videoPxPosition, setVideoPxPosition] = React.useState({ x: 0, y: 0 });
 
   React.useEffect(() => {
-    if (imageContainerRef.current) {
-      const bgWidth = imageContainerRef.current.offsetWidth;
-      const bgHeight = imageContainerRef.current.offsetHeight;
+    if (displayedImageSize.width > 0 && displayedImageSize.height > 0) {
+      const container = imageContainerRef.current;
+      const containerWidth = container.offsetWidth;
+      const containerHeight = container.offsetHeight;
+
+      const offsetX = (containerWidth - displayedImageSize.width) / 2;
+      const offsetY = (containerHeight - displayedImageSize.height) / 2;
+
       setVideoPxPosition({
-        x: normalizedVideoPosition.x * bgWidth,
-        y: normalizedVideoPosition.y * bgHeight,
+        x: normalizedVideoPosition.x * displayedImageSize.width + offsetX,
+        y: normalizedVideoPosition.y * displayedImageSize.height + offsetY,
       });
     }
-  }, [normalizedVideoPosition, imageContainerRef, narrationVideoData.url]);
+  }, [normalizedVideoPosition, displayedImageSize, narrationVideoData.url]);
 
   const handleDrag = (e, ui) => {
-    if (imageContainerRef.current) {
-      const bgWidth = imageContainerRef.current.offsetWidth;
-      const bgHeight = imageContainerRef.current.offsetHeight;
+    if (displayedImageSize.width > 0 && displayedImageSize.height > 0) {
+      const container = imageContainerRef.current;
+      const containerWidth = container.offsetWidth;
+      const containerHeight = container.offsetHeight;
+
+      const offsetX = (containerWidth - displayedImageSize.width) / 2;
+      const offsetY = (containerHeight - displayedImageSize.height) / 2;
+
       setNormalizedVideoPosition({
-        x: ui.x / bgWidth,
-        y: ui.y / bgHeight,
+        x: (ui.x - offsetX) / displayedImageSize.width,
+        y: (ui.y - offsetY) / displayedImageSize.height,
       });
     }
   };

--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -52,6 +52,7 @@ const VideoGenerator2 = ({ generatedImages, generatedAudioData }) => {
   });
   const [normalizedVideoPosition, setNormalizedVideoPosition] = useState({ x: 0, y: 0 });
   const [videoScale, setVideoScale] = useState(1);
+  const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
 
 
   const isCancelledRef = useRef(false);
@@ -151,6 +152,48 @@ const VideoGenerator2 = ({ generatedImages, generatedAudioData }) => {
     }
     return () => clearInterval(interval);
   }, [isPlaying, slideDuration, generatedImages.length]);
+
+  useEffect(() => {
+    const calculateSize = () => {
+      const container = imageContainerRef.current;
+      if (container && generatedImages.length > 0 && generatedImages[0].url) {
+        const containerWidth = container.offsetWidth;
+        const containerHeight = container.offsetHeight;
+        const containerAspectRatio = containerWidth / containerHeight;
+
+        const image = new Image();
+        image.src = generatedImages[0].url;
+        image.onload = () => {
+          const imageAspectRatio = image.width / image.height;
+
+          let newWidth, newHeight;
+
+          if (imageAspectRatio > containerAspectRatio) {
+            newWidth = containerWidth;
+            newHeight = containerWidth / imageAspectRatio;
+          } else {
+            newHeight = containerHeight;
+            newWidth = containerHeight * imageAspectRatio;
+          }
+
+          setDisplayedImageSize({ width: newWidth, height: newHeight });
+        };
+      }
+    };
+
+    calculateSize();
+
+    const resizeObserver = new ResizeObserver(calculateSize);
+    if (imageContainerRef.current) {
+      resizeObserver.observe(imageContainerRef.current);
+    }
+
+    return () => {
+      if (imageContainerRef.current) {
+        resizeObserver.unobserve(imageContainerRef.current);
+      }
+    };
+  }, [generatedImages, imageContainerRef.current]);
 
   const handleGeneratePreview = () => {
     setCurrentImageIndex(0);
@@ -590,8 +633,8 @@ const generateSingleVideo = async (imageData, audioData, index) => {
       const realWidth = narrationVideoData.width * videoScale;
       const realHeight = narrationVideoData.height * videoScale;
 
-      const realX = (normalizedVideoPosition.x * realBgWidth) - (realWidth / 2);
-      const realY = (normalizedVideoPosition.y * realBgHeight) - (realHeight / 2);
+      const realX = (normalizedVideoPosition.x * realBgWidth);
+      const realY = (normalizedVideoPosition.y * realBgHeight);
 
       const colorHex = `0x${chromaKeyColor.replace('#', '')}`;
 
@@ -963,6 +1006,7 @@ const generateSingleVideo = async (imageData, audioData, index) => {
               videoScale={videoScale}
               useChromaKey={useChromaKey}
               chromaKeyColor={chromaKeyColor}
+              displayedImageSize={displayedImageSize}
             />
 
           {isLoading && (


### PR DESCRIPTION
This commit fixes an issue where the video thumbnail's position and scale were not being calculated correctly, causing it to become misaligned when the browser window was resized.

The following changes were made:
- Added a new state variable `displayedImageSize` to store the actual rendered dimensions of the background image.
- Implemented a `useEffect` hook to calculate the `displayedImageSize` whenever the background image or container size changes.
- Passed the `displayedImageSize` as a prop to the `Preview` component.
- Updated the `Preview` component to use the `displayedImageSize` prop for calculating the video's pixel position and for handling drag-and-drop.
- Adjusted the `generateNarrationVideo` function to correctly calculate the overlay position based on the original image dimensions.