### PR TITLE
fix(GeneratedImageEditor): Pass missing props to prevent crash

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -52,7 +52,10 @@ const GeneratedImageEditor = ({
   onSave, // Callback: (editedImageData) => void
   colorPalette, // Paleta de cores global
   globalBackgroundImage, // Imagem de fundo global, como fallback
-  originalImageSize
+  originalImageSize,
+  imageFilters, // Adicionado
+  includeLogo, // Adicionado
+  includeEmpresa // Adicionado
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
   const [editedStyles, setEditedStyles] = useState({});
@@ -166,6 +169,9 @@ const GeneratedImageEditor = ({
                 onSelectFieldExternal={handleInternalFieldSelection} // Use memoized handler
                 onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
                 originalImageSize={originalImageSize}
+                imageFilters={imageFilters}
+                includeLogo={includeLogo}
+                includeEmpresa={includeEmpresa}
               />
             </Grid>
             {isLargeScreen && (

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -1201,6 +1201,9 @@ const ImageGeneratorFrontendOnly = ({
             colorPalette={colorPalette}
             globalBackgroundImage={backgroundImage}
             originalImageSize={originalImageSize} // Pass the prop here
+            imageFilters={imageFilters}
+            includeLogo={includeLogo}
+            includeEmpresa={includeEmpresa}
           />
         );
       })()}


### PR DESCRIPTION
A TypeError occurred when clicking a generated image to open the editor, with the error message "Cannot read properties of undefined (reading 'brightness')".

This was caused by the `FieldPositioner` component, which is used inside the `GeneratedImageEditor`, not receiving the `imageFilters`, `includeLogo`, and `includeEmpresa` props. These props are necessary for it to correctly compose and render the image preview.

The fix involves passing these required props from the parent `ImageGeneratorFrontendOnly` component to `GeneratedImageEditor`, and then subsequently passing them from `GeneratedImageEditor` down to the `FieldPositioner` component. This ensures the data is available where needed and prevents the crash.