### PR TITLE
feat(scheduling): Implement weekly schedule selector

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -31,7 +31,7 @@ import {
 import { Language, Publish, LinkedIn } from '@mui/icons-material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DateTimePicker, DatePicker } from '@mui/x-date-pickers';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { ptBR } from 'date-fns/locale/pt-BR';
 import TimeHeatMap from './TimeHeatMap';
 import { publishToWordPress } from '../utils/wordpressAPI';
@@ -78,8 +78,8 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
 
   // New states for LinkedIn Publisher enhancements
   const [isScheduled, setIsScheduled] = useState(false);
-  const [scheduleDate, setScheduleDate] = useState(new Date(new Date().getTime() + 60 * 60 * 1000)); // Default to 1 hour from now
-  const [selectedTime, setSelectedTime] = useState(null);
+  const [scheduleDate, setScheduleDate] = useState(new Date(new Date().getTime() + 24 * 60 * 60 * 1000)); // Default to tomorrow
+  const [weeklySchedule, setWeeklySchedule] = useState({}); // { 0: '09:00', 1: '10:00', ... }
   const [selectedImages, setSelectedImages] = useState({}); // e.g. { 0: true, 1: false }
   const [selectedVideos, setSelectedVideos] = useState({});
   const [linkedinProfiles, setLinkedinProfiles] = useState([]);
@@ -236,10 +236,22 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
 
         setPublishingStatusLi('Criando planilha de controle no Google Drive...');
 
-        const headers = ['Data de Publicação', 'Author URN', 'Título', 'Conteúdo', 'Convite (CTA)', 'Hashtags', 'Imagens (IDs no Drive)', 'Video (ID no Drive)'];
+        const headers = ['Data', 'Horário', 'Author URN', 'Título', 'Conteúdo', 'Convite (CTA)', 'Hashtags', 'Imagens (IDs no Drive)', 'Video (ID no Drive)'];
+
+        const formatDate = (date) => date.toLocaleDateString('pt-BR');
+        const getScheduledTime = (date) => {
+            const dayIndex = date.getDay(); // 0 for Sunday, 1 for Monday, etc.
+            const time = weeklySchedule[dayIndex];
+            if (!time) {
+                console.warn(`Nenhum horário agendado para o dia ${dayIndex}. Usando 12:00 como padrão.`);
+                return '12:00';
+            }
+            return time;
+        };
 
         const mainPostRow = [
-            scheduleDate.toLocaleString('pt-BR'),
+            formatDate(scheduleDate),
+            getScheduledTime(scheduleDate),
             selectedProfile,
             campaignContent?.titulo || '',
             campaignContent?.conteudo || '',
@@ -257,7 +269,8 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
                 followupDate.setDate(scheduleDate.getDate() + index + 1);
 
                 const followupRow = [
-                    followupDate.toLocaleString('pt-BR'),
+                    formatDate(followupDate),
+                    getScheduledTime(followupDate),
                     selectedProfile,
                     post.tipo_gancho || '', // Usando tipo_gancho como título
                     post.conteudo || '',
@@ -470,36 +483,23 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
 
               {isScheduled && (
                 <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ptBR}>
-                  <Grid container spacing={2} sx={{ mt: 1 }}>
+                  <Grid container spacing={3} sx={{ mt: 1 }}>
                     <Grid item xs={12} md={4}>
-                      <DatePicker
-                        label="Data do Agendamento"
-                        value={scheduleDate}
-                        onChange={(newDate) => {
-                          const newScheduleDate = new Date(scheduleDate);
-                          newScheduleDate.setFullYear(newDate.getFullYear());
-                          newScheduleDate.setMonth(newDate.getMonth());
-                          newScheduleDate.setDate(newDate.getDate());
-                          setScheduleDate(newScheduleDate);
-                        }}
-                        renderInput={(params) => <TextField {...params} fullWidth />}
-                        minDate={new Date()}
-                      />
+                        <Typography variant="h6" gutterBottom>1. Data de Início da Campanha</Typography>
+                        <DatePicker
+                            label="Selecione a data inicial"
+                            value={scheduleDate}
+                            onChange={(newDate) => setScheduleDate(newDate)}
+                            renderInput={(params) => <TextField {...params} fullWidth />}
+                            minDate={new Date()}
+                        />
+                         <Typography variant="caption" display="block" sx={{ mt: 1 }}>
+                            Esta é a data do primeiro post. Os posts de follow-up serão agendados nos dias seguintes.
+                        </Typography>
                     </Grid>
                     <Grid item xs={12} md={8}>
-                        <Typography variant="subtitle2" gutterBottom>Selecione o Horário</Typography>
-                        <TimeHeatMap
-                            selectedDate={scheduleDate}
-                            selectedTime={selectedTime}
-                            onTimeSelect={(hour) => {
-                                setSelectedTime(hour);
-                                const newScheduleDate = new Date(scheduleDate);
-                                const [hours, minutes] = hour.split(':');
-                                newScheduleDate.setHours(parseInt(hours, 10));
-                                newScheduleDate.setMinutes(parseInt(minutes, 10));
-                                setScheduleDate(newScheduleDate);
-                            }}
-                        />
+                        <Typography variant="h6" gutterBottom>2. Horários da Semana</Typography>
+                        <TimeHeatMap onScheduleChange={setWeeklySchedule} />
                     </Grid>
                   </Grid>
                 </LocalizationProvider>

--- a/src/components/TimeHeatMap.jsx
+++ b/src/components/TimeHeatMap.jsx
@@ -1,113 +1,121 @@
-import React from 'react';
-import { Grid, Typography, ButtonBase } from '@mui/material';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
+import React, { useState, useEffect } from 'react';
+import { Grid, Typography, ButtonBase, Paper } from '@mui/material';
 
 const heatMapData = {
-  // Segunda, Terça, Quarta, Quinta, Sexta, Sábado, Domingo
-  '00:00': [0, 0, 0, 0, 0, 0, 0],
-  '01:00': [0, 0, 0, 0, 0, 0, 0],
-  '02:00': [0, 0, 0, 0, 0, 0, 0],
-  '03:00': [0, 0, 0, 0, 0, 0, 0],
-  '04:00': [0, 0, 0, 0, 0, 0, 0],
-  '05:00': [0, 0, 0, 0, 0, 0, 0],
-  '06:00': [0, 0, 0, 0, 0, 0, 0],
-  '07:00': [0, 0, 0, 0, 0, 0, 0],
-  '08:00': [0, 67, 67, 31, 0, 0, 0],
-  '09:00': [33, 100, 100, 65, 33, 0, 0],
-  '10:00': [26, 100, 100, 100, 0, 15, 9],
-  '11:00': [26, 100, 100, 100, 0, 15, 9],
-  '12:00': [26, 65, 65, 65, 0, 15, 9],
-  '13:00': [0, 31, 31, 31, 0, 0, 0],
-  '14:00': [33, 65, 65, 65, 33, 0, 0],
-  '15:00': [0, 0, 0, 0, 0, 0, 0],
-  '16:00': [0, 0, 0, 0, 0, 0, 0],
-  '17:00': [0, 0, 0, 0, 0, 0, 0],
-  '18:00': [0, 0, 0, 0, 0, 0, 0],
-  '19:00': [0, 0, 0, 0, 0, 0, 0],
-  '20:00': [0, 0, 0, 0, 0, 0, 0],
-  '21:00': [0, 0, 0, 0, 0, 0, 0],
-  '22:00': [0, 0, 0, 0, 0, 0, 0],
-  '23:00': [0, 0, 0, 0, 0, 0, 0],
+    // Data provided by user
+    '00:00': [0, 0, 0, 0, 0, 0, 0], '01:00': [0, 0, 0, 0, 0, 0, 0],
+    '02:00': [0, 0, 0, 0, 0, 0, 0], '03:00': [0, 0, 0, 0, 0, 0, 0],
+    '04:00': [0, 0, 0, 0, 0, 0, 0], '05:00': [0, 0, 0, 0, 0, 0, 0],
+    '06:00': [0, 0, 0, 0, 0, 0, 0], '07:00': [0, 0, 0, 0, 0, 0, 0],
+    '08:00': [0, 67, 67, 31, 0, 0, 0], '09:00': [33, 100, 100, 65, 33, 0, 0],
+    '10:00': [26, 100, 100, 100, 0, 15, 9], '11:00': [26, 100, 100, 100, 0, 15, 9],
+    '12:00': [26, 65, 65, 65, 0, 15, 9], '13:00': [0, 31, 31, 31, 0, 0, 0],
+    '14:00': [33, 65, 65, 65, 33, 0, 0], '15:00': [0, 0, 0, 0, 0, 0, 0],
+    '16:00': [0, 0, 0, 0, 0, 0, 0], '17:00': [0, 0, 0, 0, 0, 0, 0],
+    '18:00': [0, 0, 0, 0, 0, 0, 0], '19:00': [0, 0, 0, 0, 0, 0, 0],
+    '20:00': [0, 0, 0, 0, 0, 0, 0], '21:00': [0, 0, 0, 0, 0, 0, 0],
+    '22:00': [0, 0, 0, 0, 0, 0, 0], '23:00': [0, 0, 0, 0, 0, 0, 0],
 };
 
-const daysOfWeek = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
+// Days of week for display: Dom, Seg, Ter, Qua, Qui, Sex, Sab
+const displayDays = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
+// Mapping from JS getDay() index (0=Sun) to our display and data order.
+// Data order is Seg-Dom, so we map Sun to index 6.
+const dayIndexMapping = [6, 0, 1, 2, 3, 4, 5]; // getDay() index -> data index
+
 const hours = Object.keys(heatMapData);
 
 const getColor = (value) => {
-  if (value === 0) return '#f0f0f0'; // Light grey for 0
-  const intensity = value / 100;
-  const hue = 0; // Red
-  const saturation = 100;
-  const lightness = 100 - (50 * intensity); // from 100 (white) down to 50 (red)
-  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+    if (value === 0) return '#e0e0e0'; // A slightly darker grey for zero values
+    const intensity = value / 100;
+    // Using a blue color scale this time for variety
+    const h = 210; // Hue for blue
+    const s = 100; // Saturation
+    const l = 95 - (50 * intensity); // Lightness from 95% (very light blue) to 45% (deep blue)
+    return `hsl(${h}, ${s}%, ${l}%)`;
 };
 
-const TimeHeatMap = ({ selectedDate, selectedTime, onTimeSelect }) => {
-  const selectedDay = selectedDate ? selectedDate.getDay() : -1; // Domingo = 0, Segunda = 1, ...
+const TimeHeatMap = ({ onScheduleChange }) => {
+    // State to store the selected hour for each day of the week.
+    // Key is the JS getDay() index (0=Sun, 1=Mon, ...).
+    const [weeklySchedule, setWeeklySchedule] = useState({});
 
-  return (
-    <Grid container spacing={0.5}>
-      {/* Header Row */}
-      <Grid item xs={1.5} />
-      {daysOfWeek.map((day, index) => (
-        <Grid item xs={1.5} key={day} sx={{ textAlign: 'center' }}>
-          <Typography variant="caption" sx={{ fontWeight: selectedDay === index ? 'bold' : 'normal', color: selectedDay === index ? 'primary.main' : 'text.secondary' }}>
-            {day}
-          </Typography>
-        </Grid>
-      ))}
+    const handleTimeSelect = (dayIndex, hour) => {
+        const newSchedule = {
+            ...weeklySchedule,
+            [dayIndex]: hour,
+        };
+        setWeeklySchedule(newSchedule);
+        if (onScheduleChange) {
+            onScheduleChange(newSchedule);
+        }
+    };
 
-      {/* Data Rows */}
-      {hours.map((hour) => (
-        <React.Fragment key={hour}>
-          <Grid item xs={1.5} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            <Typography variant="caption">{hour}</Typography>
-          </Grid>
-          {daysOfWeek.map((day, dayIndex) => {
-            // Note: The provided data seems to be Monday-first, but getDay() is Sunday-first.
-            // Let's adjust the index to match the data.
-            // Data: Seg, Ter, Qua, Qui, Sex, Sab, Dom
-            // getDay(): Dom(0), Seg(1), Ter(2), Qua(3), Qui(4), Sex(5), Sab(6)
-            // Mapping: Dom -> 6, Seg -> 0, Ter -> 1, etc.
-            const dataDayIndex = (dayIndex === 0) ? 6 : dayIndex - 1;
-            const value = heatMapData[hour][dataDayIndex];
-            const isSelected = selectedTime === hour;
+    return (
+        <Paper elevation={2} sx={{ p: 2 }}>
+            <Typography variant="subtitle1" gutterBottom align="center">
+                Defina o horário de postagem para cada dia da semana
+            </Typography>
+            <Grid container spacing={0.5} sx={{ mt: 1 }}>
+                {/* Header Row */}
+                <Grid item xs={1.5} />
+                {displayDays.map((day) => (
+                    <Grid item xs={1.5} key={day} sx={{ textAlign: 'center' }}>
+                        <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+                            {day}
+                        </Typography>
+                    </Grid>
+                ))}
 
-            return (
-              <Grid item xs={1.5} key={`${day}-${hour}`}>
-                <ButtonBase
-                  onClick={() => onTimeSelect(hour)}
-                  sx={{
-                    width: '100%',
-                    height: '30px',
-                    backgroundColor: getColor(value),
-                    border: dayIndex === selectedDay ? '2px solid #1976d2' : '1px solid #ddd',
-                    borderRadius: '4px',
-                    opacity: value > 0 ? 1 : 0.5,
-                    boxSizing: 'border-box',
-                    ...(isSelected && {
-                      border: '3px solid #000',
-                      zIndex: 1
-                    }),
-                    '&:hover': {
-                      border: '2px solid #000',
-                      opacity: 1,
-                    },
-                  }}
-                  disabled={value === 0}
-                >
-                  <Typography variant="caption" sx={{ color: value > 50 ? 'white' : 'black', fontWeight: 'bold' }}>
-                    {value > 0 ? value : ''}
-                  </Typography>
-                </ButtonBase>
-              </Grid>
-            );
-          })}
-        </React.Fragment>
-      ))}
-    </Grid>
-  );
+                {/* Data Rows */}
+                {hours.map((hour) => (
+                    <React.Fragment key={hour}>
+                        <Grid item xs={1.5} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                            <Typography variant="caption">{hour}</Typography>
+                        </Grid>
+                        {displayDays.map((day, displayIndex) => {
+                            // displayIndex is 0 for Sun, 1 for Mon, etc.
+                            const dataIndex = dayIndexMapping[displayIndex];
+                            const value = heatMapData[hour][dataIndex];
+                            const isSelected = weeklySchedule[displayIndex] === hour;
+
+                            return (
+                                <Grid item xs={1.5} key={`${day}-${hour}`}>
+                                    <ButtonBase
+                                        onClick={() => handleTimeSelect(displayIndex, hour)}
+                                        sx={{
+                                            width: '100%',
+                                            height: '30px',
+                                            backgroundColor: getColor(value),
+                                            border: '1px solid #ccc',
+                                            borderRadius: '4px',
+                                            boxSizing: 'border-box',
+                                            ...(isSelected && {
+                                                border: '3px solid #0d47a1', // Dark blue border for selected
+                                                zIndex: 1,
+                                            }),
+                                            '&:hover': {
+                                                border: '2px solid #1565c0', // Medium blue on hover
+                                            },
+                                        }}
+                                    >
+                                        <Typography
+                                            variant="caption"
+                                            sx={{
+                                                color: value > 60 ? 'white' : 'black',
+                                                fontWeight: isSelected ? 'bold' : 'normal'
+                                            }}>
+                                            {value > 0 ? value : ''}
+                                        </Typography>
+                                    </ButtonBase>
+                                </Grid>
+                            );
+                        })}
+                    </React.Fragment>
+                ))}
+            </Grid>
+        </Paper>
+    );
 };
 
 export default TimeHeatMap;


### PR DESCRIPTION
I implemented a new scheduling system based on a weekly template.

- I replaced the date/time picker with a new `TimeHeatMap` component that allows you to define a posting time for each day of the week.
- I removed the restriction on selecting time slots with a score of zero.
- I updated the Google Sheets export to create separate "Data" and "Horário" columns.
- The time for each scheduled post is now determined by looking up the day of the week in your defined weekly schedule.