### PR TITLE
fix: Add missing Chip import to PaletteReportModal

### DIFF
--- a/src/components/PaletteReportModal.jsx
+++ b/src/components/PaletteReportModal.jsx
@@ -11,6 +11,7 @@ import {
   Divider,
   Grid,
   Paper,
+  Chip,
 } from '@mui/material';
 import { Close as CloseIcon, Print as PrintIcon } from '@mui/icons-material';
 import { toast } from 'sonner';


### PR DESCRIPTION
This commit fixes a `ReferenceError: Chip is not defined` by adding the missing `Chip` component to the import statement from `@mui/material` in the `PaletteReportModal.jsx` file.