### PR TITLE
fix(state): Persist publisher settings across sessions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -448,6 +448,9 @@ function App() {
   const [isScheduled, setIsScheduled] = useState(false);
   const [scheduleDate, setScheduleDate] = useState(new Date(new Date().getTime() + 24 * 60 * 60 * 1000)); // Default to tomorrow
   const [weeklySchedule, setWeeklySchedule] = useState({}); // { 0: '09:00', 1: '10:00', ... }
+  const [selectedProfile, setSelectedProfile] = useState('');
+  const [selectedImages, setSelectedImages] = useState({});
+  const [selectedVideos, setSelectedVideos] = useState({});
 
 
   // Estados para a Geração com IA
@@ -909,6 +912,10 @@ function App() {
         isScheduled: isScheduled,
         scheduleDate: scheduleDate,
         weeklySchedule: weeklySchedule,
+        // Add other publisher state
+        selectedProfile: selectedProfile,
+        selectedImages: selectedImages,
+        selectedVideos: selectedVideos,
       };
 
       const jsonString = JSON.stringify(stateToSave, null, 2);
@@ -1151,6 +1158,15 @@ function App() {
             }
             if (loadedState.weeklySchedule) {
               setWeeklySchedule(loadedState.weeklySchedule);
+            }
+            if (loadedState.selectedProfile) {
+              setSelectedProfile(loadedState.selectedProfile);
+            }
+            if (loadedState.selectedImages) {
+              setSelectedImages(loadedState.selectedImages);
+            }
+            if (loadedState.selectedVideos) {
+              setSelectedVideos(loadedState.selectedVideos);
             }
 
             // Navegação de passo
@@ -2899,6 +2915,12 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
               setScheduleDate={setScheduleDate}
               weeklySchedule={weeklySchedule}
               setWeeklySchedule={setWeeklySchedule}
+              selectedProfile={selectedProfile}
+              setSelectedProfile={setSelectedProfile}
+              selectedImages={selectedImages}
+              setSelectedImages={setSelectedImages}
+              selectedVideos={selectedVideos}
+              setSelectedVideos={setSelectedVideos}
             />
           )}
 

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -70,7 +70,13 @@ const Publisher = ({
   scheduleDate,
   setScheduleDate,
   weeklySchedule,
-  setWeeklySchedule
+  setWeeklySchedule,
+  selectedProfile,
+  setSelectedProfile,
+  selectedImages,
+  setSelectedImages,
+  selectedVideos,
+  setSelectedVideos
 }) => {
   const [tabValue, setTabValue] = React.useState(0);
 
@@ -89,10 +95,7 @@ const Publisher = ({
   const [publishedPostUrlLi, setPublishedPostUrlLi] = useState(null);
 
   // Local states for Publisher component
-  const [selectedImages, setSelectedImages] = useState({}); // e.g. { 0: true, 1: false }
-  const [selectedVideos, setSelectedVideos] = useState({});
   const [linkedinProfiles, setLinkedinProfiles] = useState([]);
-  const [selectedProfile, setSelectedProfile] = useState('');
   const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
   const [profileError, setProfileError] = useState('');
   const [unifiedMedia, setUnifiedMedia] = useState([]);


### PR DESCRIPTION
- Fixes a bug where settings in the "Publish" tab were lost when navigating between steps or reloading a project.
- Lifts all state related to the publisher (selected profile, selected media, and all schedule settings) from the `Publisher` component to the main `App` component.
- Updates the `handleSaveState` and `handleLoadStateFromFile` functions to include this state, ensuring it is correctly saved and loaded with the project.