### PR TITLE
fix(FieldPositioner): Reset formatting panel on field deselect

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -395,7 +395,7 @@ const FieldPositioner = ({
               }}
               onMouseDown={(e) => {
                 if (e.target.closest('.text-box')) return;
-                setSelectedField(null);
+                handleFieldSelectInternal(null)
               }}
               onTouchStart={handleContainerTouchStart}
               onTouchEnd={handleContainerTouchEnd}


### PR DESCRIPTION
I've fixed an issue where the formatting panel was not resetting to its initial state when you clicked away from a selected field in the `FieldPositioner` component.

This was because the `onMouseDown` event handler on the container only updated the local `selectedField` state but did not propagate this change to the parent `App` component, which controls the formatting panel.

My fix updates the `onMouseDown` handler to call `handleFieldSelectInternal(null)`. This function correctly updates both the local state and calls the `onSelectFieldExternal` prop, ensuring the parent component is notified of the deselection and can reset the formatting panel.