### PR TITLE
fix(linkedin): Use active and correct API version for all calls

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -80,7 +80,7 @@ async function handleRegisterUpload(request, response) {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202405',
+        'LinkedIn-Version': '202411',
       },
       body: JSON.stringify(payload),
     });
@@ -156,7 +156,7 @@ async function handleCreatePost(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'X-Restli-Protocol-Version': '2.0.0',
-        'LinkedIn-Version': '202405',
+        'LinkedIn-Version': '202411',
       },
       body: JSON.stringify(payload),
     });
@@ -208,7 +208,7 @@ async function handleGetOrganizations(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202405',
+        'LinkedIn-Version': '202411',
       },
     });
 


### PR DESCRIPTION
This commit fixes two issues:
1. An error `Requested version 20240501 is not active` when posting.
2. The 'Publish as' dropdown not showing company pages.

Both issues were caused by using an invalid or outdated API version in the `LinkedIn-Version` header, or by omitting the header entirely.

This change updates all calls to LinkedIn's versioned REST APIs to use the `202411` version, which is known to be active. This ensures that the application correctly fetches organization roles and can successfully use the new Posts API.