### PR TITLE
Fix: Corrige o cálculo da coordenada X para alinhamento de texto no c…

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -350,15 +350,15 @@ const ImageGeneratorFrontendOnly = ({
             } else {
               // Renderização de texto simples linha por linha (comportamento original)
               for (const line of lines) {
-                let currentLineRenderX = textContentStartX;
-                const textMetrics = ctx.measureText(line);
-                const currentTextWidth = textMetrics.width;
+                let currentLineRenderX;
 
                 // Ajuste de alinhamento horizontal
                 if (style.textAlign === 'center') {
-                  currentLineRenderX += (effectiveTextWidth - currentTextWidth) / 2;
+                  currentLineRenderX = textContentStartX + effectiveTextWidth / 2;
                 } else if (style.textAlign === 'right') {
-                  currentLineRenderX += effectiveTextWidth - currentTextWidth;
+                  currentLineRenderX = textContentStartX + effectiveTextWidth;
+                } else {
+                  currentLineRenderX = textContentStartX;
                 }
 
                 const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
@@ -650,14 +650,14 @@ const ImageGeneratorFrontendOnly = ({
           await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, { ...style, fontSize: fontSize }, effectiveTextWidth, effectiveTextHeight);
         } else {
           for (const line of lines) {
-            let currentLineRenderX = textContentStartX;
-            const textMetrics = ctx.measureText(line);
-            const currentTextWidth = textMetrics.width;
+            let currentLineRenderX;
 
             if (style.textAlign === 'center') {
-              currentLineRenderX += (effectiveTextWidth - currentTextWidth) / 2;
+              currentLineRenderX = textContentStartX + effectiveTextWidth / 2;
             } else if (style.textAlign === 'right') {
-              currentLineRenderX += effectiveTextWidth - currentTextWidth;
+              currentLineRenderX = textContentStartX + effectiveTextWidth;
+            } else {
+              currentLineRenderX = textContentStartX;
             }
             
             const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);


### PR DESCRIPTION
…anvas.

Ajusta a lógica de cálculo da posição X para texto simples nas funções `generateImages` e `regenerateSingleImage` em `ImageGeneratorFrontendOnly.jsx`. A nova lógica usa o ponto central da área de texto para `textAlign: 'center'`, garantindo que o alinhamento na imagem gerada corresponda à pré-visualização.