### PR TITLE
fix: Initialize Google Drive API before use in scheduler

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -189,6 +189,16 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
             throw new Error('O ID da Pasta no Google Drive não está configurado na autenticação do LinkedIn.');
         }
 
+        if (!googleDriveAPI.isInitialized) {
+            setPublishingStatusLi('Inicializando API do Google Drive...');
+            const apiKey = localStorage.getItem("google_drive_api_key");
+            const clientId = localStorage.getItem("google_drive_client_id");
+            if (!apiKey || !clientId) {
+                throw new Error("Credenciais da API do Google Drive não encontradas. Por favor, configure a integração na página principal.");
+            }
+            await googleDriveAPI.initialize(apiKey, clientId);
+        }
+
         if (!googleDriveAPI.isUserSignedIn()) {
             setPublishingStatusLi('Fazendo login no Google Drive...');
             await googleDriveAPI.signIn();


### PR DESCRIPTION
This commit fixes a bug where the Google Drive API would be called without being initialized, causing a crash when scheduling a LinkedIn post.

The `handleScheduleLinkedIn` function in `Publisher.jsx` has been updated to check if the `googleDriveAPI` instance is initialized. If not, it now retrieves the necessary credentials from `localStorage` and calls the `initialize()` method before proceeding with any other API calls. This ensures that the API is always ready for use, preventing the "API not initialized" error.