### PR TITLE
fix: Correct dark mode styling in palette report

### DIFF
--- a/src/components/PaletteReportModal.jsx
+++ b/src/components/PaletteReportModal.jsx
@@ -75,7 +75,7 @@ const PaletteReportModal = ({ open, onClose, paletteData, onApplyPalette, briefi
             <Typography variant="body1" paragraph>
               A paleta de cores a seguir foi gerada com base nos seguintes parâmetros criativos fornecidos:
             </Typography>
-            <Paper variant="outlined" sx={{ p: 2, backgroundColor: '#f9f9f9' }}>
+            <Paper variant="outlined" sx={{ p: 2, backgroundColor: 'background.default' }}>
               <Typography variant="body2"><strong>Objetivo:</strong> {briefing.objective}</Typography>
               <Typography variant="body2"><strong>Público-alvo:</strong> {briefing.targetAudience}</Typography>
               <Typography variant="body2"><strong>Mensagem Principal:</strong> {briefing.mainMessage}</Typography>


### PR DESCRIPTION
- Replaces the hardcoded background color in the briefing section of the `PaletteReportModal` with a theme-aware value.
- This fixes a bug where the text was unreadable in dark mode due to having a light text color on a light background.