### PR TITLE
fix: Ensure hashtags are prefixed for LinkedIn posts

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -196,7 +196,7 @@ const _createPost = async (accessToken, authorUrn, campaignContent, assetUrns = 
     '----',
     campaignContent.cta,
     '----',
-    campaignContent.hashtags.join(' '),
+    campaignContent.hashtags.map(h => h.startsWith('#') ? h : `#${h}`).join(' '),
   ].join('\n');
 
   const shareContent = {


### PR DESCRIPTION
This commit fixes a bug where hashtags were not being correctly prefixed with a '#' symbol when being published to LinkedIn.

The logic to add the prefix was previously only applied during the creation of the Google Sheet for scheduled posts. This change moves the logic to the `_createPost` function in `src/utils/linkedinAPI.js`, ensuring that all hashtags are correctly formatted before the post content is sent to the LinkedIn API.