### PR TITLE
I've finished implementing the AI palette report modal. Here's what I…

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -38,6 +38,7 @@ import ColorThief from 'colorthief';
 
 import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
+import PaletteReportModal from './PaletteReportModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
 
 function TabPanel(props) {
@@ -89,6 +90,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   });
   const [isGenerating, setIsGenerating] = useState(false);
   const [generatedPalette, setGeneratedPalette] = useState(null);
+  const [showReportModal, setShowReportModal] = useState(false);
 
   const handleBriefingChange = (e) => {
     const { name, value } = e.target;
@@ -108,6 +110,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
       `;
       const result = await onGeneratePalette(fullBriefing.trim());
       setGeneratedPalette(result);
+      setShowReportModal(true); // Open the report modal
     } catch (error) {
       toast.error('Erro ao gerar paleta de cores. Tente novamente.');
       console.error("Error generating color palette:", error);
@@ -398,27 +401,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
               >
                 {isGenerating ? <CircularProgress size={24} /> : 'Gerar Paleta'}
               </Button>
-
-              {generatedPalette && (
-                <Card sx={{ mt: 3 }}>
-                  <CardContent>
-                    <Typography variant="h6" gutterBottom>Paleta Gerada ({generatedPalette.harmony})</Typography>
-                    {generatedPalette.palette.map((color, index) => (
-                      <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
-                        <Box sx={{ width: 40, height: 40, borderRadius: '50%', backgroundColor: color.hex, border: '1px solid #ddd' }} />
-                        <Box>
-                          <Typography variant="body1" sx={{ fontWeight: 'bold' }}>{color.name} ({color.role})</Typography>
-                          <Typography variant="body2" color="text.secondary">{color.hex} | {color.rgb}</Typography>
-                          <Typography variant="caption">{color.justification}</Typography>
-                        </Box>
-                      </Box>
-                    ))}
-                    <Button variant="outlined" sx={{ mt: 2 }} onClick={applyGeneratedPalette}>
-                      Aplicar Paleta
-                    </Button>
-                  </CardContent>
-                </Card>
-              )}
             </Box>
           </TabPanel>
         </DialogContent>
@@ -434,6 +416,13 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
         content={getCurrentContent()}
         onSave={handleSaveEditor}
         onClose={handleCloseEditor}
+      />
+
+      <PaletteReportModal
+        open={showReportModal}
+        onClose={() => setShowReportModal(false)}
+        paletteData={generatedPalette}
+        onApplyPalette={applyGeneratedPalette}
       />
     </>
   );

--- a/src/components/PaletteReportModal.jsx
+++ b/src/components/PaletteReportModal.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  IconButton,
+  Divider,
+  Grid,
+  Paper,
+} from '@mui/material';
+import { Close as CloseIcon, Print as PrintIcon } from '@mui/icons-material';
+import { toast } from 'sonner';
+
+const PaletteReportModal = ({ open, onClose, paletteData, onApplyPalette }) => {
+  const handlePrint = () => {
+    // Temporarily hide buttons for printing
+    const printSection = document.querySelector('.printable-section');
+    if (printSection) {
+      window.print();
+    } else {
+      toast.error('Não foi possível encontrar a seção para impressão.');
+    }
+  };
+
+  if (!paletteData) return null;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Memorial Descritivo da Paleta de Cores
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <style>
+          {`
+            @media print {
+              body * {
+                visibility: hidden;
+              }
+              .printable-section, .printable-section * {
+                visibility: visible;
+              }
+              .printable-section {
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 100%;
+              }
+              .no-print {
+                display: none;
+              }
+            }
+          `}
+        </style>
+        <Paper elevation={0} className="printable-section" sx={{ p: 4, fontFamily: 'serif' }}>
+          <Box sx={{ textAlign: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Georgia, serif', fontWeight: 'bold' }}>
+              Memorial Descritivo de Cores
+            </Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+              Análise e Justificativa da Paleta de Cores para a Campanha
+            </Typography>
+          </Box>
+
+          <Divider sx={{ my: 3 }} />
+
+          <Box sx={{ mb: 4 }}>
+            <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>1. Harmonia da Paleta</Typography>
+            <Typography variant="body1">
+              A harmonia de cores selecionada foi a <strong>{paletteData.harmony}</strong>. Esta escolha visa criar um equilíbrio visual coeso e psicologicamente alinhado aos objetivos do briefing.
+            </Typography>
+          </Box>
+
+          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>2. Detalhamento da Paleta</Typography>
+          <Grid container spacing={3}>
+            {paletteData.palette.map((color, index) => (
+              <Grid item xs={12} key={index}>
+                <Paper variant="outlined" sx={{ p: 2 }}>
+                  <Grid container spacing={2} alignItems="center">
+                    <Grid item xs={12} sm={2}>
+                      <Box sx={{ width: '100%', height: 80, borderRadius: 2, backgroundColor: color.hex }} />
+                    </Grid>
+                    <Grid item xs={12} sm={10}>
+                      <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>{index + 1}. {color.name}</Typography>
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                        <strong>Função:</strong> {color.role}
+                      </Typography>
+                      <Typography variant="body2" sx={{ fontStyle: 'italic', mb: 1 }}>
+                        {color.justification}
+                      </Typography>
+                      <Chip label={`HEX: ${color.hex}`} size="small" sx={{ mr: 1 }} />
+                      <Chip label={`RGB: ${color.rgb}`} size="small" />
+                    </Grid>
+                  </Grid>
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+        </Paper>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }} className="no-print">
+        <Button onClick={handlePrint} startIcon={<PrintIcon />}>
+          Imprimir
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            onApplyPalette();
+            onClose();
+          }}
+        >
+          Usar Esta Paleta
+        </Button>
+        <Button onClick={onClose}>Fechar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PaletteReportModal;


### PR DESCRIPTION
… did:

- I replaced the simple card display for the AI-generated color palette with a new, professional-looking 'Memorial Descritivo' (Descriptive Memorial) modal.
- I styled the new modal to look like a print preview, and it now contains a detailed breakdown of the generated color palette, including justifications and harmony techniques.
- I added 'Print', 'Use Palette', and 'Close' actions to the new modal.
- I also included specific print styles to ensure a clean printout of the report.