### PR TITLE
feat: Improve Campaign Standards and Persona Wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "date-fns": "^4.1.0",
         "file-saver": "^2.0.5",
         "gapi-script": "^1.2.0",
+        "html-react-parser": "^5.2.6",
         "html2canvas": "^1.4.1",
         "jose": "^6.0.12",
         "jszip": "^3.10.1",
@@ -3959,6 +3960,73 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3980,6 +4048,18 @@
       "integrity": "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5030,6 +5110,37 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
+      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.6.tgz",
+      "integrity": "sha512-qcpPWLaSvqXi+TndiHbCa+z8qt0tVzjMwFGFBAa41ggC+ZA5BHaMIeMJla9g3VSp4SmiZb9qyQbmbpHYpIfPOg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.1",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.17"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -5041,6 +5152,25 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/ieee754": {
@@ -5122,6 +5252,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6487,6 +6623,12 @@
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -7349,6 +7491,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/stylis": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "date-fns": "^4.1.0",
     "file-saver": "^2.0.5",
     "gapi-script": "^1.2.0",
+    "html-react-parser": "^5.2.6",
     "html2canvas": "^1.4.1",
     "jose": "^6.0.12",
     "jszip": "^3.10.1",

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useIsMobile } from '../hooks/use-mobile';
 import {
   Dialog,
   DialogTitle,
@@ -113,6 +114,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [showPersonaGenModal, setShowPersonaGenModal] = useState(false);
   const [showPersonaWizard, setShowPersonaWizard] = useState(false);
   const [showMemorialModal, setShowMemorialModal] = useState(false);
+  const isMobile = useIsMobile();
 
   const handleBriefingChange = (e) => {
     const { name, value } = e.target;
@@ -376,7 +378,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <Box>
                 Padrões de Campanha
@@ -428,7 +430,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                     startIcon={<Add />}
                     onClick={() => setShowPersonaWizard(true)}
                 >
-                    Criar Nova Persona
+                    Assistente de Criação de Persona
                 </Button>
             </Box>
             <Grid container spacing={3}>
@@ -785,6 +787,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
       <PersonaWizard
         open={showPersonaWizard}
         onClose={() => setShowPersonaWizard(false)}
+        persona={persona}
         onSave={(newPersona) => {
             setPersona(newPersona);
             setShowPersonaWizard(false);
@@ -797,7 +800,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
       <MemorialDescritivoModal
         open={showMemorialModal}
         onClose={() => setShowMemorialModal(false)}
-        personas={[{ id: 1, nome: persona.nome || 'Persona Atual' }]} // Placeholder
+        campaignData={{ persona, autor, instrucoes, formato, colors }}
       />
     </>
   );

--- a/src/components/MemorialDescritivoModal.jsx
+++ b/src/components/MemorialDescritivoModal.jsx
@@ -1,94 +1,201 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
   Button,
-  TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
+  Box,
+  Typography,
+  IconButton,
+  Divider,
+  Grid,
+  Paper,
+  Chip,
 } from '@mui/material';
+import { Close as CloseIcon, Print as PrintIcon } from '@mui/icons-material';
+import { toast } from 'sonner';
+import { useIsMobile } from '../hooks/use-mobile';
+import parse from 'html-react-parser';
 
-const MemorialDescritivoModal = ({ open, onClose, personas }) => {
-  const [selectedPersona, setSelectedPersona] = useState('');
-  const [autor, setAutor] = useState('');
-  const [formato, setFormato] = useState('');
-  const [tonalidade, setTonalidade] = useState('');
-  const [cores, setCores] = useState('');
 
-  const handleGenerate = () => {
-    // TODO: Implementar a lógica de geração do memorial
-    console.log({
-      selectedPersona,
-      autor,
-      formato,
-      tonalidade,
-      cores,
-    });
-    onClose();
+const Section = ({ title, children, subtitle }) => (
+    <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>
+            {title}
+        </Typography>
+        {subtitle && <Typography variant="subtitle2" color="text.secondary" sx={{ mt: -1, mb: 2 }}>{subtitle}</Typography>}
+        <Paper variant="outlined" sx={{ p: 3, backgroundColor: '#f9f9f9' }}>
+            {children}
+        </Paper>
+    </Box>
+);
+
+const Field = ({ label, value, explanation }) => (
+    <Box sx={{ mb: 2 }}>
+        <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>{label}</Typography>
+        {explanation && <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>{explanation}</Typography>}
+        <Box sx={{ mt: 1, p: 1.5, borderRadius: 1, border: '1px solid #eee' }}>
+            {typeof value === 'string' && value.startsWith('<') ? parse(value) : <Typography variant="body2">{value || 'Não definido'}</Typography>}
+        </Box>
+    </Box>
+);
+
+const MemorialDescritivoModal = ({ open, onClose, campaignData }) => {
+  const isMobile = useIsMobile();
+
+  const handlePrint = () => {
+    const printSection = document.querySelector('.printable-section');
+    if (printSection) {
+      const parent = printSection.parentElement;
+      parent.style.overflow = 'visible'; // Needed for printing dialog content
+      window.print();
+      parent.style.overflow = 'auto';
+    } else {
+      toast.error('Não foi possível encontrar a seção para impressão.');
+    }
   };
 
+
+  if (!campaignData) return null;
+
+  const { persona = {}, autor = '', formato = '', instrucoes = '', colors = [] } = campaignData;
+
+  const renderPersonaField = (label, value, explanation) => {
+    let displayValue = 'Não definido';
+    if (Array.isArray(value) && value.length > 0) {
+      displayValue = value.join(', ');
+    } else if (typeof value === 'string' && value) {
+      displayValue = value;
+    }
+
+    return <Field label={label} value={displayValue} explanation={explanation} />;
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>Gerar Memorial Descritivo</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
-        <FormControl fullWidth>
-          <InputLabel>Selecionar Persona</InputLabel>
-          <Select
-            value={selectedPersona}
-            label="Selecionar Persona"
-            onChange={(e) => setSelectedPersona(e.target.value)}
-          >
-            {personas.map((persona) => (
-              <MenuItem key={persona.id} value={persona.id}>
-                {persona.nome}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <TextField
-          label="Autor da Mensagem"
-          value={autor}
-          onChange={(e) => setAutor(e.target.value)}
-          fullWidth
-        />
-        <FormControl fullWidth>
-          <InputLabel>Formato da Mensagem</InputLabel>
-          <Select
-            value={formato}
-            label="Formato da Mensagem"
-            onChange={(e) => setFormato(e.target.value)}
-          >
-            <MenuItem value="Email de Vendas">Email de Vendas</MenuItem>
-            <MenuItem value="Post de LinkedIn">Post de LinkedIn</MenuItem>
-            <MenuItem value="Anúncio Digital">Anúncio Digital</MenuItem>
-            <MenuItem value="Whitepaper">Whitepaper</MenuItem>
-          </Select>
-        </FormControl>
-        <TextField
-          label="Instruções de Tonalidade"
-          value={tonalidade}
-          onChange={(e) => setTonalidade(e.target.value)}
-          fullWidth
-          multiline
-          rows={3}
-        />
-        <TextField
-          label="Paleta de Cores (códigos hex)"
-          value={cores}
-          onChange={(e) => setCores(e.target.value)}
-          fullWidth
-          placeholder="#FFFFFF, #000000, #FF0000"
-        />
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Memorial Descritivo da Campanha
+        <IconButton onClick={onClose} className="no-print">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers className="printable-section">
+        <style>
+          {`
+            @media print {
+              body * {
+                visibility: hidden;
+              }
+              .printable-section, .printable-section * {
+                visibility: visible;
+              }
+              .printable-section {
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 100%;
+                overflow: visible !important;
+              }
+              .no-print {
+                display: none;
+              }
+               .MuiPaper-outlined {
+                border: 1px solid #ddd;
+              }
+            }
+          `}
+        </style>
+        <Paper elevation={0} sx={{ p: { xs: 2, sm: 4 }, fontFamily: 'serif' }}>
+          {/* 1. Título e Introdução */}
+          <Box sx={{ textAlign: 'center', mb: 4 }}>
+            <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Georgia, serif', fontWeight: 'bold' }}>
+              Memorial Descritivo de Campanha
+            </Typography>
+            <Typography variant="subtitle1" color="text.secondary">
+              Este documento detalha os pilares estratégicos e criativos que orientarão a criação de conteúdo para a campanha.
+            </Typography>
+          </Box>
+
+          <Divider sx={{ my: 3 }} />
+
+          {/* 2. Introdução */}
+          <Box sx={{ mb: 4 }}>
+            <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>1. Introdução</Typography>
+            <Typography variant="body1" paragraph>
+              O objetivo deste memorial é estabelecer um conjunto claro de diretrizes para garantir consistência, relevância e eficácia em todas as peças de conteúdo produzidas. A seguir, detalhamos a persona, a voz da marca, os formatos de conteúdo e as instruções criativas.
+            </Typography>
+          </Box>
+
+          {/* 3. Desenvolvimento */}
+          <Typography variant="h5" component="h2" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>2. Desenvolvimento</Typography>
+
+          <Section title="2.1. Persona" subtitle="O perfil de cliente ideal que queremos alcançar.">
+            {renderPersonaField("Nome", persona.nome, "A identificação clara e concisa do perfil.")}
+            {renderPersonaField("Posição/Cargo", persona.posicaoCargo, "A função formal da persona na empresa.")}
+            {renderPersonaField("Segmento da Empresa", persona.segmentoEmpresa, "A indústria ou setor de atuação da empresa.")}
+            {renderPersonaField("Responsabilidades-Chave", persona.responsabilidadesChave, "As principais tarefas e áreas de atuação da persona.")}
+
+            <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 3, mb: 1 }}>Dores e Desafios</Typography>
+            {renderPersonaField("Estratégicos", persona.doresEstrategicos, "Problemas relacionados ao crescimento, concorrência e visão de longo prazo.")}
+            {renderPersonaField("Operacionais", persona.doresOperacionais, "Obstáculos do dia a dia, como sistemas legados, custos e segurança.")}
+            {renderPersonaField("Pessoas e Cultura", persona.doresPessoas, "Desafios com retenção de talentos, alinhamento de equipes e cultura organizacional.")}
+            {renderPersonaField("Regulatórios e Métricas", persona.doresRegulatorios, "Questões de compliance, medição de ROI e prioridades conflitantes.")}
+
+            <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold', mt: 3, mb: 1 }}>Gatilhos e Barreiras</Typography>
+            {renderPersonaField("Gatilhos de Compra", persona.gatilhosCompra, "Os fatores que levam a persona a procurar ativamente por uma solução.")}
+            {renderPersonaField("Barreiras de Adoção", persona.barreirasAdocao, "Os obstáculos que podem impedir ou atrasar a decisão de compra.")}
+
+            <Field label="Mentalidade e Valores" value={persona.mentalidadeValores || ''} explanation="A forma de pensar, os valores e a atitude da persona." />
+            <Field label="Contexto Cultural" value={persona.contextoCultural || ''} explanation="O ambiente de trabalho e a cultura organizacional em que a persona está inserida." />
+          </Section>
+
+          <Section title="2.2. Autor (Voz da Marca)" subtitle="O tom, estilo e perspectiva que a marca usará.">
+             <Box sx={{ mt: 1 }}>
+                {autor ? parse(autor) : <Typography variant="body2">Não definido</Typography>}
+             </Box>
+          </Section>
+
+          <Section title="2.3. Formato do Conteúdo" subtitle="A estrutura e o layout das peças de conteúdo.">
+             <Box sx={{ mt: 1 }}>
+                {formato ? parse(formato) : <Typography variant="body2">Não definido</Typography>}
+             </Box>
+          </Section>
+
+          <Section title="2.4. Instruções Criativas" subtitle="Diretrizes detalhadas para a criação do conteúdo.">
+             <Box sx={{ mt: 1 }}>
+                {instrucoes ? parse(instrucoes) : <Typography variant="body2">Não definido</Typography>}
+             </Box>
+          </Section>
+
+          <Section title="2.5. Paleta de Cores" subtitle="As cores que definem a identidade visual da campanha.">
+            <Grid container spacing={2}>
+              {colors.length > 0 ? colors.map((color, index) => (
+                <Grid item xs={12} sm={6} md={4} key={index}>
+                  <Paper variant="outlined" sx={{ p: 2, textAlign: 'center' }}>
+                    <Box sx={{ width: '100%', height: 80, borderRadius: 2, backgroundColor: color, mb: 1, border: '1px solid #ddd' }} />
+                    <Typography variant="body2" sx={{ fontWeight: 'bold' }}>{color}</Typography>
+                  </Paper>
+                </Grid>
+              )) : <Typography variant="body2">Nenhuma cor definida.</Typography>}
+            </Grid>
+          </Section>
+
+          {/* 4. Conclusão */}
+           <Box sx={{ mt: 5 }}>
+            <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>3. Conclusão</Typography>
+            <Typography variant="body1" paragraph>
+              Este memorial serve como um guia fundamental para a criação de conteúdo coeso e impactante. A aderência a estas diretrizes garantirá que a comunicação da campanha seja consistente com a identidade da marca e ressoe de forma eficaz com a persona definida.
+            </Typography>
+          </Box>
+
+        </Paper>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={handleGenerate} variant="contained">
-          Gerar
+      <DialogActions sx={{ p: 2 }} className="no-print">
+        <Button onClick={handlePrint} startIcon={<PrintIcon />}>
+          Imprimir / Salvar PDF
         </Button>
+        <Button onClick={onClose}>Fechar</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useIsMobile } from '../hooks/use-mobile';
 import {
   Dialog,
   DialogTitle,
@@ -57,23 +58,31 @@ const steps = [
   'Mentalidade e Cultura',
 ];
 
-const PersonaWizard = ({ open, onClose, onSave, onGenerate, isGeneratingPersona }) => {
+const PersonaWizard = ({ open, onClose, onSave, onGenerate, isGeneratingPersona, persona }) => {
+  const isMobile = useIsMobile();
   const [activeStep, setActiveStep] = useState(0);
-  const [personaData, setPersonaData] = useState({
-      description: '',
-      nome: '',
-      posicaoCargo: [],
-      segmentoEmpresa: [],
-      responsabilidadesChave: [],
-      doresEstrategicos: [],
-      doresOperacionais: [],
-      doresPessoas: [],
-      doresRegulatorios: [],
-      gatilhosCompra: [],
-      barreirasAdocao: [],
-      mentalidadeValores: '',
-      contextoCultural: '',
-  });
+  const [personaData, setPersonaData] = useState(persona || {});
+
+  useEffect(() => {
+    if (open) {
+      setPersonaData(persona || {
+          description: '',
+          nome: '',
+          posicaoCargo: [],
+          segmentoEmpresa: [],
+          responsabilidadesChave: [],
+          doresEstrategicos: [],
+          doresOperacionais: [],
+          doresPessoas: [],
+          doresRegulatorios: [],
+          gatilhosCompra: [],
+          barreirasAdocao: [],
+          mentalidadeValores: '',
+          contextoCultural: '',
+      });
+      setActiveStep(0); // Reset to first step when modal opens
+    }
+  }, [open, persona]);
 
   const handleNext = () => {
     if (activeStep === 0) { // Step "Início Rápido com IA"
@@ -331,9 +340,9 @@ const PersonaWizard = ({ open, onClose, onSave, onGenerate, isGeneratingPersona 
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
       <DialogTitle>
-        Criar Nova Persona
+        Assistente de Criação de Persona
         <Typography variant="body2">Passo {activeStep + 1} de {steps.length}</Typography>
       </DialogTitle>
       <DialogContent sx={{ minHeight: '50vh' }}>


### PR DESCRIPTION
This commit introduces several enhancements to the Campaign Standards and Persona creation features:

1.  **Responsive UI**: The Campaign Standards, Persona Wizard, and new Memorial Descritivo modals are now full-screen on mobile devices for improved usability.

2.  **Persona Wizard as Assistant**: The "Criar Nova Persona" button and dialog title have been renamed to "Assistente de Criação de Persona". The wizard is now capable of editing the existing persona, aligning with the workflow of managing a single campaign persona.

3.  **Memorial Descritivo Report**: The "Gerar Memorial Descritivo" button now generates a comprehensive report in a modal. This report details all aspects of the campaign standards—Persona, Autor, Formato, Instruções, and Cores—with explanations for each field. It also includes a print-to-PDF function.