### PR TITLE
fix: Correct Rich Text Editor styling and API response parsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1431,8 +1431,11 @@ function App() {
         CTA: ${content.cta}
       `;
 
-      const formattedContent = await callGeminiApi(prompt, apiKey);
-      setConteudoFormatado(formattedContent);
+      const rawContent = await callGeminiApi(prompt, apiKey);
+      // Remove markdown code block delimiters if they exist
+      const match = rawContent.match(/^`{3}(?:html)?\s*([\s\S]+?)\s*`{3}$/);
+      const finalContent = match && match[1] ? match[1].trim() : rawContent.trim();
+      setConteudoFormatado(finalContent);
 
     } catch (error) {
       console.error(`Erro ao gerar conteúdo formatado:`, error);

--- a/src/components/RichTextEditor.jsx
+++ b/src/components/RichTextEditor.jsx
@@ -333,16 +333,6 @@ const RichTextEditor = ({
                 size="small"
                 onClick={() => execCommand(button.command)}
                 disabled={disabled || htmlMode}
-                sx={darkMode ? {
-                  color: '#ffffff !important',
-                  '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                  },
-                  '&.active': {
-                    backgroundColor: '#90caf9 !important',
-                    color: '#000000 !important'
-                  }
-                } : {}}
               >
                 {button.icon}
               </IconButton>
@@ -361,16 +351,6 @@ const RichTextEditor = ({
                 size="small"
                 onClick={() => execCommand(button.command)}
                 disabled={disabled || htmlMode}
-                sx={darkMode ? {
-                  color: '#ffffff !important',
-                  '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                  },
-                  '&.active': {
-                    backgroundColor: '#90caf9 !important',
-                    color: '#000000 !important'
-                  }
-                } : {}}
               >
                 {button.icon}
               </IconButton>
@@ -388,16 +368,6 @@ const RichTextEditor = ({
               size="small"
               onClick={insertBulletList}
               disabled={disabled}
-              sx={darkMode ? {
-                color: '#ffffff !important',
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                },
-                '&.active': {
-                  backgroundColor: '#90caf9 !important',
-                  color: '#000000 !important'
-                }
-              } : {}}
             >
               <FormatListBulleted />
             </IconButton>
@@ -408,16 +378,6 @@ const RichTextEditor = ({
               size="small"
               onClick={insertNumberedList}
               disabled={disabled}
-              sx={darkMode ? {
-                color: '#ffffff !important',
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                },
-                '&.active': {
-                  backgroundColor: '#90caf9 !important',
-                  color: '#000000 !important'
-                }
-              } : {}}
             >
               <FormatListNumbered />
             </IconButton>
@@ -434,16 +394,6 @@ const RichTextEditor = ({
               size="small"
               onClick={() => execCommand('undo')}
               disabled={disabled || htmlMode}
-              sx={darkMode ? {
-                color: '#ffffff !important',
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                },
-                '&.active': {
-                  backgroundColor: '#90caf9 !important',
-                  color: '#000000 !important'
-                }
-              } : {}}
             >
               <Undo />
             </IconButton>
@@ -454,16 +404,6 @@ const RichTextEditor = ({
               size="small"
               onClick={() => execCommand('redo')}
               disabled={disabled || htmlMode}
-              sx={darkMode ? {
-                color: '#ffffff !important',
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                },
-                '&.active': {
-                  backgroundColor: '#90caf9 !important',
-                  color: '#000000 !important'
-                }
-              } : {}}
             >
               <Redo />
             </IconButton>
@@ -481,16 +421,6 @@ const RichTextEditor = ({
                 size="small"
                 onClick={toggleHtmlMode}
                 disabled={disabled}
-                sx={darkMode ? {
-                  color: '#ffffff !important',
-                  '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.08) !important'
-                  },
-                  '&.active': {
-                    backgroundColor: '#90caf9 !important',
-                    color: '#000000 !important'
-                  }
-                } : {}}
               >
                 <Code />
               </IconButton>


### PR DESCRIPTION
This commit addresses two issues identified in your feedback:

1.  API responses for formatted content are now parsed to remove markdown code block delimiters (e.g., ```html) before being displayed.
2.  The RichTextEditor component's styling has been corrected. Redundant `sx` props that caused incorrect dark mode rendering have been removed, allowing the component's CSS module to handle theming correctly.