### PR TITLE
feat: Subdivide prompt into Persona, Autor, and Instrucoes fields

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -226,6 +226,9 @@ function App() {
   const [isGeneratingCampaign, setIsGeneratingCampaign] = useState(false);
   const [campaignContent, setCampaignContent] = useState(null);
   const [editingField, setEditingField] = useState(null);
+  const [persona, setPersona] = useState('');
+  const [autor, setAutor] = useState('');
+  const [instrucoes, setInstrucoes] = useState('');
 
   // Estados para a Geração com IA
   const [inputMethod, setInputMethod] = useState('csv');
@@ -233,6 +236,8 @@ function App() {
   const [promptNumRecords, setPromptNumRecords] = useState(10);
   const [promptText, setPromptText] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const fileInputRef = useRef(null);
   const imageInputRef = useRef(null);
@@ -248,10 +253,10 @@ function App() {
   }, [darkMode]);
 
   useEffect(() => {
-    const savedPrompt = getCampaignPrompt();
-    if (savedPrompt) {
-      setPromptText(savedPrompt);
-    }
+    const { persona, autor, instrucoes } = getCampaignPrompt();
+    setPersona(persona);
+    setAutor(autor);
+    setInstrucoes(instrucoes);
   }, []);
 
   useEffect(() => {
@@ -501,86 +506,106 @@ function App() {
   // Outras funções mantidas do código original...
 
   const handleSaveState = async () => {
-    // Função auxiliar para converter Blob para Base64
-    const blobToBase64 = (blob) => {
-      return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(blob);
-      });
-    };
+    setIsSaving(true);
+    try {
+      // Função auxiliar para converter Blob para Base64
+      const blobToBase64 = (blob) => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+      };
 
-    // Mapear generatedImagesData para um formato serializável
-    const serializableGeneratedImages = await Promise.all(
-      generatedImagesData.map(async (img) => {
-        let imageBase64 = null;
-        if (img.blob) {
-          try {
-            imageBase64 = await blobToBase64(img.blob);
-          } catch (error) {
-            console.error("Erro ao converter blob para Base64:", error);
-            // Continuar mesmo se um blob falhar, para não impedir o salvamento do resto
-          }
-        }
-        return {
-          ...img,
-          blob: undefined, // Remover o blob original
-          url: undefined, // Remover o objectURL temporário
-          imageBase64: imageBase64, // Adicionar a string base64
-          // Manter: record, filename, customFieldPositions, customFieldStyles, backgroundImage (se individual)
-        };
-      })
-    );
-
-    const serializableGeneratedAudio = await Promise.all(
-        generatedAudioData.map(async (audio) => {
-            let audioBase64 = null;
-            if (audio.blob) {
-                try {
-                    audioBase64 = await blobToBase64(audio.blob);
-                } catch (error) {
-                    console.error("Erro ao converter blob de áudio para Base64:", error);
-                }
+      // Mapear generatedImagesData para um formato serializável
+      const serializableGeneratedImages = await Promise.all(
+        generatedImagesData.map(async (img) => {
+          let imageBase64 = null;
+          if (img.blob) {
+            try {
+              imageBase64 = await blobToBase64(img.blob);
+            } catch (error) {
+              console.error("Erro ao converter blob para Base64:", error);
+              // Continuar mesmo se um blob falhar, para não impedir o salvamento do resto
             }
-            return {
-                ...audio,
-                blob: undefined,
-                audioBase64: audioBase64,
-            };
+          }
+          return {
+            ...img,
+            blob: undefined, // Remover o blob original
+            url: undefined, // Remover o objectURL temporário
+            imageBase64: imageBase64, // Adicionar a string base64
+            // Manter: record, filename, customFieldPositions, customFieldStyles, backgroundImage (se individual)
+          };
         })
-    );
+      );
 
-    const stateToSave = {
-      version: "1.1", // Incrementar versão para refletir a nova estrutura
-      backgroundImageUrl: backgroundImage, // Este é o BG global/template, já é uma string (dataURL ou URL externa)
-      fieldPositions: fieldPositions,
-      fieldStyles: fieldStyles,
-      csvHeaders: csvHeaders,
-      colorPalette: colorPalette,
-      csvData: csvData,
-      generatedImages: serializableGeneratedImages, // Salvar os dados das imagens geradas
-      generatedAudio: serializableGeneratedAudio,
-    };
+      const serializableGeneratedAudio = await Promise.all(
+          generatedAudioData.map(async (audio) => {
+              let audioBase64 = null;
+              if (audio.blob) {
+                  try {
+                      audioBase64 = await blobToBase64(audio.blob);
+                  } catch (error) {
+                      console.error("Erro ao converter blob de áudio para Base64:", error);
+                  }
+              }
+              return {
+                  ...audio,
+                  blob: undefined,
+                  audioBase64: audioBase64,
+              };
+          })
+      );
 
-    const jsonString = JSON.stringify(stateToSave, null, 2);
-    const compressedData = pako.gzip(jsonString);
-    const blob = new Blob([compressedData], { type: "application/octet-stream" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = "template_config.midiator";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-    alert("Configuração do template salva como template_config.midiator!");
+      const stateToSave = {
+        version: "1.3", // Nova versão para incluir os campos de prompt
+        backgroundImageUrl: backgroundImage,
+        fieldPositions: fieldPositions,
+        fieldStyles: fieldStyles,
+        csvHeaders: csvHeaders,
+        colorPalette: colorPalette,
+        csvData: csvData,
+        generatedImages: serializableGeneratedImages,
+        generatedAudio: serializableGeneratedAudio,
+        problema: problema,
+        solucao: solucao,
+        campaignContent: campaignContent,
+        // Novos campos de prompt
+        persona: persona,
+        autor: autor,
+        instrucoes: instrucoes,
+      };
+
+      const jsonString = JSON.stringify(stateToSave, null, 2);
+      const compressedData = pako.gzip(jsonString);
+      const blob = new Blob([compressedData], { type: "application/octet-stream" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "template_config.midiator";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      alert("Configuração do template salva como template_config.midiator!");
+
+    } catch (error) {
+      console.error("Erro ao salvar o estado:", error);
+      alert("Ocorreu um erro ao salvar a configuração.");
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   // Função para carregar o estado do template de um arquivo
   const handleLoadStateFromFile = (event) => {
     const file = event.target.files[0];
     if (file) {
+      setIsLoading(true);
       const reader = new FileReader();
       reader.onload = async (e) => { // Tornar async para aguardar conversões
         try {
@@ -601,7 +626,7 @@ function App() {
           };
 
           // Verificar versão e campos essenciais
-          if (loadedState.version && (loadedState.version === "1.0" || loadedState.version === "1.1") &&
+          if (loadedState.version && ["1.0", "1.1", "1.2", "1.3"].includes(loadedState.version) &&
             loadedState.backgroundImageUrl !== undefined &&
             loadedState.fieldPositions &&
             loadedState.fieldStyles &&
@@ -678,7 +703,7 @@ function App() {
               setGeneratedImagesData([]); // Limpar se não houver dados ou for versão antiga
             }
 
-            if (loadedState.version === "1.1" && loadedState.generatedAudio) {
+            if (parseFloat(loadedState.version) >= 1.1 && loadedState.generatedAudio) {
                 const restoredGeneratedAudio = await Promise.all(
                     loadedState.generatedAudio.map(async (audioData) => {
                         let blob = null;
@@ -701,6 +726,28 @@ function App() {
                 setGeneratedAudioData([]);
             }
 
+            // Restaurar dados da campanha se presentes
+            if (parseFloat(loadedState.version) >= 1.2) {
+              setProblema(loadedState.problema || '');
+              setSolucao(loadedState.solucao || '');
+              setCampaignContent(loadedState.campaignContent || null);
+            } else {
+              setProblema('');
+              setSolucao('');
+              setCampaignContent(null);
+            }
+
+            // Restaurar novos campos de prompt se presentes (versão 1.3+)
+            if (parseFloat(loadedState.version) >= 1.3) {
+              setPersona(loadedState.persona || '');
+              setAutor(loadedState.autor || '');
+              setInstrucoes(loadedState.instrucoes || '');
+            } else {
+              setPersona('');
+              setAutor('');
+              setInstrucoes('');
+            }
+
             // Navegação de passo
             if (loadedState.backgroundImageUrl && loadedState.csvHeaders.length > 0) {
               const etapaPosicionarFormatarIndex = steps.findIndex(step => step.label === 'Posicionar e Formatar');
@@ -721,6 +768,8 @@ function App() {
         } catch (error) {
           console.error("Erro ao carregar o arquivo JSON:", error);
           alert("Erro ao ler o arquivo JSON.");
+        } finally {
+          setIsLoading(false);
         }
       };
       if (file.name.endsWith('.midiator')) {
@@ -899,16 +948,17 @@ function App() {
       return;
     }
 
-    let promptTemplate = getCampaignPrompt();
-    if (!promptTemplate) {
-      promptTemplate = `Baseado no problema "{{problema}}" e na solução "{{solucao}}", gere o seguinte conteúdo para uma campanha de marketing.`;
-    }
+    const { persona, autor, instrucoes } = getCampaignPrompt();
 
-    const filledPrompt = promptTemplate
-      .replace('{{problema}}', problema)
-      .replace('{{solucao}}', solucao);
+    const promptCompleto = `
+      ${persona}
+      ${autor}
+      Problema: ${problema}
+      Solução: ${solucao}
+      ${instrucoes}
+    `;
 
-    const finalPrompt = `${filledPrompt}\n\nGere uma resposta JSON com os seguintes campos: "titulo" (string), "conteudo" (string), "cta" (string), e "hashtags" (string, separadas por vírgula). A resposta deve ser apenas o JSON.`;
+    const finalPrompt = `${promptCompleto}\n\nGere uma resposta JSON com os seguintes campos: "titulo" (string), "conteudo" (string), "cta" (string), e "hashtags" (string, separadas por vírgula). A resposta deve ser apenas o JSON.`;
 
     try {
       const response = await callGeminiApi(finalPrompt, apiKey);
@@ -2076,7 +2126,19 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
         open={showCampaignPromptModal}
         onClose={() => setShowCampaignPromptModal(false)}
       />
-      <LoadingDialog open={isGeneratingCampaign} />
+      <LoadingDialog
+        open={isGeneratingCampaign || isSaving || isLoading}
+        title={
+          isSaving ? "Salvando configuração..." :
+          isLoading ? "Carregando configuração..." :
+          "Gerando conteúdo..." // Default for isGeneratingCampaign
+        }
+        description={
+          isSaving ? "Aguarde um momento, estamos empacotando tudo para você." :
+          isLoading ? "Estamos desempacotando sua configuração. Quase pronto!" :
+          "A IA está pensando e escrevendo. Isso pode levar alguns segundos." // Default
+        }
+      />
       <TextEditorDialog
         open={editingField !== null}
         title={`Editar ${editingField === 'conteudo' ? 'Conteúdo' : 'CTA'}`}

--- a/src/components/CampaignPromptDialog.jsx
+++ b/src/components/CampaignPromptDialog.jsx
@@ -1,135 +1,158 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { getCampaignPrompt, saveCampaignPrompt, removeCampaignPrompt } from '../utils/campaignPrompt';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography, Box, Chip } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography, Box, TextField, IconButton } from '@mui/material';
+import { Edit } from '@mui/icons-material';
+import TextEditorDialog from './TextEditorDialog';
 
 const CampaignPromptDialog = ({ open, onClose }) => {
   const [message, setMessage] = useState('');
   const [hasStoredPrompt, setHasStoredPrompt] = useState(false);
-  const [usedProblema, setUsedProblema] = useState(false);
-  const [usedSolucao, setUsedSolucao] = useState(false);
-  const editorRef = useRef(null);
-  const [editorContent, setEditorContent] = useState('');
-  const [initialContent, setInitialContent] = useState('');
-
-  const getHighlightedHtml = (text) => {
-    return text
-      .replace(/{{problema}}/g, '<span style="color: #ec4899; font-family: monospace;">{{problema}}</span>')
-      .replace(/{{solucao}}/g, '<span style="color: #8b5cf6; font-family: monospace;">{{solucao}}</span>');
-  };
+  const [persona, setPersona] = useState('');
+  const [autor, setAutor] = useState('');
+  const [instrucoes, setInstrucoes] = useState('');
+  const [editingField, setEditingField] = useState(null);
 
   useEffect(() => {
     if (open) {
-      const storedPrompt = getCampaignPrompt() || '';
-      setInitialContent(storedPrompt);
-      setEditorContent(storedPrompt);
-      setHasStoredPrompt(!!storedPrompt);
-      setUsedProblema(storedPrompt.includes('{{problema}}'));
-      setUsedSolucao(storedPrompt.includes('{{solucao}}'));
+      const { persona, autor, instrucoes } = getCampaignPrompt();
+      setPersona(persona);
+      setAutor(autor);
+      setInstrucoes(instrucoes);
+      setHasStoredPrompt(!!(persona || autor || instrucoes));
       setMessage('');
     }
   }, [open]);
 
   const handleSave = () => {
-    saveCampaignPrompt(editorContent);
+    saveCampaignPrompt({ persona, autor, instrucoes });
     setHasStoredPrompt(true);
     setMessage('Prompt de campanha salvo com sucesso!');
   };
 
   const handleRemove = () => {
     removeCampaignPrompt();
+    setPersona('');
+    setAutor('');
+    setInstrucoes('');
     setHasStoredPrompt(false);
-    setInitialContent('');
-    setEditorContent('');
-    setUsedProblema(false);
-    setUsedSolucao(false);
     setMessage('Prompt de campanha removido.');
   };
 
-  const handleInsertPlaceholder = (placeholder) => {
-    const placeholderText = `{{${placeholder}}}`;
-    const newContent = editorContent + placeholderText + ' ';
-    setInitialContent(newContent);
-    setEditorContent(newContent);
-    if (placeholder === 'problema') setUsedProblema(true);
-    if (placeholder === 'solucao') setUsedSolucao(true);
+  const handleOpenEditor = (field) => {
+    setEditingField(field);
   };
 
-  const handleInput = (e) => {
-    const text = e.currentTarget.innerText;
-    setEditorContent(text);
-    if (!text.includes('{{problema}}')) setUsedProblema(false);
-    if (!text.includes('{{solucao}}')) setUsedSolucao(false);
+  const handleCloseEditor = () => {
+    setEditingField(null);
+  };
+
+  const handleSaveEditor = (newContent) => {
+    if (editingField === 'persona') {
+      setPersona(newContent);
+    } else if (editingField === 'autor') {
+      setAutor(newContent);
+    } else if (editingField === 'instrucoes') {
+      setInstrucoes(newContent);
+    }
+    setEditingField(null);
+  };
+
+  const getCurrentContent = () => {
+    if (editingField === 'persona') return persona;
+    if (editingField === 'autor') return autor;
+    if (editingField === 'instrucoes') return instrucoes;
+    return '';
+  };
+
+  const getEditorTitle = () => {
+      if (editingField === 'persona') return 'Editar Persona';
+      if (editingField === 'autor') return 'Editar Autor';
+      if (editingField === 'instrucoes') return 'Editar Instruções';
+      return 'Editar';
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Definir Texto de Prompt de Campanha</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 3 }}>
-        <Typography variant="body2" gutterBottom>
-          Insira ou edite o texto base que será usado como prompt para gerar conteúdo de campanha com IA.
-        </Typography>
-
-        <Box sx={{ my: 2 }}>
-          <Typography variant="subtitle2" gutterBottom>Campos Disponíveis</Typography>
-          <Chip
-            label="Problema"
-            onClick={() => handleInsertPlaceholder('problema')}
-            disabled={usedProblema}
-            sx={{ mr: 1, backgroundColor: '#fce7f3', color: '#be185d', '&:hover': {backgroundColor: '#f9a8d4'} }}
-          />
-          <Chip
-            label="Solução"
-            onClick={() => handleInsertPlaceholder('solucao')}
-            disabled={usedSolucao}
-            sx={{ backgroundColor: '#f5f3ff', color: '#6d28d9', '&:hover': {backgroundColor: '#c4b5fd'} }}
-          />
-        </Box>
-
-        <Box
-          ref={editorRef}
-          contentEditable
-          onInput={handleInput}
-          dangerouslySetInnerHTML={{ __html: getHighlightedHtml(initialContent) }}
-          sx={{
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            p: 2,
-            flex: 1,
-            overflowY: 'auto',
-            minHeight: '200px',
-            '&:focus': {
-              outline: '2px solid #8b5cf6',
-              borderColor: '#8b5cf6'
-            },
-            'span': {
-              padding: '2px 4px',
-              borderRadius: '4px'
-            }
-          }}
-        />
-
-        {message && (
-          <Typography color={message.includes('sucesso') ? 'green' : (message.includes('removido') ? 'textPrimary' : 'error')} variant="body2" sx={{ mt: 2 }}>
-            {message}
+    <>
+      <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+        <DialogTitle>Definir Texto de Prompt de Campanha</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 3, gap: 2 }}>
+          <Typography variant="body2" gutterBottom>
+            Insira ou edite os textos que serão usados como base para gerar o conteúdo da campanha.
           </Typography>
-        )}
-      </DialogContent>
-      <DialogActions sx={{ pb: 2, px: 3, justifyContent: 'space-between' }}>
-        <Box>
-          {hasStoredPrompt && (
-            <Button onClick={handleRemove} color="error">
-              Remover Prompt
-            </Button>
+
+          <Box>
+            <Typography variant="subtitle1" gutterBottom>Persona</Typography>
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              value={persona}
+              onClick={() => handleOpenEditor('persona')}
+              readOnly
+              placeholder="Clique para editar a persona..."
+              sx={{ cursor: 'pointer' }}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle1" gutterBottom>Autor</Typography>
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              value={autor}
+              onClick={() => handleOpenEditor('autor')}
+              readOnly
+              placeholder="Clique para editar o autor..."
+              sx={{ cursor: 'pointer' }}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle1" gutterBottom>Instruções</Typography>
+            <TextField
+              fullWidth
+              multiline
+              rows={5}
+              value={instrucoes}
+              onClick={() => handleOpenEditor('instrucoes')}
+              readOnly
+              placeholder="Clique para editar as instruções..."
+              sx={{ cursor: 'pointer' }}
+            />
+          </Box>
+
+          {message && (
+            <Typography color={message.includes('sucesso') ? 'green' : (message.includes('removido') ? 'textPrimary' : 'error')} variant="body2" sx={{ mt: 2 }}>
+              {message}
+            </Typography>
           )}
-        </Box>
-        <Box>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSave} variant="contained" sx={{ ml: 1 }}>
-            Salvar Prompt
-          </Button>
-        </Box>
-      </DialogActions>
-    </Dialog>
+        </DialogContent>
+        <DialogActions sx={{ pb: 2, px: 3, justifyContent: 'space-between' }}>
+          <Box>
+            {hasStoredPrompt && (
+              <Button onClick={handleRemove} color="error">
+                Remover Prompt
+              </Button>
+            )}
+          </Box>
+          <Box>
+            <Button onClick={onClose}>Cancelar</Button>
+            <Button onClick={handleSave} variant="contained" sx={{ ml: 1 }}>
+              Salvar Prompt
+            </Button>
+          </Box>
+        </DialogActions>
+      </Dialog>
+
+      <TextEditorDialog
+        open={editingField !== null}
+        title={getEditorTitle()}
+        content={getCurrentContent()}
+        onSave={handleSaveEditor}
+        onClose={handleCloseEditor}
+      />
+    </>
   );
 };
 

--- a/src/components/LoadingDialog.jsx
+++ b/src/components/LoadingDialog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Dialog, DialogContent, Typography, Box } from '@mui/material';
 import './LoadingDialog.css';
 
-const LoadingDialog = ({ open }) => {
+const LoadingDialog = ({ open, title = "Gerando conteúdo...", description = "A IA está pensando e escrevendo. Isso pode levar alguns segundos." }) => {
   return (
     <Dialog open={open} PaperProps={{ style: { borderRadius: '16px' } }}>
       <DialogContent sx={{ p: 4, textAlign: 'center' }}>
@@ -11,9 +11,9 @@ const LoadingDialog = ({ open }) => {
           <div className="dot" />
           <div className="dot" />
         </Box>
-        <Typography variant="h6">Gerando conteúdo...</Typography>
+        <Typography variant="h6">{title}</Typography>
         <Typography variant="body2" color="text.secondary">
-          A IA está pensando e escrevendo. Isso pode levar alguns segundos.
+          {description}
         </Typography>
       </DialogContent>
     </Dialog>

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -1,13 +1,13 @@
 const CAMPAIGN_PROMPT_STORAGE_KEY = 'campaignPrompt';
 
 /**
- * Salva o texto do prompt de campanha no localStorage.
- * @param {string} promptText - O texto do prompt a ser salvo.
+ * Salva o objeto do prompt de campanha no localStorage.
+ * @param {object} promptData - O objeto com os dados do prompt ({ persona, autor, instrucoes }).
  */
-export function saveCampaignPrompt(promptText) {
+export function saveCampaignPrompt(promptData) {
   if (typeof window !== 'undefined' && window.localStorage) {
     try {
-      window.localStorage.setItem(CAMPAIGN_PROMPT_STORAGE_KEY, promptText);
+      window.localStorage.setItem(CAMPAIGN_PROMPT_STORAGE_KEY, JSON.stringify(promptData));
     } catch (error) {
       console.error("Erro ao salvar o prompt de campanha:", error);
     }
@@ -15,23 +15,47 @@ export function saveCampaignPrompt(promptText) {
 }
 
 /**
- * Recupera o texto do prompt de campanha do localStorage.
- * @returns {string|null} O texto do prompt ou null se não for encontrado.
+ * Recupera o objeto do prompt de campanha do localStorage.
+ * Lida com a migração do formato antigo (string) para o novo (JSON).
+ * @returns {{persona: string, autor: string, instrucoes: string}|null} O objeto do prompt ou um objeto com campos vazios.
  */
 export function getCampaignPrompt() {
   if (typeof window !== 'undefined' && window.localStorage) {
     try {
-      return window.localStorage.getItem(CAMPAIGN_PROMPT_STORAGE_KEY);
+      const storedData = window.localStorage.getItem(CAMPAIGN_PROMPT_STORAGE_KEY);
+      if (!storedData) {
+        return { persona: '', autor: '', instrucoes: '' };
+      }
+      // Tenta parsear como JSON (novo formato)
+      try {
+        const parsedData = JSON.parse(storedData);
+        if (typeof parsedData === 'object' && parsedData !== null) {
+          return {
+            persona: parsedData.persona || '',
+            autor: parsedData.autor || '',
+            instrucoes: parsedData.instrucoes || '',
+          };
+        }
+      } catch (e) {
+        // Se falhar o parse, assume que é o formato antigo (string)
+        // e o coloca no campo 'instrucoes' do novo formato.
+        console.log("Migrando prompt do formato antigo para o novo.");
+        const migratedData = { persona: '', autor: '', instrucoes: storedData };
+        saveCampaignPrompt(migratedData); // Salva no novo formato
+        return migratedData;
+      }
+      // Se o dado armazenado não for um objeto JSON válido nem uma string (caso estranho), retorna o padrão.
+      return { persona: '', autor: '', instrucoes: '' };
     } catch (error) {
       console.error("Erro ao recuperar o prompt de campanha:", error);
-      return null;
+      return { persona: '', autor: '', instrucoes: '' };
     }
   }
-  return null;
+  return { persona: '', autor: '', instrucoes: '' };
 }
 
 /**
- * Remove o texto do prompt de campanha do localStorage.
+ * Remove o prompt de campanha do localStorage.
  */
 export function removeCampaignPrompt() {
   if (typeof window !== 'undefined' && window.localStorage) {


### PR DESCRIPTION
This commit implements the following features:

1.  The campaign prompt is now subdivided into three distinct fields: `Persona`, `Autor`, and `Instruções`.
2.  The `CampaignPromptDialog` has been updated with a new UI to accommodate these three fields, using `TextEditorDialog` for a better editing experience of long texts.
3.  The content of these new fields is saved to and retrieved from local storage as a single JSON object, with a migration path for the previous string-based format.
4.  The application state and the template file (`.midiator`) now include these new fields, ensuring they are persisted across sessions and in saved templates.
5.  The campaign generation logic now concatenates `Persona`, `Autor`, `problema`, `solucao`, and `Instruções` to create the final prompt for the AI.