### PR TITLE
fix(auth): Overhaul LinkedIn authentication and state preservation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -483,10 +483,8 @@ function App() {
             const { access_token, expires_in } = data;
 
             saveLinkedinConfig({
-              ...config,
               accessToken: access_token,
               tokenExpiration: Date.now() + expires_in * 1000,
-              clientSecret: undefined, // Garante que o secret não seja salvo
             });
 
             // Abre o modal para mostrar que a conexão foi bem-sucedida

--- a/src/utils/linkedinCredentials.js
+++ b/src/utils/linkedinCredentials.js
@@ -4,12 +4,19 @@ const LINKEDIN_CONFIG_KEY = 'linkedinConfig';
  * Salva a configuração do LinkedIn no armazenamento local.
  * @param {object} config - O objeto de configuração.
  */
-export const saveLinkedinConfig = (config) => {
+export const saveLinkedinConfig = (newConfig) => {
   try {
     const existingConfig = getLinkedinConfig() || {};
-    // Garantir que o clientSecret seja mesclado apenas se for fornecido
-    const newConfig = { ...existingConfig, ...config };
-    const configString = JSON.stringify(newConfig);
+
+    // Mescla a configuração existente com a nova
+    const mergedConfig = { ...existingConfig, ...newConfig };
+
+    // Se um novo accessToken está sendo salvo, remova o clientSecret por segurança.
+    if (newConfig.accessToken) {
+      delete mergedConfig.clientSecret;
+    }
+
+    const configString = JSON.stringify(mergedConfig);
     localStorage.setItem(LINKEDIN_CONFIG_KEY, configString);
   } catch (error) {
     console.error('Erro ao salvar a configuração do LinkedIn:', error);


### PR DESCRIPTION
This commit provides a comprehensive fix for multiple issues in the LinkedIn authentication and state management flow.

It ensures the clientSecret is correctly persisted and then automatically deleted after use, fixes a UI bug where the clientId would disappear, and prevents sessionStorage quota errors by excluding large generated assets from the state saved during redirects.