### PR TITLE
Refatorar handleGenerateColorPalette para generationHandlers.js

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,6 +104,7 @@ import {
   generateFormattedContent,
   generateFollowupPosts,
   generateIAContent,
+  generateColorPalette,
 } from './utils/generationHandlers.js';
 import { saveCampaignState, loadCampaignState } from './utils/campaignState.js';
 import { exportCsv, exportHtml } from './utils/exportUtils.js';
@@ -309,62 +310,6 @@ function App() {
   const [includeEmpresa, setIncludeEmpresa] = useState(true);
   const [showSetupModal, setShowSetupModal] = useState(false);
   const [showCampaignStandardsModal, setShowCampaignStandardsModal] = useState(false);
-  const handleGenerateColorPalette = async (briefing) => {
-    const apiKey = getGeminiApiKey();
-    if (!apiKey) {
-      toast.error('Por favor, configure sua chave de API Gemini primeiro.');
-      throw new Error('Missing API Key');
-    }
-
-    const prompt = `Crie uma paleta harmoniosa de 5 cores baseada no briefing abaixo, aplicando princípios da psicologia das cores na cultura ocidental.
-
-**Briefing do Cliente:**
-${briefing}
-
-**Diretrizes de Psicologia das Cores (Cultura Ocidental):**
-- Considere estas associações-chave:
-  * **Vermelho:** Energia, paixão, urgência (comida, liquidações), perigo.
-  * **Azul:** Confiança, segurança, calma, profissionalismo (bancos, saúde, tech).
-  * **Verde:** Natureza, crescimento, sustentabilidade, saúde, tranquilidade.
-  * **Amarelo:** Otimismo, criatividade, atenção (uso moderado), cautela.
-  * **Roxo:** Luxo, criatividade, espiritualidade, realeza (beleza, artes).
-  * **Laranja:** Entusiasmo, jovialidade, acessibilidade (diversão, calls-to-action).
-  * **Rosa:** Feminilidade, ternura, compaixão (beleza, infantil).
-  * **Preto:** Sofisticação, poder, elegância (luxo, moda).
-  * **Branco:** Pureza, simplicidade, limpeza (saúde, minimalismo).
-  * **Cinza:** Neutralidade, equilíbrio, modernidade (tecnologia, corporativo).
-  * **Marrom:** Solidez, confiabilidade, natureza (orgânico, artesanal).
-- Tons **pastéis** transmitem suavidade; **vibrantes** geram impacto.
-- Evite combinações culturalmente negativas (ex: vermelho+puro preto = agressão/extremismo).
-
-**Formato de Saída OBRIGATÓRIO:**
-A resposta DEVE ser um único objeto JSON, sem nenhum texto ou formatação markdown (como \`\`\`json) antes ou depois. O JSON deve ter a seguinte estrutura:
-{
-  "palette": [
-    {
-      "hex": "#RRGGBB",
-      "rgb": "RGB(R, G, B)",
-      "name": "Nome da Cor",
-      "role": "Primária | Secundária | Acento | Neutro Claro | Neutro Escuro",
-      "justification": "Explicação psicológica em uma frase."
-    }
-  ],
-  "harmony": "Nome da Harmonia (Análoga, Complementar, Triádica, etc.)"
-}
-`;
-
-    try {
-      const response = await callGeminiApi(prompt, apiKey);
-      const jsonMatch = response.match(/\{[\s\S]*\}/);
-      if (jsonMatch && jsonMatch[0]) {
-        return JSON.parse(jsonMatch[0]);
-      }
-      throw new Error("Não foi possível extrair o JSON da resposta da IA.");
-    } catch (error) {
-      console.error("Erro ao gerar paleta de cores com IA:", error);
-      throw error;
-    }
-  };
 
   const saveStateToSessionStorage = useCallback(async () => {
     const blobToBase64 = (blob) => {
@@ -2055,7 +2000,16 @@ A resposta DEVE ser um único objeto JSON, sem nenhum texto ou formatação mark
           setShowCampaignStandardsModal(false);
           loadCampaignColors();
         }}
-        onGeneratePalette={handleGenerateColorPalette}
+        onGeneratePalette={async (briefing) => {
+          try {
+            const palette = await generateColorPalette(briefing);
+            return palette;
+          } catch (error) {
+            toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores.");
+            // Re-throw to be caught by the modal's internal state
+            throw error;
+          }
+        }}
       />
       <LoadingDialog
         open={isGeneratingCampaign || isSaving || isLoading}

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -281,3 +281,67 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
   console.log("Resposta da IA (Conteúdo):", iaResponseText);
   return iaResponseText;
 };
+
+/**
+ * Generates a color palette from a briefing using an AI API.
+ * @param {string} briefing - The user's briefing for the color palette.
+ * @returns {Promise<Object>} A promise that resolves to the generated palette object.
+ */
+export const generateColorPalette = async (briefing) => {
+  const apiKey = getGeminiApiKey();
+  if (!apiKey) {
+    // The original function used toast, but in a util file, it's better to throw.
+    // The calling component will be responsible for catching the error and showing a toast.
+    throw new Error('Por favor, configure sua chave de API Gemini primeiro.');
+  }
+
+  const prompt = `Crie uma paleta harmoniosa de 5 cores baseada no briefing abaixo, aplicando princípios da psicologia das cores na cultura ocidental.
+
+**Briefing do Cliente:**
+${briefing}
+
+**Diretrizes de Psicologia das Cores (Cultura Ocidental):**
+- Considere estas associações-chave:
+  * **Vermelho:** Energia, paixão, urgência (comida, liquidações), perigo.
+  * **Azul:** Confiança, segurança, calma, profissionalismo (bancos, saúde, tech).
+  * **Verde:** Natureza, crescimento, sustentabilidade, saúde, tranquilidade.
+  * **Amarelo:** Otimismo, criatividade, atenção (uso moderado), cautela.
+  * **Roxo:** Luxo, criatividade, espiritualidade, realeza (beleza, artes).
+  * **Laranja:** Entusiasmo, jovialidade, acessibilidade (diversão, calls-to-action).
+  * **Rosa:** Feminilidade, ternura, compaixão (beleza, infantil).
+  * **Preto:** Sofisticação, poder, elegância (luxo, moda).
+  * **Branco:** Pureza, simplicidade, limpeza (saúde, minimalismo).
+  * **Cinza:** Neutralidade, equilíbrio, modernidade (tecnologia, corporativo).
+  * **Marrom:** Solidez, confiabilidade, natureza (orgânico, artesanal).
+- Tons **pastéis** transmitem suavidade; **vibrantes** geram impacto.
+- Evite combinações culturalmente negativas (ex: vermelho+puro preto = agressão/extremismo).
+
+**Formato de Saída OBRIGATÓRIO:**
+A resposta DEVE ser um único objeto JSON, sem nenhum texto ou formatação markdown (como \`\`\`json) antes ou depois. O JSON deve ter a seguinte estrutura:
+{
+  "palette": [
+    {
+      "hex": "#RRGGBB",
+      "rgb": "RGB(R, G, B)",
+      "name": "Nome da Cor",
+      "role": "Primária | Secundária | Acento | Neutro Claro | Neutro Escuro",
+      "justification": "Explicação psicológica em uma frase."
+    }
+  ],
+  "harmony": "Nome da Harmonia (Análoga, Complementar, Triádica, etc.)"
+}
+`;
+
+  try {
+    const response = await callGeminiApi(prompt, apiKey);
+    const jsonMatch = response.match(/\{[\s\S]*\}/);
+    if (jsonMatch && jsonMatch[0]) {
+      return JSON.parse(jsonMatch[0]);
+    }
+    throw new Error("Não foi possível extrair o JSON da resposta da IA.");
+  } catch (error) {
+    console.error("Erro ao gerar paleta de cores com IA:", error);
+    // Re-throw the error to be handled by the calling component
+    throw error;
+  }
+};


### PR DESCRIPTION
- Move a função handleGenerateColorPalette de App.jsx para src/utils/generationHandlers.js e a renomeia para generateColorPalette.
- Atualiza App.jsx para importar e usar a nova função, mantendo o tratamento de erros no componente.
- Esta alteração melhora a separação de responsabilidades, movendo a lógica de geração de API para o módulo de handlers apropriado.