### PR TITLE
Fix: Correct circular dependency and state initialization order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -642,7 +642,7 @@ A resposta DEVE ser um único objeto JSON, sem nenhum texto ou formatação mark
     {
       label: 'Campanha',
       description: 'Criar o material de referência para a campanha.',
-      icon: Campaign,
+      icon: CampaignIcon,
     },
     {
       label: 'Conteúdo',


### PR DESCRIPTION
This commit addresses two issues:

1.  A `ReferenceError` in `App.jsx` caused by state variables being declared after hooks that depended on them. This was fixed by moving all `useState` declarations to the top of the `App` component.

2.  A subsequent `TypeError` in `Campaign.jsx` caused by a circular dependency. The `steps` array in `App.jsx` was using the `Campaign` component itself as an icon, which was then passed as a prop back to `Campaign`, causing the prop to be `undefined`. This was fixed by using the correct `CampaignIcon` from MUI.