### PR TITLE
feat: Add save/load support for follow-up posts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -878,7 +878,7 @@ function App() {
       );
 
       const stateToSave = {
-        version: "1.9", // Version bump to save videos
+        version: "2.0", // Version bump to save followup posts
         backgroundImageUrl: backgroundImage,
         originalImageSize: originalImageSize,
         imageFilters: imageFilters,
@@ -900,6 +900,7 @@ function App() {
         conteudoMedio: conteudoMedio,
         conteudoPequeno: conteudoPequeno,
         conteudoFormatado: conteudoFormatado,
+        followupPosts: followupPosts,
       };
 
       const jsonString = JSON.stringify(stateToSave, null, 2);
@@ -1125,6 +1126,12 @@ function App() {
               setConteudoFormatado(loadedState.conteudoFormatado || '');
             } else {
               setConteudoFormatado('');
+            }
+
+            if (parseFloat(loadedState.version) >= 2.0) {
+              setFollowupPosts(loadedState.followupPosts || []);
+            } else {
+              setFollowupPosts([]);
             }
 
             // Navegação de passo


### PR DESCRIPTION
This commit enhances the application's save/load functionality to include the 'Follow-up Posts' data.

- The `handleSaveState` function in `src/App.jsx` now includes the `followupPosts` array in the `.midiator` save file.
- The save file version has been bumped to 2.0.
- The `handleLoadStateFromFile` function has been updated to correctly restore the `followupPosts` from the save file.

This ensures that generated follow-up posts are not lost when you save and later load your session.