### PR TITLE
fix: Refactor Rich Text Editor to be theme-aware

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2726,7 +2726,6 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
           }
         }}
         onClose={() => setEditingField(null)}
-        darkMode={darkMode}
       />
       {isMobile && activeStep === 4 && (
         <>

--- a/src/components/RichTextEditor.jsx
+++ b/src/components/RichTextEditor.jsx
@@ -9,7 +9,8 @@ import {
   ToggleButtonGroup,
   Popover,
   Typography,
-  Button
+  Button,
+  useTheme
 } from '@mui/material';
 import {
   FormatBold,
@@ -32,9 +33,10 @@ const RichTextEditor = ({
   placeholder = 'Digite seu texto...',
   disabled = false,
   maxHeight = 200,
-  showHtmlToggle = true,
-  darkMode = false
+  showHtmlToggle = true
 }) => {
+  const theme = useTheme();
+  const darkMode = theme.palette.mode === 'dark';
   const [htmlMode, setHtmlMode] = useState(false);
   const [selection, setSelection] = useState(null); // eslint-disable-line no-unused-vars
   const [isInitialized, setIsInitialized] = useState(false);

--- a/src/components/TextEditorDialog.jsx
+++ b/src/components/TextEditorDialog.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box } from '@mui/material';
 import RichTextEditor from './RichTextEditor'; // Import the RichTextEditor
 
-const TextEditorDialog = ({ open, title, content, onSave, onClose, darkMode }) => {
+const TextEditorDialog = ({ open, title, content, onSave, onClose }) => {
   const [editedContent, setEditedContent] = useState(content);
 
   useEffect(() => {
@@ -25,7 +25,6 @@ const TextEditorDialog = ({ open, title, content, onSave, onClose, darkMode }) =
             value={editedContent}
             onChange={setEditedContent}
             maxHeight={400}
-            darkMode={darkMode}
           />
         </Box>
       </DialogContent>


### PR DESCRIPTION
This commit resolves a persistent issue where the Rich Text Editor would not correctly display in dark mode.

Instead of manually passing a `darkMode` prop through multiple component layers, the `RichTextEditor` component has been refactored to use the `useTheme` hook from Material-UI.

This allows the component to subscribe directly to the application's theme context, making the light/dark mode detection automatic and robust. The prop-drilling has been removed.