### PR TITLE
Fix: Adjust RecordManager UI for better dark mode and screen usage

### DIFF
--- a/src/features/RecordManager/RecordManager.module.css
+++ b/src/features/RecordManager/RecordManager.module.css
@@ -1,5 +1,4 @@
 .container {
-    max-width: 1200px;
     margin: 20px auto;
     padding: 20px;
     background-color: #fff;
@@ -7,11 +6,12 @@
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     font-family: sans-serif;
     color: #333; /* Cor de texto padrão para modo claro */
+    width: 100%;
 }
 
 .container.darkMode {
     background-color: #2c2c2c; /* Fundo escuro para o container */
-    color: #e0e0e0; /* Texto claro para o container */
+    color: #f0f0f0; /* Texto claro para o container */
     box-shadow: 0 2px 10px rgba(0,0,0,0.5);
 }
 

--- a/src/features/RecordManager/components/RecordModal/RecordModal.module.css
+++ b/src/features/RecordManager/components/RecordModal/RecordModal.module.css
@@ -29,7 +29,7 @@
 
 .modalContentDarkMode {
     background-color: #1e293b; /* Dark background from App.jsx darkTheme.palette.background.paper */
-    color: hsl(var(--foreground)); /* Ensure foreground is also themed if needed, though this should be handled by .darkMode on overlay */
+    color: #f0f0f0; /* Ensure foreground is also themed if needed, though this should be handled by .darkMode on overlay */
 }
 
 /* This rule might not be needed if .modalContentDarkMode handles the text color */

--- a/src/features/RecordManager/components/RecordsTable/RecordsTable.module.css
+++ b/src/features/RecordManager/components/RecordsTable/RecordsTable.module.css
@@ -19,7 +19,7 @@
     border: 1px solid #444; /* Borda mais escura para modo escuro */
 }
 .tabela.darkMode td {
-    color: #ccc; /* Texto das células em modo escuro */
+    color: #f0f0f0; /* Texto das células em modo escuro */
 }
 
 


### PR DESCRIPTION
This commit addresses two UI issues in the RecordManager feature:

1.  **Dark Mode Text Color:** The text color in dark mode was not consistently applied, making it difficult to read. This has been fixed by ensuring all components in the RecordManager use a light text color on a dark background.

2.  **Screen Width Usage:** The main container had a `max-width` that prevented it from using the full screen width. This has been removed to allow the layout to expand and make better use of available screen space.