### PR TITLE
fix: Handle undefined properties in PersonaWizard

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -330,10 +330,10 @@ const PersonaWizard = ({ open, onClose, onSave, onGenerate, isGeneratingPersona,
   };
 
   const isNextDisabled = () => {
-    if (activeStep === 0 && !personaData.description.trim()) {
+    if (activeStep === 0 && !(personaData.description || '').trim()) {
         return true;
     }
-    if (activeStep === 1 && !personaData.nome.trim()) {
+    if (activeStep === 1 && !(personaData.nome || '').trim()) {
         return true;
     }
     return false;


### PR DESCRIPTION
This commit fixes a runtime error in the `PersonaWizard` component. The `isNextDisabled` function was attempting to call `.trim()` on `personaData.description` and `personaData.nome`, which could be `undefined` when creating a new persona, causing a TypeError.

The fix ensures that these properties are treated as empty strings if they are undefined, preventing the crash.