### PR TITLE
fix(linkedin): Use dynamic user URN for post author

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -223,11 +223,8 @@ export const publishToLinkedIn = async (campaignData) => {
   }
   const { accessToken } = config;
 
-  // As per the n8n config, we post as a specific organization.
-  // In a real-world scenario, this might be fetched or configured dynamically.
-  const authorUrn = 'urn:li:organization:669250';
-  // Alternatively, to post as the user:
-  // const authorUrn = await _getProfileUrn(accessToken);
+  // To solve the author error, we now post as the authenticated user.
+  const authorUrn = await _getProfileUrn(accessToken);
 
 
   // 1. Register Image Upload


### PR DESCRIPTION
This commit fixes a `403 Forbidden` error that occurred during post creation. The error was caused by a hardcoded organization URN being used as the author for all posts.

The code has been changed to dynamically fetch the authenticated user's profile URN using the `_getProfileUrn` function and use that as the `author` field when creating the post. This ensures that the post is created on behalf of the user who connected their LinkedIn account, which resolves the permission issue.