### PR TITLE
debug: Adiciona log para resposta da IA

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -142,6 +142,7 @@ Retorne apenas o objeto JSON sem texto adicional, markdown, ou qualquer outra fo
 
     try {
       const response = await callGeminiApi(prompt, apiKey);
+      toast.info(`Resposta da IA (copie e cole para o dev): ${response}`);
       // Clean the response to ensure it's valid JSON
       const cleanedResponse = response.replace(/```json/g, '').replace(/```/g, '').trim();
       const generatedPersona = JSON.parse(cleanedResponse);


### PR DESCRIPTION
Este commit adiciona uma notificação (toast) temporária para exibir a resposta bruta da IA ao gerar uma persona.

O objetivo é depurar um problema onde os campos do formulário não estão sendo preenchidos após a geração com IA. A exibição da resposta permitirá verificar o formato dos dados retornados e ajustar a lógica de parsing, se necessário.

Esta alteração é temporária e será removida assim que o bug for resolvido.