### PR TITLE
fix: Remove crossOrigin attribute to fix image loading

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -6,7 +6,7 @@
 const loadImage = (src) => {
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.crossOrigin = 'Anonymous'; // Handle CORS
+    // img.crossOrigin = 'Anonymous'; // This can cause issues with local dev servers and even some production environments. Removing it for same-origin requests.
     img.onload = () => resolve(img);
     img.onerror = (err) => reject(new Error(`Failed to load image: ${src}`, { cause: err }));
     img.src = src;


### PR DESCRIPTION
This commit removes the `img.crossOrigin = 'Anonymous'` attribute from the `loadImage` function. This attribute was causing CORS-related errors when loading same-origin images (like LOGO.png and EMPRESA.png) on both local development servers and the Vercel production environment.

Removing this line allows the browser to handle same-origin image loading with its default, less strict security policy, which resolves the image composition failure.