### PR TITLE
feat: Preserve problem and solution on campaign reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1538,8 +1538,8 @@ console.log(finalPrompt)
 
   const handleResetCampaign = () => {
     setCampaignContent(null);
-    setProblema('');
-    setSolucao('');
+    // setProblema(''); // Keep the problem
+    // setSolucao(''); // Keep the solution
     setGeneratedImageUrl(null);
     setConteudoMedio('');
     setConteudoPequeno('');


### PR DESCRIPTION
You requested that the 'Problem' and 'Solution' fields should not be cleared when the campaign is reset. This commit modifies the 'handleResetCampaign' function to keep these fields' values, only resetting the generated content.