### PR TITLE
Fix: Corrige o cálculo de largura no modo 'Auto Organizar'.

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -350,8 +350,12 @@ const FieldPositioner = ({
 
     // Rule for Side Label Field (Bottom-Right Corner)
     if (sideLabelField) {
+      const sideLabelStyle = newStyles[sideLabelField] || COMPLETE_DEFAULT_STYLE_FOR_FIELD_POSITIONER;
+      const fontSizePx = sideLabelStyle.fontSize || 24;
+      const labelWidthPercent = (fontSizePx / (originalImageSize?.width || imageSize.width || 1)) * 100;
+
       const labelHeight = safeZone.height * 0.7; // 70% of safe zone height
-      const labelWidth = labelHeight * 0.5; // Width is 50% of the height
+      const labelWidth = labelWidthPercent; // Use the calculated width
 
       const centerX = (safeZone.x + safeZone.width - labelHeight / 2) - innerMargin;
       const centerY = (safeZone.y + safeZone.height - labelWidth / 2) - innerMargin;


### PR DESCRIPTION
A função `autoArrangeFields` em `FieldPositioner.jsx` foi alterada para que a largura do terceiro campo (rótulo lateral) seja calculada com base na altura da fonte. Isso garante que o campo tenha as proporções corretas quando rotacionado.