### PR TITLE
fix: Add missing useMemo import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useIsMobile } from './hooks/use-mobile.js';
 import { LinkedIn } from '@mui/icons-material';
 import {


### PR DESCRIPTION
This commit fixes a `ReferenceError: useMemo is not defined` by adding the missing `useMemo` import to the `react` import statement in `App.jsx`.