### PR TITLE
fix: Restore image filter controls in formatting panel

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -50,72 +50,28 @@ const FormattingPanel = ({
   imageFilters,
   setImageFilters
 }) => {
-  // Log received props
-  console.log('[FormattingPanel] Received props: selectedField =', selectedField, 'fieldStyles =', fieldStyles);
-
   const fonts = [
-    'Arial',
-    'Helvetica',
-    'Times New Roman',
-    'Georgia',
-    'Verdana',
-    'Courier New',
-    'Impact',
-    'Comic Sans MS',
-    'Roboto',
-    'Open Sans',
-    'Montserrat',
-    'Lato',
-    'Poppins',
-    'Inter',
-    'Source Sans Pro',
-    'Anton',
-    'Bebas Neue',
-    'Caveat',
-    'Courgette',
-    'Dancing Script',
-    'Lora',
-    'Merriweather',
-    'Playfair Display',
-    'Raleway'
+    'Arial', 'Helvetica', 'Times New Roman', 'Georgia', 'Verdana', 'Courier New', 'Impact', 'Comic Sans MS',
+    'Roboto', 'Open Sans', 'Montserrat', 'Lato', 'Poppins', 'Inter', 'Source Sans Pro', 'Anton',
+    'Bebas Neue', 'Caveat', 'Courgette', 'Dancing Script', 'Lora', 'Merriweather', 'Playfair Display', 'Raleway'
   ];
 
-
   const updateFieldStyle = (field, property, value) => {
-    setFieldStyles(prev => ({
-      ...prev,
-      [field]: {
-        ...prev[field],
-        [property]: value
-      }
-    }));
+    setFieldStyles(prev => ({ ...prev, [field]: { ...prev[field], [property]: value } }));
   };
 
   const updateFieldPosition = (field, property, value) => {
-    setFieldPositions(prev => ({
-      ...prev,
-      [field]: {
-        ...prev[field],
-        [property]: value
-      }
-    }));
+    setFieldPositions(prev => ({ ...prev, [field]: { ...prev[field], [property]: value } }));
   };
 
   const copyStyleToAll = (sourceField) => {
     const sourceStyle = fieldStyles[sourceField];
     if (!sourceStyle) return;
-
     const newStyles = {};
     csvHeaders.forEach(header => {
-      if (header !== sourceField) {
-        newStyles[header] = { ...sourceStyle };
-      }
+      if (header !== sourceField) { newStyles[header] = { ...sourceStyle }; }
     });
-
-    setFieldStyles(prev => ({
-      ...prev,
-      ...newStyles
-    }));
+    setFieldStyles(prev => ({ ...prev, ...newStyles }));
   };
 
   const toggleFieldVisibility = (field) => {
@@ -124,518 +80,173 @@ const FormattingPanel = ({
 
   const resetFieldStyle = (field) => {
     const defaultStyle = {
-      fontFamily: 'Arial',
-      fontSize: 24,
-      fontWeight: 'normal',
-      fontStyle: 'normal',
-      textDecoration: 'none',
-      color: '#000000',
-      textStroke: false,
-      strokeColor: '#ffffff',
-      strokeWidth: 2,
-      textShadow: false,
-      shadowColor: '#000000',
-      shadowBlur: 4,
-      shadowOffsetX: 2,
-      shadowOffsetY: 2
+      fontFamily: 'Arial', fontSize: 24, fontWeight: 'normal', fontStyle: 'normal', textDecoration: 'none',
+      color: '#000000', textStroke: false, strokeColor: '#ffffff', strokeWidth: 2, textShadow: false,
+      shadowColor: '#000000', shadowBlur: 4, shadowOffsetX: 2, shadowOffsetY: 2,
+      textAlign: 'left', verticalAlign: 'top'
     };
-
-    setFieldStyles(prev => ({
-      ...prev,
-      [field]: defaultStyle
-    }));
+    setFieldStyles(prev => ({ ...prev, [field]: defaultStyle }));
   };
 
-  if (!selectedField) {
-    return (
-      <Card>
-        <CardContent>
-          <Typography variant="h6" color="textSecondary" align="center" gutterBottom>
-            Selecione um campo de texto para editar suas propriedades
-          </Typography>
-          <Divider sx={{ my: 2 }} />
-          <Accordion>
-            <AccordionSummary expandIcon={<ExpandMore />}>
-              <Typography variant="subtitle1">Filtros de Imagem de Fundo</Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Box sx={{ p: 1 }}>
-                <Typography gutterBottom>Brilho: {imageFilters.brightness}%</Typography>
-                <Slider value={imageFilters.brightness} onChange={(e, v) => setImageFilters(f => ({ ...f, brightness: v }))} min={0} max={200} step={1} />
-                <Typography gutterBottom>Contraste: {imageFilters.contrast}%</Typography>
-                <Slider value={imageFilters.contrast} onChange={(e, v) => setImageFilters(f => ({ ...f, contrast: v }))} min={0} max={200} step={1} />
-                <Typography gutterBottom>Saturação: {imageFilters.saturate}%</Typography>
-                <Slider value={imageFilters.saturate} onChange={(e, v) => setImageFilters(f => ({ ...f, saturate: v }))} min={0} max={200} step={1} />
-                <Typography gutterBottom>Desfoque: {imageFilters.blur}px</Typography>
-                <Slider value={imageFilters.blur} onChange={(e, v) => setImageFilters(f => ({ ...f, blur: v }))} min={0} max={20} step={1} />
-                <Typography gutterBottom>Opacidade: {imageFilters.opacity}%</Typography>
-                <Slider value={imageFilters.opacity} onChange={(e, v) => setImageFilters(f => ({ ...f, opacity: v }))} min={0} max={100} step={1} />
-              </Box>
-            </AccordionDetails>
-          </Accordion>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const style = fieldStyles[selectedField] || {};
-  const position = fieldPositions[selectedField] || {};
-
-  // Log the resolved style object for the selected field
-  if (selectedField) {
-    console.log('[FormattingPanel] Resolved style for selectedField (' + selectedField + '):', style);
-  } else {
-    console.log('[FormattingPanel] No selectedField, style object is default:', style);
-  }
+  const style = selectedField ? fieldStyles[selectedField] || {} : {};
+  const position = selectedField ? fieldPositions[selectedField] || {} : {};
 
   return (
     <Card>
       <CardContent>
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-          <Chip
-            label={selectedField}
-            color="primary"
-            sx={{ mr: 2 }}
-          />
-          <FormControlLabel
-            control={
-              <Switch
-                checked={position.visible !== false}
-                onChange={() => toggleFieldVisibility(selectedField)}
-                size="small"
-              />
-            }
-            label={
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                {position.visible !== false ? <Visibility /> : <VisibilityOff />}
-                <Typography variant="caption" sx={{ ml: 0.5 }}>
-                  {position.visible !== false ? 'Visível' : 'Oculto'}
-                </Typography>
-              </Box>
-            }
-          />
-        </Box>
-
-        {/* Posicionamento e Tamanho */}
-        <Accordion defaultExpanded>
-          <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle1">
-              📐 Posição e Tamanho
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Grid container spacing={2}>
-              <Grid item xs={6}>
-                <TextField
-                  label="X (%)"
-                  type="number"
-                  size="small"
-                  value={position.x?.toFixed(1) || '0.0'}
-                  onChange={(e) => updateFieldPosition(selectedField, 'x', parseFloat(e.target.value) || 0)}
-                  inputProps={{ min: 0, max: 100, step: 0.1 }}
-                  fullWidth
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <TextField
-                  label="Y (%)"
-                  type="number"
-                  size="small"
-                  value={position.y?.toFixed(1) || '0.0'}
-                  onChange={(e) => updateFieldPosition(selectedField, 'y', parseFloat(e.target.value) || 0)}
-                  inputProps={{ min: 0, max: 100, step: 0.1 }}
-                  fullWidth
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <TextField
-                  label="Largura (%)"
-                  type="number"
-                  size="small"
-                  value={position.width?.toFixed(1) || '20.0'}
-                  onChange={(e) => updateFieldPosition(selectedField, 'width', parseFloat(e.target.value) || 20)}
-                  inputProps={{ min: 5, max: 100, step: 0.1 }}
-                  fullWidth
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <TextField
-                  label="Altura (%)"
-                  type="number"
-                  size="small"
-                  value={position.height?.toFixed(1) || '10.0'}
-                  onChange={(e) => updateFieldPosition(selectedField, 'height', parseFloat(e.target.value) || 10)}
-                  inputProps={{ min: 3, max: 100, step: 0.1 }}
-                  fullWidth
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <Typography gutterBottom>Rotação: {position.rotation?.toFixed(0) || '0'}°</Typography>
-                <Slider
-                  value={position.rotation || 0}
-                  onChange={(e, value) => updateFieldPosition(selectedField, 'rotation', value)}
-                  min={0}
-                  max={360}
-                  step={1}
-                  valueLabelDisplay="auto"
-                  marks={[
-                    { value: 0, label: '0°' },
-                    { value: 90, label: '90°' },
-                    { value: 180, label: '180°' },
-                    { value: 270, label: '270°' },
-                    { value: 360, label: '360°' },
-                  ]}
-                />
-              </Grid>
-              <Grid item xs={12} sx={{ mt: 1 }}>
-                <Typography variant="caption" display="block" gutterBottom>
-                  Alinhamento do Texto na Caixa
-                </Typography>
-                <ToggleButtonGroup
-                  value={style.textAlign || 'left'}
-                  exclusive
-                  onChange={(e, newAlignment) => {
-                    if (newAlignment) updateFieldStyle(selectedField, 'textAlign', newAlignment);
-                  }}
-                  aria-label="text alignment"
-                  size="small"
-                  fullWidth
-                >
-                  <ToggleButton value="left" aria-label="left aligned">
-                    <FormatAlignLeft />
-                  </ToggleButton>
-                  <ToggleButton value="center" aria-label="centered">
-                    <FormatAlignCenter />
-                  </ToggleButton>
-                  <ToggleButton value="right" aria-label="right aligned">
-                    <FormatAlignRight />
-                  </ToggleButton>
-                </ToggleButtonGroup>
-              </Grid>
-              <Grid item xs={12} sx={{ mt: 1 }}>
-                 <ToggleButtonGroup
-                    value={style.verticalAlign || 'top'}
-                    exclusive
-                    onChange={(e, newAlignment) => {
-                      if (newAlignment) updateFieldStyle(selectedField, 'verticalAlign', newAlignment);
-                    }}
-                    aria-label="vertical alignment"
-                    size="small"
-                    fullWidth
-                  >
-                    <ToggleButton value="top" aria-label="top aligned">
-                      <VerticalAlignTop />
-                    </ToggleButton>
-                    <ToggleButton value="middle" aria-label="middle aligned">
-                      <VerticalAlignCenter />
-                    </ToggleButton>
-                    <ToggleButton value="bottom" aria-label="bottom aligned">
-                      <VerticalAlignBottom />
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-              </Grid>
-            </Grid>
-          </AccordionDetails>
-        </Accordion>
-
-        {/* Fonte e Estilo Rápido */}
-        <Accordion defaultExpanded>
-          <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle1">
-              <FormatSize sx={{ mr: 1, verticalAlign: 'middle' }} />
-              Fonte e Estilo
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Fonte</InputLabel>
-                  <Select
-                    value={style.fontFamily || 'Arial'}
-                    label="Fonte"
-                    onChange={(e) => updateFieldStyle(selectedField, 'fontFamily', e.target.value)}
-                  >
-                    {fonts.map(font => (
-                      <MenuItem key={font} value={font} style={{ fontFamily: font }}>
-                        {font}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Grid>
-
-              <Grid item xs={12} sx={{mt: 1}}>
-                 <ToggleButtonGroup
-                    value={[]} // Este value não é diretamente usado para controlar os botões, mas é necessário
-                    aria-label="text formatting"
-                    size="small"
-                    fullWidth
-                  >
-                    <ToggleButton
-                      value="bold"
-                      aria-label="bold"
-                      selected={style.fontWeight === 'bold'}
-                      onClick={() => updateFieldStyle(selectedField, 'fontWeight', style.fontWeight === 'bold' ? 'normal' : 'bold')}
-                    >
-                      <FormatBold />
-                    </ToggleButton>
-                    <ToggleButton
-                      value="italic"
-                      aria-label="italic"
-                      selected={style.fontStyle === 'italic'}
-                      onClick={() => updateFieldStyle(selectedField, 'fontStyle', style.fontStyle === 'italic' ? 'normal' : 'italic')}
-                    >
-                      <FormatItalic />
-                    </ToggleButton>
-                    <ToggleButton
-                      value="underline"
-                      aria-label="underline"
-                      selected={style.textDecoration === 'underline'}
-                      onClick={() => updateFieldStyle(selectedField, 'textDecoration', style.textDecoration === 'underline' ? 'none' : 'underline')}
-                    >
-                      <FormatUnderlined />
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-              </Grid>
-
-              <Grid item xs={12}>
-                <Typography gutterBottom sx={{mt:1}}>
-                  Tamanho: {style.fontSize || 24}px
-                </Typography>
-                <Slider
-                  value={style.fontSize || 24}
-                  onChange={(e, value) => updateFieldStyle(selectedField, 'fontSize', value)}
-                  min={8}
-                  max={120}
-                  valueLabelDisplay="auto"
-                  marks={[
-                    { value: 12, label: '12' },
-                    { value: 24, label: '24' },
-                    { value: 48, label: '48' },
-                    { value: 72, label: '72' }
-                  ]}
-                />
-              </Grid>
-            </Grid>
-          </AccordionDetails>
-        </Accordion>
-
-        {/* Detalhes de Estilo (Peso, Estilo, Decoração - Avançado) */}
+        {/* Filtros de Imagem de Fundo (Sempre visível) */}
         <Accordion>
           <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle1">
-              <Style sx={{ mr: 1, verticalAlign: 'middle' }} />
-              Ajustes Finos de Estilo
-            </Typography>
+            <Typography variant="subtitle1">🎨 Filtros de Imagem de Fundo</Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <Grid container spacing={2}>
-              <Grid item xs={6}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Peso da Fonte</InputLabel>
-                  <Select
-                    value={style.fontWeight || 'normal'}
-                    label="Peso da Fonte"
-                    onChange={(e) => updateFieldStyle(selectedField, 'fontWeight', e.target.value)}
-                  >
-                    <MenuItem value="100">Thin (100)</MenuItem>
-                    <MenuItem value="200">Extra Light (200)</MenuItem>
-                    <MenuItem value="300">Light (300)</MenuItem>
-                    <MenuItem value="normal">Normal (400)</MenuItem>
-                    <MenuItem value="500">Medium (500)</MenuItem>
-                    <MenuItem value="600">Semi Bold (600)</MenuItem>
-                    <MenuItem value="bold">Bold (700)</MenuItem>
-                    <MenuItem value="800">Extra Bold (800)</MenuItem>
-                    <MenuItem value="900">Black (900)</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              <Grid item xs={6}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Estilo da Fonte</InputLabel>
-                  <Select
-                    value={style.fontStyle || 'normal'}
-                    label="Estilo da Fonte"
-                    onChange={(e) => updateFieldStyle(selectedField, 'fontStyle', e.target.value)}
-                  >
-                    <MenuItem value="normal">Normal</MenuItem>
-                    <MenuItem value="italic">Itálico</MenuItem>
-                    <MenuItem value="oblique">Oblíquo</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              <Grid item xs={6}>
-                <FormControl fullWidth size="small">
-                  <InputLabel>Decoração do Texto</InputLabel>
-                  <Select
-                    value={style.textDecoration || 'none'}
-                    label="Decoração do Texto"
-                    onChange={(e) => updateFieldStyle(selectedField, 'textDecoration', e.target.value)}
-                  >
-                    <MenuItem value="none">Nenhuma</MenuItem>
-                    <MenuItem value="underline">Sublinhado</MenuItem>
-                    <MenuItem value="overline">Sobrelinha</MenuItem>
-                    <MenuItem value="line-through">Riscado</MenuItem>
-                  </Select>
-                </FormControl>
-              </Grid>
-              <Grid item xs={6}>
-                <TextField
-                  label="Cor"
-                  type="color"
-                  value={style.color || '#000000'}
-                  onChange={(e) => updateFieldStyle(selectedField, 'color', e.target.value)}
-                  fullWidth
-                  size="small"
-                />
-              </Grid>
-            </Grid>
-          </AccordionDetails>
-        </Accordion>
-
-        {/* Efeitos */}
-        <Accordion>
-          <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle1">
-              <Palette sx={{ mr: 1, verticalAlign: 'middle' }} />
-              Efeitos
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Grid container spacing={2}>
-              {/* Contorno */}
-              <Grid item xs={12}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={style.textStroke || false}
-                      onChange={(e) => updateFieldStyle(selectedField, 'textStroke', e.target.checked)}
-                      size="small"
-                    />
-                  }
-                  label="Contorno"
-                />
-
-                {style.textStroke && (
-                  <Grid container spacing={2} sx={{ mt: 1 }}>
-                    <Grid item xs={6}>
-                      <TextField
-                        label="Cor do Contorno"
-                        type="color"
-                        value={style.strokeColor || '#ffffff'}
-                        onChange={(e) => updateFieldStyle(selectedField, 'strokeColor', e.target.value)}
-                        fullWidth
-                        size="small"
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <Typography gutterBottom>Espessura: {style.strokeWidth || 2}px</Typography>
-                      <Slider
-                        value={style.strokeWidth || 2}
-                        onChange={(e, value) => updateFieldStyle(selectedField, 'strokeWidth', value)}
-                        min={1}
-                        max={10}
-                        size="small"
-                      />
-                    </Grid>
-                  </Grid>
-                )}
-              </Grid>
-
-              {/* Sombra */}
-              <Grid item xs={12}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={style.textShadow || false}
-                      onChange={(e) => updateFieldStyle(selectedField, 'textShadow', e.target.checked)}
-                      size="small"
-                    />
-                  }
-                  label="Sombra"
-                />
-
-                {style.textShadow && (
-                  <Grid container spacing={2} sx={{ mt: 1 }}>
-                    <Grid item xs={6}>
-                      <TextField
-                        label="Cor da Sombra"
-                        type="color"
-                        value={style.shadowColor || '#000000'}
-                        onChange={(e) => updateFieldStyle(selectedField, 'shadowColor', e.target.value)}
-                        fullWidth
-                        size="small"
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <Typography gutterBottom>Desfoque: {style.shadowBlur || 4}px</Typography>
-                      <Slider
-                        value={style.shadowBlur || 4}
-                        onChange={(e, value) => updateFieldStyle(selectedField, 'shadowBlur', value)}
-                        min={0}
-                        max={20}
-                        size="small"
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <Typography gutterBottom>Offset X: {style.shadowOffsetX || 2}px</Typography>
-                      <Slider
-                        value={style.shadowOffsetX || 2}
-                        onChange={(e, value) => updateFieldStyle(selectedField, 'shadowOffsetX', value)}
-                        min={-20}
-                        max={20}
-                        size="small"
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <Typography gutterBottom>Offset Y: {style.shadowOffsetY || 2}px</Typography>
-                      <Slider
-                        value={style.shadowOffsetY || 2}
-                        onChange={(e, value) => updateFieldStyle(selectedField, 'shadowOffsetY', value)}
-                        min={-20}
-                        max={20}
-                        size="small"
-                      />
-                    </Grid>
-                  </Grid>
-                )}
-              </Grid>
-            </Grid>
+            <Box sx={{ p: 1 }}>
+              <Typography gutterBottom>Brilho: {imageFilters.brightness}%</Typography>
+              <Slider value={imageFilters.brightness} onChange={(e, v) => setImageFilters(f => ({ ...f, brightness: v }))} min={0} max={200} step={1} />
+              <Typography gutterBottom>Contraste: {imageFilters.contrast}%</Typography>
+              <Slider value={imageFilters.contrast} onChange={(e, v) => setImageFilters(f => ({ ...f, contrast: v }))} min={0} max={200} step={1} />
+              <Typography gutterBottom>Saturação: {imageFilters.saturate}%</Typography>
+              <Slider value={imageFilters.saturate} onChange={(e, v) => setImageFilters(f => ({ ...f, saturate: v }))} min={0} max={200} step={1} />
+              <Typography gutterBottom>Desfoque: {imageFilters.blur}px</Typography>
+              <Slider value={imageFilters.blur} onChange={(e, v) => setImageFilters(f => ({ ...f, blur: v }))} min={0} max={20} step={1} />
+              <Typography gutterBottom>Opacidade: {imageFilters.opacity}%</Typography>
+              <Slider value={imageFilters.opacity} onChange={(e, v) => setImageFilters(f => ({ ...f, opacity: v }))} min={0} max={100} step={1} />
+            </Box>
           </AccordionDetails>
         </Accordion>
 
         <Divider sx={{ my: 2 }} />
 
-        {/* Ações */}
-        <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => copyStyleToAll(selectedField)}
-              startIcon={<ContentCopy />}
-              fullWidth
-            >
-              Aplicar a Todos
-            </Button>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => resetFieldStyle(selectedField)}
-              color="secondary"
-              fullWidth
-            >
-              Resetar Estilo
-            </Button>
-          </Grid>
-        </Grid>
+        {/* Controles do Campo de Texto (Visível apenas se um campo for selecionado) */}
+        {selectedField ? (
+          <>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+              <Chip label={selectedField} color="primary" sx={{ mr: 2 }} />
+              <FormControlLabel
+                control={<Switch checked={position.visible !== false} onChange={() => toggleFieldVisibility(selectedField)} size="small" />}
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    {position.visible !== false ? <Visibility /> : <VisibilityOff />}
+                    <Typography variant="caption" sx={{ ml: 0.5 }}>
+                      {position.visible !== false ? 'Visível' : 'Oculto'}
+                    </Typography>
+                  </Box>
+                }
+              />
+            </Box>
+
+            {/* Posicionamento e Tamanho */}
+            <Accordion defaultExpanded>
+              <AccordionSummary expandIcon={<ExpandMore />}><Typography variant="subtitle1">📐 Posição e Tamanho</Typography></AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  <Grid item xs={6}>
+                    <TextField label="X (%)" type="number" size="small" value={position.x?.toFixed(1) || '0.0'} onChange={(e) => updateFieldPosition(selectedField, 'x', parseFloat(e.target.value) || 0)} inputProps={{ min: 0, max: 100, step: 0.1 }} fullWidth />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <TextField label="Y (%)" type="number" size="small" value={position.y?.toFixed(1) || '0.0'} onChange={(e) => updateFieldPosition(selectedField, 'y', parseFloat(e.target.value) || 0)} inputProps={{ min: 0, max: 100, step: 0.1 }} fullWidth />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <TextField label="Largura (%)" type="number" size="small" value={position.width?.toFixed(1) || '20.0'} onChange={(e) => updateFieldPosition(selectedField, 'width', parseFloat(e.target.value) || 20)} inputProps={{ min: 5, max: 100, step: 0.1 }} fullWidth />
+                  </Grid>
+                  <Grid item xs={6}>
+                    <TextField label="Altura (%)" type="number" size="small" value={position.height?.toFixed(1) || '10.0'} onChange={(e) => updateFieldPosition(selectedField, 'height', parseFloat(e.target.value) || 10)} inputProps={{ min: 3, max: 100, step: 0.1 }} fullWidth />
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Typography gutterBottom>Rotação: {position.rotation?.toFixed(0) || '0'}°</Typography>
+                    <Slider value={position.rotation || 0} onChange={(e, value) => updateFieldPosition(selectedField, 'rotation', value)} min={0} max={360} step={1} valueLabelDisplay="auto" marks={[{ value: 0, label: '0°' }, { value: 90, label: '90°' }, { value: 180, label: '180°' }, { value: 270, label: '270°' }, { value: 360, label: '360°' }]} />
+                  </Grid>
+                  <Grid item xs={12} sx={{ mt: 1 }}>
+                    <Typography variant="caption" display="block" gutterBottom>Alinhamento do Texto na Caixa</Typography>
+                    <ToggleButtonGroup value={style.textAlign || 'left'} exclusive onChange={(e, newAlignment) => { if (newAlignment) updateFieldStyle(selectedField, 'textAlign', newAlignment); }} aria-label="text alignment" size="small" fullWidth>
+                      <ToggleButton value="left" aria-label="left aligned"><FormatAlignLeft /></ToggleButton>
+                      <ToggleButton value="center" aria-label="centered"><FormatAlignCenter /></ToggleButton>
+                      <ToggleButton value="right" aria-label="right aligned"><FormatAlignRight /></ToggleButton>
+                    </ToggleButtonGroup>
+                  </Grid>
+                  <Grid item xs={12} sx={{ mt: 1 }}>
+                     <ToggleButtonGroup value={style.verticalAlign || 'top'} exclusive onChange={(e, newAlignment) => { if (newAlignment) updateFieldStyle(selectedField, 'verticalAlign', newAlignment); }} aria-label="vertical alignment" size="small" fullWidth>
+                        <ToggleButton value="top" aria-label="top aligned"><VerticalAlignTop /></ToggleButton>
+                        <ToggleButton value="middle" aria-label="middle aligned"><VerticalAlignCenter /></ToggleButton>
+                        <ToggleButton value="bottom" aria-label="bottom aligned"><VerticalAlignBottom /></ToggleButton>
+                      </ToggleButtonGroup>
+                  </Grid>
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+
+            {/* Fonte e Estilo Rápido */}
+            <Accordion defaultExpanded>
+              <AccordionSummary expandIcon={<ExpandMore />}><Typography variant="subtitle1"><FormatSize sx={{ mr: 1, verticalAlign: 'middle' }} />Fonte e Estilo</Typography></AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  <Grid item xs={12}>
+                    <FormControl fullWidth size="small">
+                      <InputLabel>Fonte</InputLabel>
+                      <Select value={style.fontFamily || 'Arial'} label="Fonte" onChange={(e) => updateFieldStyle(selectedField, 'fontFamily', e.target.value)}>
+                        {fonts.map(font => (<MenuItem key={font} value={font} style={{ fontFamily: font }}>{font}</MenuItem>))}
+                      </Select>
+                    </FormControl>
+                  </Grid>
+                  <Grid item xs={12} sx={{mt: 1}}>
+                     <ToggleButtonGroup value={[]} aria-label="text formatting" size="small" fullWidth>
+                        <ToggleButton value="bold" aria-label="bold" selected={style.fontWeight === 'bold'} onClick={() => updateFieldStyle(selectedField, 'fontWeight', style.fontWeight === 'bold' ? 'normal' : 'bold')}><FormatBold /></ToggleButton>
+                        <ToggleButton value="italic" aria-label="italic" selected={style.fontStyle === 'italic'} onClick={() => updateFieldStyle(selectedField, 'fontStyle', style.fontStyle === 'italic' ? 'normal' : 'italic')}><FormatItalic /></ToggleButton>
+                        <ToggleButton value="underline" aria-label="underline" selected={style.textDecoration === 'underline'} onClick={() => updateFieldStyle(selectedField, 'textDecoration', style.textDecoration === 'underline' ? 'none' : 'underline')}><FormatUnderlined /></ToggleButton>
+                      </ToggleButtonGroup>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Typography gutterBottom sx={{mt:1}}>Tamanho: {style.fontSize || 24}px</Typography>
+                    <Slider value={style.fontSize || 24} onChange={(e, value) => updateFieldStyle(selectedField, 'fontSize', value)} min={8} max={120} valueLabelDisplay="auto" marks={[{ value: 12, label: '12' }, { value: 24, label: '24' }, { value: 48, label: '48' }, { value: 72, label: '72' }]} />
+                  </Grid>
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+
+            {/* Efeitos */}
+            <Accordion>
+              <AccordionSummary expandIcon={<ExpandMore />}><Typography variant="subtitle1"><Palette sx={{ mr: 1, verticalAlign: 'middle' }} />Efeitos</Typography></AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  <Grid item xs={12}>
+                    <FormControlLabel control={<Switch checked={style.textStroke || false} onChange={(e) => updateFieldStyle(selectedField, 'textStroke', e.target.checked)} size="small" />} label="Contorno" />
+                    {style.textStroke && (
+                      <Grid container spacing={2} sx={{ mt: 1 }}>
+                        <Grid item xs={6}><TextField label="Cor do Contorno" type="color" value={style.strokeColor || '#ffffff'} onChange={(e) => updateFieldStyle(selectedField, 'strokeColor', e.target.value)} fullWidth size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Espessura: {style.strokeWidth || 2}px</Typography><Slider value={style.strokeWidth || 2} onChange={(e, value) => updateFieldStyle(selectedField, 'strokeWidth', value)} min={1} max={10} size="small" /></Grid>
+                      </Grid>
+                    )}
+                  </Grid>
+                  <Grid item xs={12}>
+                    <FormControlLabel control={<Switch checked={style.textShadow || false} onChange={(e) => updateFieldStyle(selectedField, 'textShadow', e.target.checked)} size="small" />} label="Sombra" />
+                    {style.textShadow && (
+                      <Grid container spacing={2} sx={{ mt: 1 }}>
+                        <Grid item xs={6}><TextField label="Cor da Sombra" type="color" value={style.shadowColor || '#000000'} onChange={(e) => updateFieldStyle(selectedField, 'shadowColor', e.target.value)} fullWidth size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Desfoque: {style.shadowBlur || 4}px</Typography><Slider value={style.shadowBlur || 4} onChange={(e, value) => updateFieldStyle(selectedField, 'shadowBlur', value)} min={0} max={20} size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Offset X: {style.shadowOffsetX || 2}px</Typography><Slider value={style.shadowOffsetX || 2} onChange={(e, value) => updateFieldStyle(selectedField, 'shadowOffsetX', value)} min={-20} max={20} size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Offset Y: {style.shadowOffsetY || 2}px</Typography><Slider value={style.shadowOffsetY || 2} onChange={(e, value) => updateFieldStyle(selectedField, 'shadowOffsetY', value)} min={-20} max={20} size="small" /></Grid>
+                      </Grid>
+                    )}
+                  </Grid>
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+
+            <Divider sx={{ my: 2 }} />
+
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}><Button variant="outlined" size="small" onClick={() => copyStyleToAll(selectedField)} startIcon={<ContentCopy />} fullWidth>Aplicar a Todos</Button></Grid>
+              <Grid item xs={12} sm={6}><Button variant="outlined" size="small" onClick={() => resetFieldStyle(selectedField)} color="secondary" fullWidth>Resetar Estilo</Button></Grid>
+            </Grid>
+          </>
+        ) : (
+          <Typography variant="h6" color="textSecondary" align="center" gutterBottom sx={{mt: 4}}>
+            Selecione um campo de texto para editar suas propriedades
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );
 };
 
 export default FormattingPanel;
-


### PR DESCRIPTION
This commit fixes a regression where the controls for adjusting background image filters (brightness, contrast, etc.) were not visible in the 'Posicionar e Formatar' step.

The `FormattingPanel` component has been refactored to ensure the 'Filtros de Imagem de Fundo' accordion is always displayed, regardless of whether a text field is selected. Previously, it was only visible when no field was selected, which was incorrect.