### PR TITLE
feat: Implement proactive Google Sign-In for Drive Picker

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -11,6 +11,7 @@ import {
   IconButton,
   Tooltip,
   Grid,
+  CircularProgress,
 } from '@mui/material';
 import { InfoOutlined } from '@mui/icons-material';
 import {
@@ -19,6 +20,7 @@ import {
   removeLinkedinConfig,
 } from '../utils/linkedinCredentials';
 import GoogleDriveFolderPicker from './GoogleDriveFolderPicker';
+import googleDriveAPI from '../utils/googleDriveAPI';
 
 const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
   const [config, setConfig] = useState({
@@ -28,6 +30,7 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
   const [currentConfig, setCurrentConfig] = useState(null);
   const [message, setMessage] = useState('');
   const [isPickerOpen, setPickerOpen] = useState(false);
+  const [isDriveLoading, setIsDriveLoading] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -61,6 +64,39 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
       folderId: folder.id,
     }));
     setPickerOpen(false);
+  };
+
+  const handleBrowseDrive = async () => {
+    setMessage('');
+    setIsDriveLoading(true);
+
+    const apiKey = localStorage.getItem("google_drive_api_key");
+    const clientId = localStorage.getItem("google_drive_client_id");
+
+    if (!apiKey || !clientId) {
+      setMessage('❌ Por favor, configure a integração com o Google na página principal primeiro.');
+      setIsDriveLoading(false);
+      return;
+    }
+
+    try {
+      if (!googleDriveAPI.isInitialized) {
+        await googleDriveAPI.initialize(apiKey, clientId);
+      }
+
+      if (!googleDriveAPI.isUserSignedIn()) {
+        setMessage('Aguardando login com o Google...');
+        await googleDriveAPI.signIn();
+        setMessage('');
+      }
+
+      setPickerOpen(true);
+    } catch (error) {
+      console.error('Erro ao preparar o seletor de pastas do Google Drive:', error);
+      setMessage(`❌ Erro no Google Drive: ${error.message}`);
+    } finally {
+      setIsDriveLoading(false);
+    }
   };
 
   const handleConnect = async () => {
@@ -152,8 +188,13 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
                 helperText="Este ID de pasta será usado para monitorar novos conteúdos."
                 sx={{ mb: 2 }}
               />
-              <Button variant="outlined" onClick={() => setPickerOpen(true)}>
-                Procurar Pasta no Google Drive...
+              <Button
+                variant="outlined"
+                onClick={handleBrowseDrive}
+                disabled={isDriveLoading}
+                startIcon={isDriveLoading ? <CircularProgress size={16} /> : null}
+              >
+                {isDriveLoading ? 'Aguarde...' : 'Procurar Pasta no Google Drive...'}
               </Button>
             </Box>
           ) : (

--- a/src/utils/googleDriveAPI.js
+++ b/src/utils/googleDriveAPI.js
@@ -11,6 +11,9 @@ class GoogleDriveAPI {
     this.isSignedIn = false;
     this.accessToken = null;
     this.initPromise = null;
+    // Promise handlers for discrete signIn calls
+    this.signInResolver = null;
+    this.signInRejecter = null;
   }
 
   /**
@@ -62,15 +65,32 @@ class GoogleDriveAPI {
         scope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/spreadsheets',
         callback: (response) => {
           if (response.error) {
-            reject(new Error(`Erro de autenticação: ${response.error}`));
+            const err = new Error(`Erro de autenticação: ${response.error}`);
+            if (this.signInRejecter) {
+              this.signInRejecter(err);
+              this.signInRejecter = null;
+              this.signInResolver = null;
+            }
+            reject(err); // For initialize() promise
             return;
           }
           this.accessToken = response.access_token;
           this.isSignedIn = true;
-          resolve(true);
+          if (this.signInResolver) {
+            this.signInResolver(true);
+            this.signInResolver = null;
+            this.signInRejecter = null;
+          }
+          resolve(true); // For initialize() promise
         },
         error_callback: (error) => {
-          reject(new Error(`Erro no cliente de token: ${error}`));
+          const err = new Error(`Erro no cliente de token: ${error.message || 'desconhecido'}`);
+           if (this.signInRejecter) {
+              this.signInRejecter(err);
+              this.signInRejecter = null;
+              this.signInResolver = null;
+            }
+          reject(err); // For initialize() promise
         }
       });
 
@@ -124,11 +144,19 @@ class GoogleDriveAPI {
   /**
    * Faz login do usuário
    */
-  async signIn() {
-    if (!this.tokenClient) {
-      throw new Error('API não inicializada. Chame initialize() primeiro.');
-    }
-    this.tokenClient.requestAccessToken();
+  signIn() {
+    return new Promise((resolve, reject) => {
+      if (!this.isInitialized || !this.tokenClient) {
+        return reject(new Error('API não inicializada. Chame initialize() primeiro.'));
+      }
+      // Store the resolve/reject functions to be called by the central callback
+      this.signInResolver = resolve;
+      this.signInRejecter = reject;
+
+      // Prompt for consent only if necessary.
+      // An empty prompt is usually sufficient if the user has already granted consent.
+      this.tokenClient.requestAccessToken({ prompt: '' });
+    });
   }
 
   /**


### PR DESCRIPTION
This commit improves your experience when accessing the Google Drive Folder Picker from the LinkedIn settings modal.

Previously, the application would show an error if you were not signed into Google. Now, it implements a proactive flow:
1.  It checks if Google credentials are configured in the app. If not, it displays a message guiding you.
2.  If credentials exist, it checks if you are signed in to Google.
3.  If you are not signed in, it now automatically triggers the Google Sign-In process.
4.  The folder picker is then opened only after a successful sign-in.

This was enabled by refactoring the `signIn` method in `googleDriveAPI.js` to be asynchronous and return a promise, allowing the UI to `await` the result of the sign-in attempt.