### PR TITLE
debug: Adiciona log para a resposta da API de ACLs do LinkedIn

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -203,6 +203,7 @@ async function handleGetOrganizations(request, response) {
     }
 
     const aclData = await aclResponse.json();
+    console.log('LinkedIn ACL Data:', JSON.stringify(aclData, null, 2));
     const organizationUrns = aclData.elements?.map(el => el.organization) || [];
 
     if (organizationUrns.length === 0) {


### PR DESCRIPTION
Para depurar por que a lista de organizações não está sendo retornada, esta alteração adiciona um log que imprime o corpo da resposta da chamada à API `organizationAcls`.

A versão da API foi mantida em `202402` e o tratamento de erros aprimorado também foi mantido.