### PR TITLE
fix: Correct asset ownership for LinkedIn posts

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -172,7 +172,6 @@ const _pollVideoStatus = async (accessToken, videoUrn) => {
     });
 
     if (!response.ok) {
-        // Don't throw an error, just log it and continue polling
         console.warn(`Polling video status failed with status ${response.status}. Retrying...`);
         continue;
     }
@@ -273,13 +272,16 @@ export const publishToLinkedIn = async (campaignData) => {
   }
   const { accessToken } = config;
 
-  const authorUrn = providedAuthorUrn || await _getProfileUrn(accessToken);
+  const personalUrn = await _getProfileUrn(accessToken);
+  const authorUrn = providedAuthorUrn || personalUrn; // The author of the POST
+  const assetOwnerUrn = personalUrn; // The owner of the ASSET is always the authenticated user
+
   let postResult;
 
   if (videoBlob) {
     console.log('Publishing to LinkedIn: Starting new video upload process...');
     // 1. Initialize
-    const initData = await _initializeVideoUpload(accessToken, authorUrn, videoBlob.size);
+    const initData = await _initializeVideoUpload(accessToken, assetOwnerUrn, videoBlob.size);
     const { video: videoUrn, uploadInstructions, uploadToken } = initData;
     console.log(`Video initialized. URN: ${videoUrn}`);
 
@@ -302,7 +304,7 @@ export const publishToLinkedIn = async (campaignData) => {
     console.log(`Publishing to LinkedIn: Registering and uploading ${imageBlobs.length} image(s)...`);
     const assetUrns = [];
     for (const imageBlob of imageBlobs) {
-        const { uploadUrl, assetUrn } = await _registerImageUpload(accessToken, authorUrn);
+        const { uploadUrl, assetUrn } = await _registerImageUpload(accessToken, assetOwnerUrn);
         await _uploadImage(accessToken, uploadUrl, imageBlob);
         console.log(`Image with asset URN: ${assetUrn} uploaded successfully.`);
         assetUrns.push(assetUrn);


### PR DESCRIPTION
This commit fixes a bug where creating a post with a video or image would fail with an ownership error. The LinkedIn API requires that the uploaded asset (video or image) be owned by your authenticated personal account, even when the final post is authored by an organization page that you manage.

The `publishToLinkedIn` function in `src/utils/linkedinAPI.js` has been updated to reflect this. It now always uses your authenticated personal URN as the `owner` when initializing an asset upload (`_initializeVideoUpload` or `_registerImageUpload`). The `author` of the final UGC Post remains the page or profile you selected in the UI.

This change resolves the "One or more of the contents is not owned by the author" error and allows for successful posting of media on behalf of an organization.