### PR TITLE
feat: Add LinkedIn OAuth2 integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,8 +79,10 @@ import GeminiAuthSetup from './components/GeminiAuthSetup';
 import GoogleDriveAuthModal from './components/GoogleDriveAuthModal';
 import GoogleCloudTTSAuth from './components/GoogleCloudTTSAuth';
 import WordpressAuthSetup from './components/WordpressAuthSetup';
+import LinkedinAuthSetup from './components/LinkedinAuthSetup';
 import CampaignPromptDialog from './components/CampaignPromptDialog';
 import { getGeminiApiKey } from './utils/geminiCredentials';
+import { getLinkedinConfig, saveLinkedinConfig } from './utils/linkedinCredentials';
 import { getCampaignPrompt } from './utils/campaignPrompt';
 import { callGeminiApi, generateImage } from './utils/geminiAPI';
 import { composeImage } from './utils/imageComposer';
@@ -233,6 +235,7 @@ function App() {
   const [showGoogleDriveAuthModal, setShowGoogleDriveAuthModal] = useState(false);
   const [showGoogleCloudTTSAuthModal, setShowGoogleCloudTTSAuthModal] = useState(false);
   const [showWordpressAuthModal, setShowWordpressAuthModal] = useState(false);
+  const [showLinkedinAuthModal, setShowLinkedinAuthModal] = useState(false);
   const [showCampaignPromptModal, setShowCampaignPromptModal] = useState(false);
 
   // Estados para a Campanha
@@ -284,6 +287,69 @@ function App() {
     setInstrucoes(instrucoes);
     setFormato(formato);
     setAspectRatio(aspectRatio || '1:1');
+  }, []);
+
+  useEffect(() => {
+    const handleLinkedinCallback = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const code = urlParams.get('code');
+
+      if (code) {
+        // Remove o código da URL para não ser usado novamente
+        window.history.replaceState({}, document.title, "/");
+
+        const config = getLinkedinConfig();
+        if (!config || !config.clientId || !config.clientSecret) {
+          console.error('Client ID ou Client Secret do LinkedIn não encontrado.');
+          // Talvez mostrar uma mensagem para o usuário
+          return;
+        }
+
+        const { clientId, clientSecret } = config;
+        const redirectUri = window.location.origin;
+
+        const tokenUrl = 'https://www.linkedin.com/oauth/v2/accessToken';
+        const body = new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: code,
+          redirect_uri: redirectUri,
+          client_id: clientId,
+          client_secret: clientSecret,
+        });
+
+        try {
+          const response = await fetch(tokenUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: body,
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            const { access_token, expires_in } = data;
+
+            saveLinkedinConfig({
+              ...config,
+              accessToken: access_token,
+              tokenExpiration: Date.now() + expires_in * 1000,
+              clientSecret: undefined, // Garante que o secret não seja salvo
+            });
+
+            // Abre o modal para mostrar que a conexão foi bem-sucedida
+            setShowLinkedinAuthModal(true);
+          } else {
+            console.error('Erro ao obter o token de acesso do LinkedIn:', await response.text());
+            // Tratar erro, talvez mostrar mensagem
+          }
+        } catch (error) {
+          console.error('Erro de rede ao contatar o LinkedIn:', error);
+        }
+      }
+    };
+
+    handleLinkedinCallback();
   }, []);
 
   useEffect(() => {
@@ -1626,6 +1692,10 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
                   <Language sx={{ mr: 1 }} />
                   Configurar WordPress
                 </MenuItem>
+                <MenuItem onClick={() => { setShowLinkedinAuthModal(true); handleMenuClose(); }}>
+                  <Language sx={{ mr: 1 }} />
+                  Configurar LinkedIn
+                </MenuItem>
                 <MenuItem onClick={() => { setShowCampaignPromptModal(true); handleMenuClose(); }}>
                   <Edit sx={{ mr: 1 }} />
                   Definir Prompt de Campanha
@@ -2400,6 +2470,10 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
       <WordpressAuthSetup
         open={showWordpressAuthModal}
         onClose={() => setShowWordpressAuthModal(false)}
+      />
+      <LinkedinAuthSetup
+        open={showLinkedinAuthModal}
+        onClose={() => setShowLinkedinAuthModal(false)}
       />
        <CampaignPromptDialog
         open={showCampaignPromptModal}

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -1,0 +1,178 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Typography,
+  Box,
+  IconButton,
+  Tooltip,
+  Grid,
+} from '@mui/material';
+import { Visibility, VisibilityOff, InfoOutlined } from '@mui/icons-material';
+import {
+  saveLinkedinConfig,
+  getLinkedinConfig,
+  removeLinkedinConfig,
+} from '../utils/linkedinCredentials';
+
+const LinkedinAuthSetup = ({ open, onClose }) => {
+  const [config, setConfig] = useState({
+    clientId: '',
+    clientSecret: '',
+  });
+  const [currentConfig, setCurrentConfig] = useState(null);
+  const [showSecret, setShowSecret] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      const storedConfig = getLinkedinConfig();
+      if (storedConfig && storedConfig.accessToken) {
+        setCurrentConfig(storedConfig);
+        setConfig({
+            clientId: storedConfig.clientId,
+            clientSecret: '', // Do not expose client secret
+        });
+      } else {
+        setCurrentConfig(null);
+        setConfig({
+            clientId: '',
+            clientSecret: '',
+        });
+      }
+      setMessage('');
+    }
+  }, [open]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setConfig((prevConfig) => ({
+      ...prevConfig,
+      [name]: value,
+    }));
+    if (message) setMessage('');
+  };
+
+  const handleConnect = () => {
+    if (config.clientId.trim()) {
+      // Save the clientId for the callback handler
+      saveLinkedinConfig({ clientId: config.clientId, clientSecret: config.clientSecret });
+
+      const redirectUri = window.location.origin;
+      const scope = 'r_liteprofile%20r_emailaddress%20w_member_social';
+      const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${config.clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
+
+      window.location.href = authUrl;
+    } else {
+      setMessage('Por favor, preencha o Client ID.');
+    }
+  };
+
+  const handleRemove = () => {
+    removeLinkedinConfig();
+    setCurrentConfig(null);
+    setConfig({
+      clientId: '',
+      clientSecret: '',
+    });
+    setMessage('Configuração do LinkedIn removida.');
+  };
+
+  const aplicationInfoTooltip = (
+    <span>
+      Como obter o Client ID e Secret do LinkedIn:
+      <ol>
+        <li>Acesse: LinkedIn Developer Portal</li>
+        <li>Crie um novo aplicativo ou selecione um existente.</li>
+        <li>Copie o Client ID e o Client Secret.</li>
+        <li>Configure o Redirect URI para: {window.location.origin}</li>
+        <li>Cole essas informações aqui.</li>
+      </ol>
+      ⚠️ O Client Secret não será armazenado de forma permanente no navegador.
+    </span>
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Configurar Integração com LinkedIn</DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" gutterBottom>
+          Insira seu Client ID e Client Secret para conectar sua conta do LinkedIn.
+        </Typography>
+
+        {currentConfig && currentConfig.accessToken ? (
+          <Typography variant="h6" color="green" sx={{ mt: 2 }}>
+            ✅ Conectado ao LinkedIn.
+          </Typography>
+        ) : (
+          <Grid container spacing={2} sx={{ mt: 2 }}>
+              <Grid item xs={12} sm={6}>
+                  <TextField
+                      name="clientId"
+                      label="Client ID"
+                      value={config.clientId}
+                      onChange={handleChange}
+                      fullWidth
+                      required
+                      variant="outlined"
+                      placeholder="Seu Client ID do LinkedIn"
+                      disabled={currentConfig && currentConfig.accessToken}
+                  />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                   <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      <TextField
+                          name="clientSecret"
+                          label="Client Secret"
+                          type={showSecret ? 'text' : 'password'}
+                          value={config.clientSecret}
+                          onChange={handleChange}
+                          fullWidth
+                          required
+                          variant="outlined"
+                          disabled={currentConfig && currentConfig.accessToken}
+                      />
+                      <IconButton onClick={() => setShowSecret(!showSecret)} edge="end">
+                          {showSecret ? <VisibilityOff /> : <Visibility />}
+                      </IconButton>
+                      <Tooltip title={aplicationInfoTooltip}>
+                          <IconButton>
+                              <InfoOutlined />
+                          </IconButton>
+                      </Tooltip>
+                  </Box>
+              </Grid>
+          </Grid>
+        )}
+
+        {message && (
+          <Typography color={message.includes('sucesso') || message.includes('Conectado') ? 'green' : 'error'} variant="body2" sx={{ mt: 2 }}>
+            {message}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ pb: 2, px: 3, justifyContent: 'space-between' }}>
+        <Box>
+            {currentConfig && currentConfig.accessToken ? (
+                <Button onClick={handleRemove} color="error">
+                    Desconectar
+                </Button>
+            ) : (
+                <Button onClick={handleConnect} variant="contained">
+                  Conectar com o LinkedIn
+                </Button>
+            )}
+        </Box>
+        <Box>
+          <Button onClick={onClose}>Fechar</Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default LinkedinAuthSetup;

--- a/src/utils/linkedinCredentials.js
+++ b/src/utils/linkedinCredentials.js
@@ -1,0 +1,46 @@
+const LINKEDIN_CONFIG_KEY = 'linkedinConfig';
+
+/**
+ * Salva a configuração do LinkedIn no armazenamento local.
+ * @param {object} config - O objeto de configuração.
+ */
+export const saveLinkedinConfig = (config) => {
+  try {
+    // Não armazene o clientSecret no localStorage por motivos de segurança.
+    const { clientSecret: _clientSecret, ...configToStore } = config;
+    const existingConfig = getLinkedinConfig() || {};
+    const newConfig = { ...existingConfig, ...configToStore };
+    const configString = JSON.stringify(newConfig);
+    localStorage.setItem(LINKEDIN_CONFIG_KEY, configString);
+  } catch (error) {
+    console.error('Erro ao salvar a configuração do LinkedIn:', error);
+  }
+};
+
+/**
+ * Obtém a configuração do LinkedIn do armazenamento local.
+ * @returns {object|null} O objeto de configuração ou nulo se não for encontrado.
+ */
+export const getLinkedinConfig = () => {
+  try {
+    const configString = localStorage.getItem(LINKEDIN_CONFIG_KEY);
+    if (configString) {
+      return JSON.parse(configString);
+    }
+    return null;
+  } catch (error) {
+    console.error('Erro ao obter a configuração do LinkedIn:', error);
+    return null;
+  }
+};
+
+/**
+ * Remove a configuração do LinkedIn do armazenamento local.
+ */
+export const removeLinkedinConfig = () => {
+  try {
+    localStorage.removeItem(LINKEDIN_CONFIG_KEY);
+  } catch (error) {
+    console.error('Erro ao remover a configuração do LinkedIn:', error);
+  }
+};


### PR DESCRIPTION
This commit introduces a new feature that allows you to connect your LinkedIn account using OAuth2.

- A new component `LinkedinAuthSetup.jsx` has been created to handle the UI for the integration.
- The component allows you to input your Client ID and Client Secret.
- It implements the full client-side OAuth2 Authorization Code Flow.
- The access token is stored in localStorage, while the client secret is not persisted.
- A new utility file `linkedinCredentials.js` has been added to manage the LinkedIn configuration.
- The main `App.jsx` component has been updated to handle the OAuth2 callback and manage the authentication flow.