### PR TITLE
feat(scheduling): Add save/load and preview for scheduler

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -444,6 +444,11 @@ function App() {
   const [isGeneratingFollowup, setIsGeneratingFollowup] = useState(false);
   const [followupPostsQuantity, setFollowupPostsQuantity] = useState(5);
 
+  // Publisher State
+  const [isScheduled, setIsScheduled] = useState(false);
+  const [scheduleDate, setScheduleDate] = useState(new Date(new Date().getTime() + 24 * 60 * 60 * 1000)); // Default to tomorrow
+  const [weeklySchedule, setWeeklySchedule] = useState({}); // { 0: '09:00', 1: '10:00', ... }
+
 
   // Estados para a Geração com IA
   const [inputMethod, setInputMethod] = useState('csv');
@@ -900,6 +905,10 @@ function App() {
         conteudoPequeno: conteudoPequeno,
         conteudoFormatado: conteudoFormatado,
         followupPosts: followupPosts,
+        // Add scheduling state
+        isScheduled: isScheduled,
+        scheduleDate: scheduleDate,
+        weeklySchedule: weeklySchedule,
       };
 
       const jsonString = JSON.stringify(stateToSave, null, 2);
@@ -1131,6 +1140,17 @@ function App() {
               setFollowupPosts(loadedState.followupPosts || []);
             } else {
               setFollowupPosts([]);
+            }
+
+            // Restore scheduling state (add a version check if this feature is versioned)
+            if (loadedState.isScheduled !== undefined) {
+              setIsScheduled(loadedState.isScheduled);
+            }
+            if (loadedState.scheduleDate) {
+              setScheduleDate(new Date(loadedState.scheduleDate));
+            }
+            if (loadedState.weeklySchedule) {
+              setWeeklySchedule(loadedState.weeklySchedule);
             }
 
             // Navegação de passo
@@ -2873,6 +2893,12 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
               generatedImagesData={generatedImagesData}
               generatedVideosData={generatedVideosData}
               followupPosts={followupPosts}
+              isScheduled={isScheduled}
+              setIsScheduled={setIsScheduled}
+              scheduleDate={scheduleDate}
+              setScheduleDate={setScheduleDate}
+              weeklySchedule={weeklySchedule}
+              setWeeklySchedule={setWeeklySchedule}
             />
           )}
 

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -59,7 +59,19 @@ function TabPanel(props) {
   );
 }
 
-const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, generatedVideosData, followupPosts }) => {
+const Publisher = ({
+  campaignContent,
+  conteudoFormatado,
+  generatedImagesData,
+  generatedVideosData,
+  followupPosts,
+  isScheduled,
+  setIsScheduled,
+  scheduleDate,
+  setScheduleDate,
+  weeklySchedule,
+  setWeeklySchedule
+}) => {
   const [tabValue, setTabValue] = React.useState(0);
 
   const handleTabChange = (event, newValue) => {
@@ -76,10 +88,7 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
   const [publishingStatusLi, setPublishingStatusLi] = useState('');
   const [publishedPostUrlLi, setPublishedPostUrlLi] = useState(null);
 
-  // New states for LinkedIn Publisher enhancements
-  const [isScheduled, setIsScheduled] = useState(false);
-  const [scheduleDate, setScheduleDate] = useState(new Date(new Date().getTime() + 24 * 60 * 60 * 1000)); // Default to tomorrow
-  const [weeklySchedule, setWeeklySchedule] = useState({}); // { 0: '09:00', 1: '10:00', ... }
+  // Local states for Publisher component
   const [selectedImages, setSelectedImages] = useState({}); // e.g. { 0: true, 1: false }
   const [selectedVideos, setSelectedVideos] = useState({});
   const [linkedinProfiles, setLinkedinProfiles] = useState([]);
@@ -88,6 +97,37 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
   const [profileError, setProfileError] = useState('');
   const [unifiedMedia, setUnifiedMedia] = useState([]);
   const [previewedMedia, setPreviewedMedia] = useState(null);
+  const [schedulePreview, setSchedulePreview] = useState([]);
+
+  useEffect(() => {
+    if (!followupPosts || followupPosts.length === 0) {
+      setSchedulePreview([]);
+      return;
+    }
+
+    const daysOfWeek = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
+
+    const getScheduledTime = (date) => {
+      const dayIndex = date.getDay();
+      return weeklySchedule[dayIndex] || 'N/A';
+    };
+
+    const preview = followupPosts.map((post, index) => {
+      const postDate = new Date(scheduleDate);
+      postDate.setDate(postDate.getDate() + index + 1);
+
+      return {
+        key: `followup-${index}`,
+        date: postDate.toLocaleDateString('pt-BR'),
+        day: daysOfWeek[postDate.getDay()],
+        time: getScheduledTime(postDate),
+        title: post.tipo_gancho || `Follow-up ${index + 1}`
+      };
+    });
+
+    setSchedulePreview(preview);
+
+  }, [followupPosts, scheduleDate, weeklySchedule]);
 
   const formatBytes = (bytes, decimals = 2) => {
     if (bytes === 0) return '0 Bytes';
@@ -497,9 +537,32 @@ const Publisher = ({ campaignContent, conteudoFormatado, generatedImagesData, ge
                             Esta é a data do primeiro post. Os posts de follow-up serão agendados nos dias seguintes.
                         </Typography>
                     </Grid>
-                    <Grid item xs={12} md={8}>
+                    <Grid item xs={12} md={5}>
                         <Typography variant="h6" gutterBottom>2. Horários da Semana</Typography>
                         <TimeHeatMap onScheduleChange={setWeeklySchedule} />
+                    </Grid>
+                    <Grid item xs={12} md={3}>
+                        <Typography variant="h6" gutterBottom>3. Prévia do Agendamento</Typography>
+                        <Paper sx={{ p: 2, height: '100%', overflowY: 'auto' }}>
+                            {schedulePreview.length > 0 ? (
+                                <List dense>
+                                    {schedulePreview.map(item => (
+                                        <ListItem key={item.key} disablePadding sx={{ mb: 1 }}>
+                                            <ListItemText
+                                                primary={`${item.date} (${item.day}) às ${item.time}`}
+                                                secondary={item.title}
+                                                primaryTypographyProps={{ variant: 'body2', fontWeight: 'bold' }}
+                                                secondaryTypographyProps={{ variant: 'caption' }}
+                                            />
+                                        </ListItem>
+                                    ))}
+                                </List>
+                            ) : (
+                                <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', mt: 2 }}>
+                                    Nenhum post de follow-up para exibir.
+                                </Typography>
+                            )}
+                        </Paper>
                     </Grid>
                   </Grid>
                 </LocalizationProvider>


### PR DESCRIPTION
Implements Save and Load functionality for the LinkedIn scheduling settings.

- Lifts scheduling state (isScheduled, scheduleDate, weeklySchedule) to the main App component to allow it to be included in the project's save file.
- Adds a new schedule preview panel in the Publisher UI. This panel shows a list of upcoming follow-up posts with their calculated dates and times based on the user's settings.
- This enhances the scheduling feature by making it persistent and providing better user feedback.