### PR TITLE
feat: Restructure scheduled posts Google Sheet

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2872,6 +2872,7 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
               conteudoFormatado={conteudoFormatado}
               generatedImagesData={generatedImagesData}
               generatedVideosData={generatedVideosData}
+              followupPosts={followupPosts}
             />
           )}
 

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -58,7 +58,7 @@ function TabPanel(props) {
   );
 }
 
-const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, generatedVideosData }) => {
+const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, generatedVideosData, followupPosts }) => {
   const [tabValue, setTabValue] = React.useState(0);
 
   const handleTabChange = (event, newValue) => {
@@ -225,15 +225,35 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
         }
 
         setPublishingStatusLi('Criando planilha de controle no Google Drive...');
-        const sheetData = [
-            ['Título da Campanha', campaignTitle],
-            ['Data do Agendamento', scheduleDate.toLocaleString('pt-BR')],
-            ['Perfil do LinkedIn', selectedProfile],
-            ['Conteúdo do Post', campaignContent?.conteudo],
-            ['CTA', campaignContent?.cta],
-            ['Hashtags', campaignContent?.hashtags.join(' ')],
-            ['Imagens (IDs no Drive)', uploadedImageLinks.join(', ')]
+
+        const headers = ['Data de Publicação', 'Título', 'Conteúdo', 'CTA', 'Hashtags', 'Imagem Principal (ID no Drive)'];
+        const mainPostRow = [
+            scheduleDate.toLocaleString('pt-BR'),
+            campaignContent?.titulo || '',
+            campaignContent?.conteudo || '',
+            campaignContent?.cta || '',
+            campaignContent?.hashtags?.join(' ') || '',
+            uploadedImageLinks.join(', ')
         ];
+
+        const sheetData = [headers, mainPostRow];
+
+        if (followupPosts && followupPosts.length > 0) {
+            followupPosts.forEach((post, index) => {
+                const followupDate = new Date(scheduleDate);
+                followupDate.setDate(scheduleDate.getDate() + index + 1);
+
+                const followupRow = [
+                    followupDate.toLocaleString('pt-BR'),
+                    post.tipo_gancho || '', // Usando tipo_gancho como título
+                    post.conteudo || '',
+                    post.cta || '',
+                    post.hashtags_sugeridas?.join(' ') || '',
+                    '' // Sem imagem para follow-up posts
+                ];
+                sheetData.push(followupRow);
+            });
+        }
 
         const spreadsheet = await googleDriveAPI.createSpreadsheet(
             `Controle - ${campaignTitle}`,


### PR DESCRIPTION
This commit refactors the Google Sheet generation for scheduled LinkedIn posts. The spreadsheet is now organized in a columnar format, with each row representing a post.

The changes are as follows:
- The spreadsheet now has a header row.
- The first data row contains the main post's information.
- Subsequent rows contain the data for each generated follow-up post.
- The publication date for each follow-up post is automatically set to one day after the previous post.
- The `followupPosts` state is now passed down to the `Publisher` component to make this data available for the spreadsheet.