### PR TITLE
fix(linkedin): Add LinkedIn-Version header to API calls

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -80,6 +80,7 @@ async function handleRegisterUpload(request, response) {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
+        'LinkedIn-Version': '202405',
       },
       body: JSON.stringify(payload),
     });
@@ -155,6 +156,7 @@ async function handleCreatePost(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'X-Restli-Protocol-Version': '2.0.0',
+        'LinkedIn-Version': '202405',
       },
       body: JSON.stringify(payload),
     });
@@ -206,6 +208,7 @@ async function handleGetOrganizations(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
+        'LinkedIn-Version': '202405',
       },
     });
 


### PR DESCRIPTION
This commit fixes an issue where company pages were not appearing in the 'Publish as' dropdown. The root cause was that API calls to LinkedIn's REST endpoints were missing the required `LinkedIn-Version` header.

Without this header, the API was likely defaulting to an older version which did not return the expected data for organization roles.

This change adds the `LinkedIn-Version: 202405` header to all relevant API calls in the `api/linkedin-proxy.js` function to ensure the application uses a recent and consistent version of the LinkedIn API.