### PR TITLE
fix: Usa o endpoint administeredOrganizations para buscar páginas do …

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -183,40 +183,27 @@ async function handleGetOrganizations(request, response) {
       name: `${profileData.localizedFirstName} ${profileData.localizedLastName} (Pessoal)`,
     }];
 
-    // 2. Find organizations for which the authenticated user has an approved role.
-    const userUrn = `urn:li:person:${profileData.id}`;
-    const aclUrl = `https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&roleAssignee=${encodeURIComponent(userUrn)}&state=APPROVED&role=ADMINISTRATOR,CONTENT_ADMINISTRATOR`;
-    const aclResponse = await fetch(aclUrl, {
+    // 2. Find organizations the user administers using projection.
+    const orgsUrl = 'https://api.linkedin.com/v2/organizations?q=administeredOrganizations&projection=(elements*(organization~(id,localizedName)))';
+    const orgsResponse = await fetch(orgsUrl, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
-        'X-Restli-Protocol-Version': '2.0.0',
         'Content-Type': 'application/json',
       },
     });
 
-    if (!aclResponse.ok) {
-       // It's possible the user has no organizations, so don't throw an error, just log it.
-       console.warn(`Could not fetch organization ACLs, status: ${aclResponse.status}`);
-       return response.status(200).json(profiles); // Return at least the personal profile
-    }
-
-    const aclData = await aclResponse.json();
-    const organizationUrns = aclData.elements?.map(el => el.organization) || [];
-
-    if (organizationUrns.length === 0) {
+    if (!orgsResponse.ok) {
+      const errorBody = await orgsResponse.text();
+      console.warn(`Could not fetch administered organizations, status: ${orgsResponse.status}, body: ${errorBody}`);
+      // If this fails, just return the personal profile.
       return response.status(200).json(profiles);
     }
 
-    // 3. Fetch details for each organization
-    const organizationPromises = organizationUrns.map(urn =>
-      fetch(`https://api.linkedin.com/v2/organizations/${urn.split(':').pop()}`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      }).then(res => res.ok ? res.json() : null)
-    );
+    const orgsData = await orgsResponse.json();
+    const organizations = orgsData.elements || [];
 
-    const organizationResults = await Promise.all(organizationPromises);
-
-    organizationResults.forEach(orgData => {
+    organizations.forEach(orgAcl => {
+      const orgData = orgAcl['organization~']; // Details are in the projected field
       if (orgData) {
         profiles.push({
           urn: `urn:li:organization:${orgData.id}`,

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -131,7 +131,7 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
       // w_member_social: To post, comment, and like on behalf of a member.
       // w_organization_social: To post, comment, and like on behalf of an organization. Replaces w_share.
       // rw_organization_admin: For managing organization pages.
-      const scope = encodeURIComponent('r_basicprofile w_member_social w_organization_social rw_organization_admin');
+      const scope = encodeURIComponent('r_basicprofile w_member_social w_organization_social rw_organization_admin r_organization_admin');
       const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${config.clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
       window.location.href = authUrl;
     } else {


### PR DESCRIPTION
…LinkedIn

Com base nas suas instruções e em uma nova análise, esta correção substitui completamente a implementação anterior que usava o endpoint `/organizationAcls`.

Fiz as seguintes alterações:
- A função `handleGetOrganizations` agora usa o endpoint `GET /v2/organizations?q=administeredOrganizations`, que é mais simples e direto para obter as organizações que você administra.
- O escopo OAuth foi atualizado para incluir `r_organization_admin`, conforme solicitado, para garantir as permissões corretas.

Esta abordagem é mais robusta e deve resolver definitivamente o problema de não conseguir buscar as suas organizações.