### PR TITLE
fix: Add rw_organization_admin scope for LinkedIn pages

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -63,7 +63,11 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
       saveLinkedinConfig({ clientId: config.clientId });
 
       const redirectUri = window.location.origin;
-      const scope = 'r_basicprofile%20w_member_social%20r_1st_connections_size';
+      // Scopes updated to include organization admin permissions and newer recommended scopes.
+      // r_liteprofile: Basic profile data
+      // w_share: Ability to post shares
+      // rw_organization_admin: Read and write access to managed organization pages, required for posting on their behalf.
+      const scope = encodeURIComponent('r_liteprofile w_share rw_organization_admin');
       const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${config.clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
 
       window.location.href = authUrl;


### PR DESCRIPTION
This commit fixes a bug where managed organization pages were not appearing in the profile selection dropdown.

The root cause was that the application was not requesting the necessary permissions from LinkedIn during the OAuth2 flow. The `rw_organization_admin` scope, which is required to read and post to your managed pages, was missing.

This commit updates the `scope` parameter in the authentication URL to include `rw_organization_admin`. It also updates the deprecated `r_basicprofile` and `w_member_social` scopes to the newer `r_liteprofile` and `w_share` scopes for best practice.

With this change, you will be prompted to grant the new permissions, and upon approval, your managed pages will correctly appear in the publisher.