### PR TITLE
fix(state): Refactor TimeHeatMap to be a controlled component

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -568,7 +568,10 @@ const Publisher = ({
                     {/* Right Column */}
                     <Grid item xs={12} md={7}>
                         <Typography variant="h6" gutterBottom>2. Horários da Semana</Typography>
-                        <TimeHeatMap onScheduleChange={setWeeklySchedule} />
+                        <TimeHeatMap
+                            weeklySchedule={weeklySchedule}
+                            onScheduleChange={setWeeklySchedule}
+                        />
                     </Grid>
                   </Grid>
                 </LocalizationProvider>

--- a/src/components/TimeHeatMap.jsx
+++ b/src/components/TimeHeatMap.jsx
@@ -35,17 +35,12 @@ const getColor = (value) => {
     return `hsl(${h}, ${s}%, ${l}%)`;
 };
 
-const TimeHeatMap = ({ onScheduleChange }) => {
-    // State to store the selected hour for each day of the week.
-    // Key is the JS getDay() index (0=Sun, 1=Mon, ...).
-    const [weeklySchedule, setWeeklySchedule] = useState({});
-
+const TimeHeatMap = ({ weeklySchedule = {}, onScheduleChange }) => {
     const handleTimeSelect = (dayIndex, hour) => {
         const newSchedule = {
             ...weeklySchedule,
             [dayIndex]: hour,
         };
-        setWeeklySchedule(newSchedule);
         if (onScheduleChange) {
             onScheduleChange(newSchedule);
         }


### PR DESCRIPTION
- Fixes a bug where TimeHeatMap selections were lost on re-render.
- The TimeHeatMap component was incorrectly managing its own local state for the weekly schedule, causing it to ignore the state passed down from the parent App component.
- This has been fixed by refactoring TimeHeatMap into a fully controlled component that receives its state via props.
- This ensures that all publisher settings are now correctly persisted across navigation and save/load operations.