### PR TITLE
fix: Allow popups for OAuth by updating COOP header

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     rel="stylesheet" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin-allow-popups" />
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
  
   <title>Midiator</title>


### PR DESCRIPTION
This commit resolves an issue where the Google Sign-In popup was being blocked by the browser's Cross-Origin-Opener-Policy (COOP). The strict `same-origin` policy interfered with the OAuth flow required for the Google Drive integration.

The `index.html` file has been modified to change the COOP from `same-origin` to `same-origin-allow-popups`. This is a standard and safe way to allow cross-origin authentication popups to function correctly while maintaining the security context needed for other browser features like `SharedArrayBuffer` (used by ffmpeg).