### PR TITLE
fix(ImageGenerator): Correct useEffect dependency array to prevent in…

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -138,7 +138,7 @@ const ImageGeneratorFrontendOnly = ({
     // If `generatedImages` were included, and `setGeneratedImages` was called, it could lead to
     // loops if `App.jsx` passes the same reference back. The `initialGeneratedImagesData !== generatedImages`
     // check helps, but keeping dependencies minimal for prop-driven effects is often clearer.
-  }, [initialGeneratedImagesData, generatedImages]);
+  }, [initialGeneratedImagesData]);
 
   // Função para quebrar texto em linhas dentro de uma área retangular
   const wrapTextInArea = (ctx, text, x, y, maxWidth, maxHeight, style) => {


### PR DESCRIPTION
…finite loop

The image generation screen was flashing due to an infinite re-render loop in the `ImageGeneratorFrontendOnly` component.

The loop was caused by a `useEffect` hook that incorrectly included its own component's state (`generatedImages`) in its dependency array. This created a feedback loop where updating the state would trigger the effect, which would then update the state again.

The fix removes `generatedImages` from the dependency array, breaking the loop. The effect now only runs when the `initialGeneratedImagesData` prop changes, as was originally intended.