### PR TITLE
refactor: Move WordPress publishing to a dedicated step

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ import {
   Campaign,
   AspectRatio,
   Language,
+  Publish,
 } from '@mui/icons-material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import Papa from 'papaparse';
@@ -80,13 +81,13 @@ import GoogleDriveAuthModal from './components/GoogleDriveAuthModal';
 import GoogleCloudTTSAuth from './components/GoogleCloudTTSAuth';
 import WordpressAuthSetup from './components/WordpressAuthSetup';
 import LinkedinAuthSetup from './components/LinkedinAuthSetup';
+import WordpressPublisher from './components/WordpressPublisher';
 import CampaignPromptDialog from './components/CampaignPromptDialog';
 import { getGeminiApiKey } from './utils/geminiCredentials';
 import { getLinkedinConfig, saveLinkedinConfig } from './utils/linkedinCredentials';
 import { getCampaignPrompt } from './utils/campaignPrompt';
 import { callGeminiApi, generateImage } from './utils/geminiAPI';
 import { composeImage } from './utils/imageComposer';
-import { publishToWordPress } from './utils/wordpressAPI';
 import GoogleIcon from '@mui/icons-material/Google';
 import pako from 'pako';
 import './App.css';
@@ -398,11 +399,6 @@ function App() {
   const [conteudoFormatado, setConteudoFormatado] = useState('');
   const [isGeneratingConteudoFormatado, setIsGeneratingConteudoFormatado] = useState(false);
 
-  // Estados para Publicação
-  const [isPublishing, setIsPublishing] = useState(false);
-  const [publishingStatus, setPublishingStatus] = useState('');
-  const [publishedPostUrl, setPublishedPostUrl] = useState(null);
-
 
   // Estados para a Geração com IA
   const [inputMethod, setInputMethod] = useState('csv');
@@ -536,6 +532,11 @@ function App() {
       label: 'Gerar Imagens',
       description: 'Gere as imagens finais.',
       icon: FormatBold
+    },
+    {
+      label: 'Publicar',
+      description: 'Publique o conteúdo no WordPress.',
+      icon: Publish
     },
     {
       label: 'Gerar Áudio',
@@ -1516,36 +1517,6 @@ function App() {
     URL.revokeObjectURL(url);
   };
 
-  const handlePublishToWordPress = async () => {
-    setIsPublishing(true);
-    setPublishingStatus('Iniciando publicação...');
-    setPublishedPostUrl(null);
-
-    try {
-      if (!campaignContent || !generatedImageUrl || !conteudoFormatado) {
-        throw new Error('Dados da campanha incompletos. Gere todo o conteúdo primeiro.');
-      }
-
-      const campaignData = {
-        campaignContent,
-        generatedImageUrl,
-        conteudoFormatado,
-      };
-
-      setPublishingStatus('Publicando no WordPress... Isso pode levar um momento.');
-      const post = await publishToWordPress(campaignData);
-
-      setPublishingStatus(`Post "${post.title.rendered}" criado como rascunho com sucesso!`);
-      setPublishedPostUrl(post.link);
-
-    } catch (error) {
-      console.error('Erro ao publicar no WordPress:', error);
-      setPublishingStatus(`Erro ao publicar: ${error.message}`);
-    } finally {
-      setIsPublishing(false);
-    }
-  };
-
   const handleGenerateIAContent = async () => {
     setIsGenerating(true);
 
@@ -2107,36 +2078,14 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
 
                 {campaignContent && (
                   <Box sx={{ mt: 4 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, mb: 2 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
                       <Button
                         variant="outlined"
                         onClick={handleExportHtml}
                       >
                         Exportar como HTML
                       </Button>
-                      <Button
-                        variant="contained"
-                        color="secondary"
-                        startIcon={<Language />}
-                        onClick={handlePublishToWordPress}
-                        disabled={isPublishing || !generatedImageUrl}
-                      >
-                        {isPublishing ? 'Publicando...' : 'Publicar no WordPress'}
-                      </Button>
                     </Box>
-
-                    {isPublishing && <LinearProgress sx={{ mb: 2 }} />}
-                    {publishingStatus && (
-                      <Alert severity={publishedPostUrl ? "success" : "info"} sx={{ mb: 2 }}>
-                        {publishingStatus}
-                        {publishedPostUrl && (
-                          <MuiLink href={publishedPostUrl} target="_blank" rel="noopener" sx={{ ml: 1 }}>
-                            Ver post
-                          </MuiLink>
-                        )}
-                      </Alert>
-                    )}
-
                     <Typography variant="h6" gutterBottom>Conteúdo Gerado</Typography>
                     <Grid container spacing={2}>
                       <Grid item xs={12}>
@@ -2646,8 +2595,17 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
             />
           )}
 
-          {/* Passo 6: Geração de Áudio */}
-          <div hidden={activeStep !== 6}>
+          {/* Passo 6: Publicar */}
+          {activeStep === 6 && (
+            <WordpressPublisher
+              campaignContent={campaignContent}
+              conteudoFormatado={conteudoFormatado}
+              generatedImagesData={generatedImagesData}
+            />
+          )}
+
+          {/* Passo 7: Geração de Áudio */}
+          <div hidden={activeStep !== 7}>
             <AudioGenerator
               csvData={csvData}
               fieldPositions={fieldPositions}
@@ -2656,8 +2614,8 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
             />
           </div>
 
-          {/* Passo 7: Geração de Vídeo */}
-          {activeStep === 7 && (
+          {/* Passo 8: Geração de Vídeo */}
+          {activeStep === 8 && (
             <VideoGenerator2
               generatedImages={generatedImagesData}
               generatedAudioData={generatedAudioData}

--- a/src/components/WordpressPublisher.jsx
+++ b/src/components/WordpressPublisher.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Typography,
+  Card,
+  CardContent,
+  Alert,
+  LinearProgress,
+  Link as MuiLink,
+} from '@mui/material';
+import { Language, Publish } from '@mui/icons-material';
+import { publishToWordPress } from '../utils/wordpressAPI';
+
+const WordpressPublisher = ({ campaignContent, conteudoFormatado, generatedImagesData }) => {
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [publishingStatus, setPublishingStatus] = useState('');
+  const [publishedPostUrl, setPublishedPostUrl] = useState(null);
+
+  const handlePublish = async () => {
+    setIsPublishing(true);
+    setPublishingStatus('Iniciando publicação...');
+    setPublishedPostUrl(null);
+
+    try {
+      // Validar se os dados necessários estão presentes
+      if (!campaignContent || !conteudoFormatado || !generatedImagesData || generatedImagesData.length === 0) {
+        throw new Error('Dados da campanha ou imagens não estão disponíveis. Volte para as etapas anteriores.');
+      }
+
+      // Pegar a primeira imagem da lista de imagens geradas
+      const firstImage = generatedImagesData[0];
+      if (!firstImage || !firstImage.blob) {
+        throw new Error('A primeira imagem gerada não contém um blob válido.');
+      }
+
+      const campaignData = {
+        campaignContent,
+        conteudoFormatado,
+        imageBlob: firstImage.blob, // Passando o blob da imagem
+      };
+
+      setPublishingStatus('Publicando no WordPress... Isso pode levar um momento.');
+      const post = await publishToWordPress(campaignData);
+
+      setPublishingStatus(`Post "${post.title.rendered}" criado como rascunho com sucesso!`);
+      setPublishedPostUrl(post.link);
+
+    } catch (error) {
+      console.error('Erro ao publicar no WordPress:', error);
+      setPublishingStatus(`Erro ao publicar: ${error.message}`);
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent sx={{ p: 4 }}>
+        <Typography variant="h5" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 3 }}>
+          <Publish />
+          Publicar no WordPress
+        </Typography>
+
+        <Typography variant="body1" sx={{ mb: 3 }}>
+          Esta ação enviará o conteúdo gerado para o seu site WordPress como um novo post em rascunho.
+          A primeira imagem da lista de "Imagens Geradas" será usada como a imagem destacada do post.
+        </Typography>
+
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3, gap: 2 }}>
+          <Button
+            variant="contained"
+            size="large"
+            color="secondary"
+            startIcon={<Language />}
+            onClick={handlePublish}
+            disabled={isPublishing}
+          >
+            {isPublishing ? 'Publicando...' : 'Publicar Post no WordPress'}
+          </Button>
+        </Box>
+
+        {isPublishing && <LinearProgress sx={{ my: 2 }} />}
+
+        {publishingStatus && (
+          <Alert
+            severity={publishedPostUrl ? "success" : (publishingStatus.startsWith('Erro') ? 'error' : 'info')}
+            sx={{ mt: 3 }}
+          >
+            {publishingStatus}
+            {publishedPostUrl && (
+              <MuiLink href={publishedPostUrl} target="_blank" rel="noopener" sx={{ display: 'block', mt: 1 }}>
+                Visualizar rascunho do post
+              </MuiLink>
+            )}
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default WordpressPublisher;

--- a/src/utils/wordpressAPI.js
+++ b/src/utils/wordpressAPI.js
@@ -81,19 +81,15 @@ const _processHashtags = async (hashtags, config, headers) => {
 
 /**
  * Faz o upload de uma imagem para o WordPress e retorna os dados da mídia.
- * @param {string} imageUrl - A URL da imagem gerada (pode ser base64).
+ * @param {Blob} imageBlob - O blob da imagem a ser enviada.
  * @param {object} campaignContent - O conteúdo da campanha para metadados.
  * @param {object} config - O objeto de configuração do WordPress.
  * @param {Headers} headers - Os cabeçalhos da requisição (sem Content-Type de JSON).
  * @returns {Promise<object>} Uma promessa que resolve para o objeto da mídia criada.
  */
-const _uploadImage = async (imageUrl, campaignContent, config, headers) => {
+const _uploadImage = async (imageBlob, campaignContent, config, headers) => {
   const wordpressUrl = config.wordpressUrl.replace(/\/$/, '');
   const mediaUrl = `${wordpressUrl}${config.mediaUrl}`;
-
-  // Converter a imagem (que pode ser base64) para um Blob
-  const fetchResponse = await fetch(imageUrl);
-  const imageBlob = await fetchResponse.blob();
 
   // Criar um nome de arquivo a partir do título
   const filename = `${campaignContent.titulo.replace(/\s+/g, '-').toLowerCase()}.png`;
@@ -184,13 +180,13 @@ const _createPost = async (campaignContent, conteudoFormatado, tagIds, mediaId, 
  * Publica o conteúdo de uma campanha no WordPress.
  * @param {object} campaignData - Objeto contendo os dados da campanha.
  *   @param {object} campaignData.campaignContent - Título, conteúdo, CTA, hashtags.
- *   @param {string} campaignData.generatedImageUrl - A URL da imagem gerada.
+ *   @param {Blob} campaignData.imageBlob - O blob da imagem a ser enviada.
  *   @param {string} campaignData.conteudoFormatado - O conteúdo principal em HTML.
  * @returns {Promise<object>} Uma promessa que resolve para o objeto do post criado.
  * @throws {Error} Se a configuração do WordPress não for encontrada ou se ocorrer um erro na API.
  */
 export const publishToWordPress = async (campaignData) => {
-  const { campaignContent, generatedImageUrl, conteudoFormatado } = campaignData;
+  const { campaignContent, imageBlob, conteudoFormatado } = campaignData;
 
   const config = getWordpressConfig();
   if (!config) {
@@ -206,7 +202,7 @@ export const publishToWordPress = async (campaignData) => {
 
   // 2. Fazer Upload da Imagem
   console.log('Publicando no WordPress: Fazendo upload da imagem...');
-  const mediaObject = await _uploadImage(generatedImageUrl, campaignContent, config, headers);
+  const mediaObject = await _uploadImage(imageBlob, campaignContent, config, headers);
   const mediaId = mediaObject.id;
   const mediaUrl = mediaObject.guid.rendered;
   console.log('Publicando no WordPress: Imagem enviada. ID:', mediaId);


### PR DESCRIPTION
This commit refactors the WordPress publishing feature based on your feedback. The functionality is now moved from the 'Campanha' step to its own dedicated 'Publicar' step in the main workflow.

Changes include:
- The sidebar in `App.jsx` now has a 'Publicar' step, placed after 'Gerar Imagens'.
- A new component, `WordpressPublisher.jsx`, has been created to encapsulate the UI and logic for the publishing action.
- The `WordpressPublisher` component is rendered as the new step and receives the necessary campaign data and the list of generated images.
- `wordpressAPI.js` has been updated to use the image blob from the `generatedImagesData` array, instead of the AI-generated `generatedImageUrl`, as the featured image for the post.
- The initial implementation that placed the publishing button in the 'Campanha' step has been removed.