### PR TITLE
fix: Correct text color in Memorial Descritivo for dark mode

### DIFF
--- a/src/components/MemorialDescritivoModal.jsx
+++ b/src/components/MemorialDescritivoModal.jsx
@@ -25,7 +25,7 @@ const Section = ({ title, children, subtitle }) => (
             {title}
         </Typography>
         {subtitle && <Typography variant="subtitle2" color="text.secondary" sx={{ mt: -1, mb: 2 }}>{subtitle}</Typography>}
-        <Paper variant="outlined" sx={{ p: 3, backgroundColor: '#f9f9f9' }}>
+        <Paper variant="outlined" sx={{ p: 3, backgroundColor: '#f9f9f9', color: 'black' }}>
             {children}
         </Paper>
     </Box>


### PR DESCRIPTION
This commit fixes a readability issue in the 'Memorial Descritivo' modal when using dark mode. The text color was inheriting the theme's light color, making it invisible against the modal's light-colored background sections.

The fix explicitly sets the text color to black within these sections, ensuring the report is always readable regardless of the selected theme.