### PR TITLE
fix: Remove deprecated videoPlayStats from video upload request

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -159,10 +159,7 @@ const _registerVideoUpload = async (accessToken, authorUrn) => {
           serviceRelationships: [{
             relationshipType: 'OWNER',
             identifier: 'urn:li:userGeneratedContent',
-          }],
-          videoPlayStats: {
-            videoPlayStatsType: 'PER_VIEWER_STATS'
-          }
+          }]
         },
       },
     }),


### PR DESCRIPTION
When registering a video upload, the LinkedIn API was returning a 403 error with the message "Unpermitted fields present in REQUEST_BODY: ... [/registerUploadRequest/videoPlayStats]". This indicates that the `videoPlayStats` field is no longer a valid parameter for this API call.

This commit removes the `videoPlayStats` object from the payload of the video registration request in `_registerVideoUpload` function within `src/utils/linkedinAPI.js`. This resolves the error and allows video uploads to be registered successfully.