### PR TITLE
chore: Add debug logging for LinkedIn publishing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -950,7 +950,7 @@ function App() {
           };
 
           // Verificar versão e campos essenciais
-          if (loadedState.version && ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9"].includes(loadedState.version) &&
+          if (loadedState.version && ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "2.0"].includes(loadedState.version) &&
             loadedState.backgroundImageUrl !== undefined &&
             loadedState.fieldPositions &&
             loadedState.fieldStyles &&

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -274,6 +274,9 @@ export const publishToLinkedIn = async (campaignData) => {
 
   const authorUrn = providedAuthorUrn || await _getProfileUrn(accessToken);
 
+  console.log('--- LinkedIn Publishing Debug ---');
+  console.log('Using URN for both Asset Owner and Post Author:', authorUrn);
+
   let postResult;
 
   if (videoBlob) {


### PR DESCRIPTION
This commit adds `console.log` statements to the `publishToLinkedIn` function in `src/utils/linkedinAPI.js`.

These logs will print the exact URN being used for both the asset owner and the post author. This is intended to help debug a persistent 'content not owned by author' error when posting media on behalf of an organization. The logs will allow us to see the URNs being sent to the API in the browser's developer console.