### PR TITLE
fix(linkedin): Explicitly query for user's organization roles

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -183,14 +183,15 @@ async function handleGetOrganizations(request, response) {
       name: `${profileData.localizedFirstName} ${profileData.localizedLastName} (Pessoal)`,
     }];
 
-    // 2. Find organizations the user has an approved role for.
-    const aclUrl = 'https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED';
+    // 2. Find organizations for which the authenticated user has an approved role.
+    const userUrn = `urn:li:person:${profileData.id}`;
+    const aclUrl = `https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&roleAssignee=${encodeURIComponent(userUrn)}&state=APPROVED`;
     const aclResponse = await fetch(aclUrl, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202403', // Use a stable, recent version
+        'LinkedIn-Version': '202403',
       },
     });
 


### PR DESCRIPTION
This commit attempts to fix an issue where company pages were not appearing in the 'Publish as' dropdown.

Previous attempts to fix this by broadening the `organizationAcls` query were unsuccessful. This change takes a more explicit approach.

It now first fetches the authenticated user's profile to get their person URN, and then uses that URN to explicitly query the `organizationAcls` endpoint for that specific `roleAssignee`. This should resolve any ambiguity in the API call and correctly return all pages the user is associated with.