### PR TITLE
I've added the `w_member_social` scope to the LinkedIn authentication…

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -128,9 +128,10 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
 
       // Scopes updated to include organization admin permissions and newer recommended scopes.
       // r_basicprofile: For basic profile data.
+      // w_member_social: To post, comment, and like on behalf of a member.
       // w_organization_social: To post, comment, and like on behalf of an organization. Replaces w_share.
       // rw_organization_admin: For managing organization pages.
-      const scope = encodeURIComponent('r_basicprofile w_organization_social rw_organization_admin');
+      const scope = encodeURIComponent('r_basicprofile w_member_social w_organization_social rw_organization_admin');
       const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${config.clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
       window.location.href = authUrl;
     } else {


### PR DESCRIPTION
… request as a diagnostic step.

My goal is to figure out why you're seeing that 403 Forbidden error when you try to post as an organization. By also adding the permission to post as a person, we can test whether the problem is specific to organization posting, or if it's a more general issue with the API call.

Once this is in place, I'll need you to try posting to your personal profile and then to your company page. That will show us exactly where the process is failing.