### PR TITLE
Olá! Eu identifiquei que a chamada para a API do LinkedIn para buscar…

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -191,14 +191,15 @@ async function handleGetOrganizations(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202403',
+        'LinkedIn-Version': '202405',
       },
     });
 
     if (!aclResponse.ok) {
-       // It's possible the user has no organizations, so don't throw an error, just log it.
-       console.warn(`Could not fetch organization ACLs, status: ${aclResponse.status}`);
-       return response.status(200).json(profiles); // Return at least the personal profile
+       const errorBody = await aclResponse.text();
+       console.warn(`Could not fetch organization ACLs, status: ${aclResponse.status}, body: ${errorBody}`);
+       // It's possible the user has no organizations, so don't throw an error, just return personal profile.
+       return response.status(200).json(profiles);
     }
 
     const aclData = await aclResponse.json();


### PR DESCRIPTION
… as suas organizações estava falhando. Isso fazia com que apenas o seu perfil pessoal aparecesse na lista de opções 'Publicar como'.

Para corrigir o problema, eu atualizei a versão da API do LinkedIn de '202403' para '202405' na chamada do endpoint `organizationAcls`, pois a versão mais antiga provavelmente foi descontinuada.

Além disso, aprimorei o tratamento de erros para registrar o corpo da resposta em caso de falha, o que facilitará a depuração de problemas futuros.