### PR TITLE
fix(linkedin): Fetch all pages for a user regardless of role

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -186,8 +186,9 @@ async function handleGetOrganizations(request, response) {
       name: `${profileData.localizedFirstName} ${profileData.localizedLastName} (Pessoal)`,
     }];
 
-    // 2. Find organizations the user is an administrator for
-    const aclUrl = 'https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED&role=ADMINISTRATOR';
+    // 2. Find organizations the user has an approved role for.
+    // We fetch all roles and de-duplicate, as a user might have multiple roles for one page.
+    const aclUrl = 'https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED';
     const aclResponse = await fetch(aclUrl, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,


### PR DESCRIPTION
The previous implementation only fetched pages where the user had the 'ADMINISTRATOR' role. This was too restrictive and did not show pages where the user had other administrative roles, such as 'CONTENT_ADMINISTRATOR'.

This change modifies the call to the `organizationAcls` endpoint to remove the `role` filter. This will return all organizations for which the user has any approved role. The existing de-duplication logic handles cases where a user has multiple roles for a single page.