### PR TITLE
fix: Improve campaign prompt dialog and add reset functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -941,6 +941,12 @@ function App() {
     }
   };
 
+  const handleResetCampaign = () => {
+    setCampaignContent(null);
+    setProblema('');
+    setSolucao('');
+  };
+
   const handleExportHtml = () => {
     if (!campaignContent) return;
 
@@ -1486,6 +1492,7 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
                       variant="outlined"
                       fullWidth
                       placeholder="Descreva o problema que sua campanha busca resolver."
+                      disabled={campaignContent !== null}
                     />
                   </Grid>
                   <Grid item xs={12} md={6}>
@@ -1498,18 +1505,28 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
                       variant="outlined"
                       fullWidth
                       placeholder="Descreva a solução que sua campanha oferece."
+                      disabled={campaignContent !== null}
                     />
                   </Grid>
                 </Grid>
-                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3, gap: 2 }}>
                   <Button
                     variant="contained"
                     size="large"
                     onClick={handleGenerateCampaignContent}
-                    disabled={!problema.trim() || !solucao.trim() || isGeneratingCampaign}
+                    disabled={!problema.trim() || !solucao.trim() || isGeneratingCampaign || campaignContent !== null}
                   >
                     {isGeneratingCampaign ? 'Gerando...' : 'Gerar conteúdo com IA'}
                   </Button>
+                  {campaignContent && (
+                    <Button
+                      variant="outlined"
+                      size="large"
+                      onClick={handleResetCampaign}
+                    >
+                      Resetar
+                    </Button>
+                  )}
                 </Box>
 
                 {campaignContent && (

--- a/src/components/CampaignPromptDialog.jsx
+++ b/src/components/CampaignPromptDialog.jsx
@@ -8,37 +8,27 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   const [usedProblema, setUsedProblema] = useState(false);
   const [usedSolucao, setUsedSolucao] = useState(false);
   const editorRef = useRef(null);
+  const [editorContent, setEditorContent] = useState('');
 
-  const updateEditorContent = (text) => {
-    const html = text
+  const getHighlightedHtml = (text) => {
+    return text
       .replace(/{{problema}}/g, '<span style="color: #ec4899; font-family: monospace;">{{problema}}</span>')
       .replace(/{{solucao}}/g, '<span style="color: #8b5cf6; font-family: monospace;">{{solucao}}</span>');
-    if (editorRef.current) {
-      editorRef.current.innerHTML = html;
-    }
   };
 
   useEffect(() => {
     if (open) {
-      const storedPrompt = getCampaignPrompt();
-      if (storedPrompt) {
-        setHasStoredPrompt(true);
-        setUsedProblema(storedPrompt.includes('{{problema}}'));
-        setUsedSolucao(storedPrompt.includes('{{solucao}}'));
-        updateEditorContent(storedPrompt);
-      } else {
-        setHasStoredPrompt(false);
-        setUsedProblema(false);
-        setUsedSolucao(false);
-        updateEditorContent('');
-      }
+      const storedPrompt = getCampaignPrompt() || '';
+      setEditorContent(storedPrompt);
+      setHasStoredPrompt(!!storedPrompt);
+      setUsedProblema(storedPrompt.includes('{{problema}}'));
+      setUsedSolucao(storedPrompt.includes('{{solucao}}'));
       setMessage('');
     }
   }, [open]);
 
   const handleSave = () => {
-    const text = editorRef.current.innerText;
-    saveCampaignPrompt(text);
+    saveCampaignPrompt(editorContent);
     setHasStoredPrompt(true);
     setMessage('Prompt de campanha salvo com sucesso!');
   };
@@ -46,35 +36,23 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   const handleRemove = () => {
     removeCampaignPrompt();
     setHasStoredPrompt(false);
+    setEditorContent('');
     setUsedProblema(false);
     setUsedSolucao(false);
-    updateEditorContent('');
     setMessage('Prompt de campanha removido.');
   };
 
   const handleInsertPlaceholder = (placeholder) => {
     const placeholderText = `{{${placeholder}}}`;
-    if (editorRef.current) {
-      editorRef.current.focus();
-      const selection = window.getSelection();
-      const range = selection.getRangeAt(0);
-      range.deleteContents();
-      const textNode = document.createTextNode(placeholderText + ' ');
-      range.insertNode(textNode);
-      range.setStartAfter(textNode);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
-
-      const newText = editorRef.current.innerText;
-      if (placeholder === 'problema') setUsedProblema(true);
-      if (placeholder === 'solucao') setUsedSolucao(true);
-      updateEditorContent(newText);
-    }
+    const newContent = editorContent + placeholderText + ' ';
+    setEditorContent(newContent);
+    if (placeholder === 'problema') setUsedProblema(true);
+    if (placeholder === 'solucao') setUsedSolucao(true);
   };
 
-  const handleInput = () => {
-    const text = editorRef.current.innerText;
+  const handleInput = (e) => {
+    const text = e.currentTarget.innerText;
+    setEditorContent(text);
     if (!text.includes('{{problema}}')) setUsedProblema(false);
     if (!text.includes('{{solucao}}')) setUsedSolucao(false);
   };
@@ -82,7 +60,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>Definir Texto de Prompt de Campanha</DialogTitle>
-      <DialogContent>
+      <DialogContent dividers>
         <Typography variant="body2" gutterBottom>
           Insira ou edite o texto base que será usado como prompt para gerar conteúdo de campanha com IA.
         </Typography>
@@ -107,6 +85,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
           ref={editorRef}
           contentEditable
           onInput={handleInput}
+          dangerouslySetInnerHTML={{ __html: getHighlightedHtml(editorContent) }}
           sx={{
             mt: 2,
             mb: 2,
@@ -114,6 +93,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
             borderRadius: '4px',
             p: 2,
             minHeight: '200px',
+            overflowY: 'auto',
             '&:focus': {
               outline: '2px solid #8b5cf6',
               borderColor: '#8b5cf6'


### PR DESCRIPTION
This commit addresses several issues and improves the user experience of the 'Campanha' step and the 'Definir Texto de Prompt de Campanha' dialog.

The following changes have been implemented:

1.  **Bug Fix: Campaign Prompt Restoration:**
    *   The `CampaignPromptDialog` has been refactored to use React state for managing the editor's content. This fixes a bug where the saved prompt was not being reliably displayed when the dialog was reopened.

2.  **UI/UX Improvement: Prompt Dialog Scroll Behavior:**
    *   The scroll behavior of the `CampaignPromptDialog` has been improved. The content of the text editor now scrolls independently, while the dialog title and actions remain fixed.

3.  **UI/UX Improvement: Disable/Reset Functionality:**
    *   After successfully generating AI content, the 'Problema', 'Solução', and 'Gerar' buttons are now disabled to prevent accidental changes.
    *   A 'Resetar' button is now displayed, allowing you to clear the generated content and re-enable the input fields to start over.