### PR TITLE
fix(api): Use correct environment variable names in LinkedIn proxy

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -13,8 +13,8 @@ export default async function handler(request, response) {
 
   // Case 1: OAuth Token Exchange
   if (code) {
-    const clientId = process.env.VITE_LINKEDIN_CLIENT_ID;
-    const clientSecret = process.env.VITE_LINKEDIN_CLIENT_SECRET;
+    const clientId = process.env.LINKEDIN_CLIENT_ID;
+    const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
 
     if (!redirectUri) {
       return response.status(400).json({ error: 'Redirect URI is missing for token exchange.' });


### PR DESCRIPTION
The serverless function at /api/linkedin-proxy was returning a 403 Forbidden error, likely due to a Vercel security policy.

The function was incorrectly attempting to access server-side environment variables using a 'VITE_' prefix, which is reserved for variables exposed to the frontend client.

This commit corrects the code to access the variables without the prefix (e.g., process.env.LINKEDIN_CLIENT_ID). This is the proper way to handle secure secrets on the backend and should resolve the 403 error.