### PR TITLE
fix: Address LinkedIn scheduling and rate-limiting issues

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -170,6 +170,7 @@ const LinkedinAuthSetup = ({ open, onClose, onBeforeRedirect }) => {
 
   const handleRemove = () => {
     removeLinkedinConfig();
+    sessionStorage.removeItem('linkedin_profiles_cache');
     setCurrentConfig(null);
     setConnectedUser(null); // Limpar usuário ao desconectar
     setConfig({ clientId: '', folderId: '' });

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -210,11 +210,10 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
         const campaignFolder = await googleDriveAPI.createFolder(campaignTitle, driveFolderId);
 
         const imagesToUpload = generatedImagesData.filter((_, index) => selectedImages[index]);
-        if (imagesToUpload.length === 0) {
-            throw new Error("Nenhuma imagem selecionada para upload.");
-        }
 
-        setPublishingStatusLi(`Fazendo upload de ${imagesToUpload.length} imagens...`);
+        if (imagesToUpload.length > 0) {
+            setPublishingStatusLi(`Fazendo upload de ${imagesToUpload.length} imagens...`);
+        }
         const uploadedImageLinks = [];
         for (let i = 0; i < imagesToUpload.length; i++) {
             const image = imagesToUpload[i];

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -246,6 +246,21 @@ const _createPost = async (accessToken, authorUrn, campaignContent, assetUrns = 
 };
 
 export const getLinkedInProfiles = async () => {
+  const cacheKey = 'linkedin_profiles_cache';
+  const cachedData = sessionStorage.getItem(cacheKey);
+
+  if (cachedData) {
+    try {
+      const profiles = JSON.parse(cachedData);
+      console.log('Returning cached LinkedIn profiles.');
+      return profiles;
+    } catch (e) {
+      console.error('Failed to parse cached LinkedIn profiles, fetching again.', e);
+      sessionStorage.removeItem(cacheKey);
+    }
+  }
+
+  console.log('Fetching fresh LinkedIn profiles from API.');
   const config = getLinkedinConfig();
   if (!config || !config.accessToken) {
     throw new Error('LinkedIn configuration or Access Token not found. Please connect first.');
@@ -263,7 +278,15 @@ export const getLinkedInProfiles = async () => {
     throw new Error(`Failed to fetch LinkedIn profiles via proxy: ${errorData.message || 'Unknown error'}`);
   }
 
-  return await response.json();
+  const profiles = await response.json();
+
+  try {
+    sessionStorage.setItem(cacheKey, JSON.stringify(profiles));
+  } catch (e) {
+    console.error('Failed to cache LinkedIn profiles.', e);
+  }
+
+  return profiles;
 };
 
 export const publishToLinkedIn = async (campaignData) => {


### PR DESCRIPTION
This commit includes two main fixes:

1.  **Allow Text-Only Scheduling:** The `handleScheduleLinkedIn` function in `Publisher.jsx` is updated to allow scheduling posts with no images. The previous implementation required at least one image, which was incorrect. This change aligns the scheduling feature with LinkedIn's ability to have text-only posts.

2.  **Fix Rate-Limiting Error:** A 429 "Too Many Requests" error was occurring when fetching the list of LinkedIn profiles to post as. This was caused by excessive API calls. The `getLinkedInProfiles` function in `linkedinAPI.js` has been updated to cache the profiles in `sessionStorage`. This prevents repeated API calls and resolves the rate-limiting issue. The cache is invalidated upon logout in `LinkedinAuthSetup.jsx`.