### PR TITLE
fix: Remove &nbsp; from text before audio generation

### DIFF
--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -87,8 +87,11 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
     // Remove tags HTML
     const noHtml = noEmojis.replace(/<\/?[^>]+(>|$)/g, '');
 
+    // Substituir &nbsp; por espaço normal
+    const noNbsp = noHtml.replace(/&nbsp;/g, ' ');
+
     // Remove múltiplos pontos com ou sem espaços: ". .", "..", "... ", etc → ". "
-    const fixedDots = noHtml.replace(/(\s*\.\s*){2,}/g, '. ');
+    const fixedDots = noNbsp.replace(/(\s*\.\s*){2,}/g, '. ');
 
     // Limpa padrões específicos indesejados, como "..':"
     const cleanedText = fixedDots.replace(/\.{2,}':/g, '');


### PR DESCRIPTION
This commit fixes an issue where non-breaking space HTML entities (`&nbsp;`) were being included in the text sent to the text-to-speech engine, causing incorrect pronunciation.

The `removeFormatting` function in `AudioGenerator.jsx` has been updated to replace all instances of `&nbsp;` with a standard space.