### PR TITLE
fix: Ensure generated images are loaded from saved state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -943,7 +943,7 @@ function App() {
             }
 
             // Restaurar generatedImages se presentes (versão 1.1+)
-            if (loadedState.version === "1.1" && loadedState.generatedImages) {
+            if (parseFloat(loadedState.version) >= 1.1 && loadedState.generatedImages) {
               const restoredGeneratedImages = await Promise.all(
                 loadedState.generatedImages.map(async (imgData) => {
                   let blob = null;


### PR DESCRIPTION
The `handleLoadStateFromFile` function had a strict version check (`=== '1.1'`) that prevented the `generatedImages` array from being restored from save files created with newer versions of the application.

This commit changes the check to `parseFloat(loadedState.version) >= 1.1`, ensuring that the image restoration logic runs for all compatible save file versions.