### PR TITLE
fix: Reverti a versão da API do LinkedIn para uma versão estável (202…

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -191,7 +191,7 @@ async function handleGetOrganizations(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202405',
+        'LinkedIn-Version': '202402',
       },
     });
 


### PR DESCRIPTION
…402)

Minhas tentativas anteriores de usar versões mais recentes da API (`202405`, `202501`) falharam porque essas versões não estavam ativas, conforme indicado pelos logs do servidor (`NONEXISTENT_VERSION`).

Por isso, reverti a versão da API do LinkedIn para `202402`. Esta é uma versão mais antiga, mas que está estável e ativa, com data de desativação em fevereiro de 2025. Isso deve resolver o problema de não conseguir buscar as suas organizações.

Mantive o tratamento de erros aprimorado para ajudar a diagnosticar problemas futuros.