### PR TITLE
fix: Remove o cabeçalho de versão da API do LinkedIn

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -191,19 +191,16 @@ async function handleGetOrganizations(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
-        'LinkedIn-Version': '202402',
       },
     });
 
     if (!aclResponse.ok) {
-       const errorBody = await aclResponse.text();
-       console.warn(`Could not fetch organization ACLs, status: ${aclResponse.status}, body: ${errorBody}`);
-       // It's possible the user has no organizations, so don't throw an error, just return personal profile.
-       return response.status(200).json(profiles);
+       // It's possible the user has no organizations, so don't throw an error, just log it.
+       console.warn(`Could not fetch organization ACLs, status: ${aclResponse.status}`);
+       return response.status(200).json(profiles); // Return at least the personal profile
     }
 
     const aclData = await aclResponse.json();
-    console.log('LinkedIn ACL Data:', JSON.stringify(aclData, null, 2));
     const organizationUrns = aclData.elements?.map(el => el.organization) || [];
 
     if (organizationUrns.length === 0) {


### PR DESCRIPTION
Como as tentativas anteriores de usar diferentes versões da API falharam com o erro `NONEXISTENT_VERSION`, esta alteração remove completamente o cabeçalho `LinkedIn-Version` da chamada para a API `organizationAcls`.

A hipótese é que, sem um cabeçalho de versão, a API do LinkedIn possa usar uma versão padrão estável, contornando o problema de versão que estamos enfrentando.