### PR TITLE
I've added server-side and client-side logging to the LinkedIn OAuth2…

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -31,6 +31,9 @@ async function handleTokenExchange(request, response) {
       body: params.toString(),
     });
     const data = await linkedinResponse.json();
+    if (!linkedinResponse.ok) {
+      console.error('LinkedIn API Error during token exchange:', data);
+    }
     return response.status(linkedinResponse.status).json(data);
   } catch (error) {
     console.error('Error during token exchange:', error);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -475,7 +475,7 @@ function App() {
             // Abre o modal para mostrar que a conexão foi bem-sucedida
             setShowLinkedinAuthModal(true);
           } else {
-            console.error('Erro ao obter o token de acesso do LinkedIn:', await response.text());
+            console.error('Erro ao obter o token de acesso do LinkedIn:', data);
             // Tratar erro, talvez mostrar mensagem
           }
         } catch (error) {


### PR DESCRIPTION
… authentication flow to help you diagnose failures.

On the backend, I updated the proxy (`api/linkedin-proxy.js`) to log any errors returned by the LinkedIn API during the token exchange. This will ensure that failures are visible in your Vercel logs.

On the frontend, I updated `src/App.jsx` to correctly log the JSON error object received from the backend, which also fixed a bug where the response body was being read twice.