### PR TITLE
fix: Update Google Sheet format and ensure hashtag prefixes

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -226,13 +226,13 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
 
         setPublishingStatusLi('Criando planilha de controle no Google Drive...');
 
-        const headers = ['Data de Publicação', 'Título', 'Conteúdo', 'CTA', 'Hashtags', 'Imagem Principal (ID no Drive)'];
+        const headers = ['Data de Publicação', 'Título', 'Conteúdo', 'Convite', 'Hashtags', 'Imagem Principal (ID no Drive)'];
         const mainPostRow = [
             scheduleDate.toLocaleString('pt-BR'),
             campaignContent?.titulo || '',
             campaignContent?.conteudo || '',
             campaignContent?.cta || '',
-            campaignContent?.hashtags?.join(' ') || '',
+            campaignContent?.hashtags?.map(h => h.startsWith('#') ? h : `#${h}`).join(' ') || '',
             uploadedImageLinks.join(', ')
         ];
 
@@ -248,7 +248,7 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
                     post.tipo_gancho || '', // Usando tipo_gancho como título
                     post.conteudo || '',
                     post.cta || '',
-                    post.hashtags_sugeridas?.join(' ') || '',
+                    post.hashtags_sugeridas?.map(h => h.startsWith('#') ? h : `#${h}`).join(' ') || '',
                     '' // Sem imagem para follow-up posts
                 ];
                 sheetData.push(followupRow);


### PR DESCRIPTION
This commit addresses two issues with the Google Sheet generated for scheduled LinkedIn posts:

1.  The 'CTA' column header has been renamed to 'Convite' as you requested.
2.  The logic for writing hashtags to the sheet has been updated to ensure that every hashtag is prefixed with a '#' symbol, adding it if it's missing. This applies to both the main post's hashtags and the suggested hashtags for follow-up posts.