### PR TITLE
Fix: Prevent cursor jump in Campaign Prompt editor

### DIFF
--- a/src/components/CampaignPromptDialog.jsx
+++ b/src/components/CampaignPromptDialog.jsx
@@ -9,6 +9,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   const [usedSolucao, setUsedSolucao] = useState(false);
   const editorRef = useRef(null);
   const [editorContent, setEditorContent] = useState('');
+  const [initialContent, setInitialContent] = useState('');
 
   const getHighlightedHtml = (text) => {
     return text
@@ -19,6 +20,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   useEffect(() => {
     if (open) {
       const storedPrompt = getCampaignPrompt() || '';
+      setInitialContent(storedPrompt);
       setEditorContent(storedPrompt);
       setHasStoredPrompt(!!storedPrompt);
       setUsedProblema(storedPrompt.includes('{{problema}}'));
@@ -36,6 +38,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   const handleRemove = () => {
     removeCampaignPrompt();
     setHasStoredPrompt(false);
+    setInitialContent('');
     setEditorContent('');
     setUsedProblema(false);
     setUsedSolucao(false);
@@ -45,6 +48,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
   const handleInsertPlaceholder = (placeholder) => {
     const placeholderText = `{{${placeholder}}}`;
     const newContent = editorContent + placeholderText + ' ';
+    setInitialContent(newContent);
     setEditorContent(newContent);
     if (placeholder === 'problema') setUsedProblema(true);
     if (placeholder === 'solucao') setUsedSolucao(true);
@@ -85,7 +89,7 @@ const CampaignPromptDialog = ({ open, onClose }) => {
           ref={editorRef}
           contentEditable
           onInput={handleInput}
-          dangerouslySetInnerHTML={{ __html: getHighlightedHtml(editorContent) }}
+          dangerouslySetInnerHTML={{ __html: getHighlightedHtml(initialContent) }}
           sx={{
             border: '1px solid #ccc',
             borderRadius: '4px',


### PR DESCRIPTION
The cursor was jumping to the beginning of the input field after each character was typed in the Campaign Prompt editor.

This was caused by the component's state being updated on every keystroke, which triggered a re-render of the `contentEditable` div with `dangerouslySetInnerHTML`. This process replaced the entire HTML content of the editor, resetting the cursor position.

The fix involves separating the concerns of display and state management:
- A new state, `initialContent`, is introduced to control the HTML rendering. It is set only when the dialog opens or when a placeholder is inserted, which are the only times a full re-render of the highlighted content is needed.
- The existing `editorContent` state is now updated on every keystroke in the background without triggering a re-render of the editor's HTML. This ensures the cursor position is maintained during typing.
- The `dangerouslySetInnerHTML` prop now uses `initialContent` for rendering, breaking the problematic re-render cycle during normal typing.