### PR TITLE
fix(linkedin): Change test connection endpoint to /v2/me

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -45,7 +45,7 @@ async function handleTestConnection(request, response) {
         return response.status(400).json({ error: 'Missing accessToken for test connection.' });
     }
 
-    const testUrl = 'https://api.linkedin.com/v2/connections?q=viewer&start=0&count=0';
+    const testUrl = 'https://api.linkedin.com/v2/me';
 
     try {
         const linkedinResponse = await fetch(testUrl, {

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -95,7 +95,7 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
 
       const data = await response.json();
       if (response.ok) {
-        setMessage(`✅ Conexão bem-sucedida. Você tem ${data.paging.total} conexões de 1º grau.`);
+        setMessage(`✅ Conexão bem-sucedida.`);
       } else {
         const errorData = await response.json().catch(() => ({ message: 'Não foi possível ler a resposta de erro.' }));
         setMessage(`❌ Erro no teste: ${errorData.message || 'Ocorreu um erro desconhecido.'}`);


### PR DESCRIPTION
The 'Test Connection' button was failing with a 403 Forbidden error, likely because the /v2/connections endpoint requires special permissions.

This commit changes the test to use the standard /v2/me endpoint, which is a more reliable way to verify that an access token is valid.

The success message in the UI has also been updated to be more generic, as the new endpoint does not return a connection count.