### PR TITLE
fix(linkedin): Persist clientSecret to complete OAuth flow

### DIFF
--- a/src/utils/linkedinCredentials.js
+++ b/src/utils/linkedinCredentials.js
@@ -6,10 +6,9 @@ const LINKEDIN_CONFIG_KEY = 'linkedinConfig';
  */
 export const saveLinkedinConfig = (config) => {
   try {
-    // Não armazene o clientSecret no localStorage por motivos de segurança.
-    const { clientSecret: _clientSecret, ...configToStore } = config;
     const existingConfig = getLinkedinConfig() || {};
-    const newConfig = { ...existingConfig, ...configToStore };
+    // Garantir que o clientSecret seja mesclado apenas se for fornecido
+    const newConfig = { ...existingConfig, ...config };
     const configString = JSON.stringify(newConfig);
     localStorage.setItem(LINKEDIN_CONFIG_KEY, configString);
   } catch (error) {


### PR DESCRIPTION
The LinkedIn configuration was not saving the Client Secret, which prevented the application from exchanging the authorization code for an access token.

The 'saveLinkedinConfig' function was explicitly discarding the secret for security reasons, but this broke the authentication process.

This commit modifies the function to save the clientSecret to localStorage, allowing the OAuth2 flow to complete successfully. The UI already contains a warning about storing secrets.