### PR TITLE
fix(state): Correctly persist all publisher settings

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -175,20 +175,16 @@ const Publisher = ({
     fetchProfiles();
   }, []);
 
-  // Set default image selection when images are generated, only if no selection exists
+  // Effect to clear selection if media data is removed.
   useEffect(() => {
-    if (generatedImagesData && generatedImagesData.length > 0 && !Object.values(selectedImages).some(v => v)) {
-      setSelectedImages({ 0: true });
-    } else if (!generatedImagesData || generatedImagesData.length === 0) {
+    if (!generatedImagesData || generatedImagesData.length === 0) {
       setSelectedImages({});
     }
   }, [generatedImagesData]);
 
-  // Set default video selection when videos are generated, only if no selection exists
+  // Effect to clear selection if media data is removed.
   useEffect(() => {
-    if (generatedVideosData && generatedVideosData.length > 0 && !Object.values(selectedVideos).some(v => v)) {
-      setSelectedVideos({ 0: true });
-    } else if (!generatedVideosData || generatedVideosData.length === 0) {
+    if (!generatedVideosData || generatedVideosData.length === 0) {
       setSelectedVideos({});
     }
   }, [generatedVideosData]);


### PR DESCRIPTION
- Fixes a bug where settings in the "Publish" tab were being overwritten by component re-initialization logic.
- Ensures that all publisher-related state (profile, media selections, schedule settings) is lifted to the main App component.
- Updates the Save/Load functions in App.jsx to correctly handle all publisher state.
- Removes aggressive default-setting logic from `useEffect` hooks in `Publisher.jsx` to prevent overwriting loaded or user-selected state.