### PR TITLE
Fix(TextBox): Correctly apply center alignment to rendered HTML

### DIFF
--- a/src/components/HtmlTextBox.jsx
+++ b/src/components/HtmlTextBox.jsx
@@ -69,7 +69,8 @@ const HtmlTextBox = ({
           height: '100%',
           overflow: 'hidden',
           wordWrap: 'break-word',
-          pointerEvents: 'none'
+        pointerEvents: 'none',
+        textAlign: style.textAlign || 'left',
         }}
       />
     );


### PR DESCRIPTION
The `HtmlTextBox` component was not applying the `textAlign` style to the inner `div` that renders the HTML content using `dangerouslySetInnerHTML`.

This caused text with `textAlign: 'center'` to appear left-aligned when it had multiple lines in the rendered view, even though it looked correct in the editor's `<textarea>`.

The fix applies the `textAlign` style directly to the inner `div`, ensuring that the alignment is correctly inherited by the rendered HTML content.