### PR TITLE
fix(utils): Replace regex HTML stripping with DOMParser

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,5 +12,12 @@ export function cn(...inputs) {
  */
 export function stripHtml(html) {
   if (!html) return "";
-  return html.replace(/<[^>]*>?/gm, '');
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent || "";
+  } catch (e) {
+    console.error("Error stripping HTML, falling back to regex", e);
+    // Fallback for environments where DOMParser might not be available or fails
+    return html.replace(/<[^>]*>?/gm, '');
+  }
 }


### PR DESCRIPTION
The previous regex-based 'stripHtml' function was not robust enough to handle complex, nested HTML generated by the rich text editor, resulting in HTML tags being leaked into the prompts sent to the AI.

The function has been updated to use the browser's native DOMParser, which can reliably parse the HTML string and extract its plain text content. This ensures all HTML is stripped correctly before being used in AI prompts.