### PR TITLE
fix: Save and restore originalImageSize in state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -830,8 +830,9 @@ function App() {
       );
 
       const stateToSave = {
-        version: "1.6",
+        version: "1.7", // Incremented version to reflect this change
         backgroundImageUrl: backgroundImage,
+        originalImageSize: originalImageSize, // <<<<<<<<<<<< SAVE
         fieldPositions: fieldPositions,
         fieldStyles: fieldStyles,
         csvHeaders: csvHeaders,
@@ -898,7 +899,7 @@ function App() {
           };
 
           // Verificar versão e campos essenciais
-          if (loadedState.version && ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6"].includes(loadedState.version) &&
+          if (loadedState.version && ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7"].includes(loadedState.version) &&
             loadedState.backgroundImageUrl !== undefined &&
             loadedState.fieldPositions &&
             loadedState.fieldStyles &&
@@ -908,6 +909,11 @@ function App() {
             setFieldPositions(loadedState.fieldPositions);
             setFieldStyles(loadedState.fieldStyles);
             setCsvHeaders(loadedState.csvHeaders);
+
+            // Restore originalImageSize if it exists in the saved file
+            if (loadedState.originalImageSize) {
+              setOriginalImageSize(loadedState.originalImageSize);
+            }
 
             if (loadedState.colorPalette) {
               setColorPalette(loadedState.colorPalette);


### PR DESCRIPTION
The `originalImageSize` state was not being saved to or restored from the project's state file. This caused the font scaling to be incorrect after loading a saved project, as the font scale depends on the original dimensions of the background image.

This commit adds `originalImageSize` to the saved state object and adds the logic to restore it when a file is loaded. The state file version has been incremented to 1.7.