### PR TITLE
feat(responsive): Make sidebar and main content responsive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,7 @@ function App() {
     return savedMode ? JSON.parse(savedMode) : window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const isMobile = useIsMobile();
   const [csvData, setCsvData] = useState([]);
   const [csvHeaders, setCsvHeaders] = useState([]);
   const [backgroundImage, setBackgroundImage] = useState(null);
@@ -184,7 +185,6 @@ function App() {
   const [generatedImagesData, setGeneratedImagesData] = useState([]);
   const [generatedAudioData, setGeneratedAudioData] = useState([]);
   const [generatedVideosData, setGeneratedVideosData] = useState([]);
-  const isMobile = useIsMobile();
   const [anchorElMenu, setAnchorElMenu] = useState(null);
   const [isDraggingOverImage, setIsDraggingOverImage] = useState(false);
   const [selectedField, setSelectedField] = useState(null);
@@ -410,6 +410,12 @@ function App() {
       document.documentElement.classList.remove('dark-mode-active');
     }
   }, [darkMode]);
+
+  useEffect(() => {
+    if (isMobile) {
+      setSidebarOpen(false);
+    }
+  }, [isMobile]);
 
   useEffect(() => {
     const { persona: personaData, autor, instrucoes, formato, aspectRatio } = getCampaignPrompt();
@@ -842,6 +848,13 @@ function App() {
     setAnchorElMenu(null);
   };
 
+  const handleSidebarStepClick = (index) => {
+    setActiveStep(index);
+    if (isMobile) {
+      setSidebarOpen(false);
+    }
+  };
+
   const handleLoadTemplateClick = () => {
     handleMenuClose();
     // Acionar o clique no input de arquivo escondido
@@ -1126,6 +1139,7 @@ function App() {
           csvHeaders={csvHeaders}
           loadStateInputRef={loadStateInputRef}
           handleLoadStateFromFile={handleLoadStateFromFile}
+          onMenuClick={() => setSidebarOpen(!sidebarOpen)}
         />
 
         <Sidebar
@@ -1139,38 +1153,49 @@ function App() {
           visibleFields={visibleFields}
           totalFields={totalFields}
           styledFields={styledFields}
+          variant={isMobile ? 'temporary' : 'persistent'}
+          onClose={() => setSidebarOpen(false)}
+          onStepClick={handleSidebarStepClick}
         />
 
-        <Fab
-          size="small"
-          onClick={() => setSidebarOpen(!sidebarOpen)}
-          sx={{
-            position: 'fixed',
-            top: '50%',
-            left: sidebarOpen ? 320 - 20 : 0,
-            transform: 'translateY(-50%)',
-            zIndex: (theme) => theme.zIndex.drawer + 2,
-            transition: 'left 0.2s ease-in-out',
-            backgroundColor: 'background.paper',
-            border: '1px solid',
-            borderColor: 'divider',
-            '&:hover': {
-              backgroundColor: 'background.default'
-            }
-          }}
-        >
-          {sidebarOpen ? <ChevronLeft /> : <ChevronRight />}
-        </Fab>
+        {!isMobile && (
+          <Fab
+            size="small"
+            onClick={() => setSidebarOpen(!sidebarOpen)}
+            sx={{
+              position: 'fixed',
+              top: '50%',
+              left: sidebarOpen ? 320 - 20 : 0,
+              transform: 'translateY(-50%)',
+              zIndex: (theme) => theme.zIndex.drawer + 1,
+              transition: 'left 0.2s ease-in-out',
+              backgroundColor: 'background.paper',
+              border: '1px solid',
+              borderColor: 'divider',
+              '&:hover': {
+                backgroundColor: 'background.default',
+              },
+            }}
+          >
+            {sidebarOpen ? <ChevronLeft /> : <ChevronRight />}
+          </Fab>
+        )}
 
         {/* Main Content */}
         <Box
+          key={isMobile ? 'mobile' : 'desktop'}
           component="main"
           sx={{
             flexGrow: 1,
             p: { xs: 1, sm: 2, md: 3 },
-            mt: 8,
-            ml: sidebarOpen ? 0 : 0,
-            transition: 'margin-left 0.3s ease',
+            mt: { xs: 8, sm: 8 },
+            ml: !isMobile && sidebarOpen ? `${320}px` : 0,
+            transition: (theme) =>
+              theme.transitions.create('margin', {
+                easing: theme.transitions.easing.sharp,
+                duration: theme.transitions.duration.leavingScreen,
+              }),
+            width: `calc(100% - ${!isMobile && sidebarOpen ? '320px' : '0px'})`,
           }}
         >
           {/* Passo 0: Campanha */}

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -58,7 +58,6 @@ import MemorialDescritivoModal from './MemorialDescritivoModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
 import { callGeminiApi } from '../utils/geminiAPI';
 import { getGeminiApiKey } from '../utils/geminiCredentials';
-import { useIsMobile } from '../hooks/use-mobile.js';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -117,7 +116,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [showPersonaGenModal, setShowPersonaGenModal] = useState(false);
   const [showPersonaWizard, setShowPersonaWizard] = useState(false);
   const [showMemorialModal, setShowMemorialModal] = useState(false);
-  const isMobile = useIsMobile();
 
   const handleBriefingChange = (e) => {
     const { name, value } = e.target;

--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -16,12 +16,15 @@ import {
   Edit,
   Download as DownloadIcon,
   FileUpload as FileUploadIcon,
+  Menu as MenuIcon,
 } from '@mui/icons-material';
+import { useIsMobile } from '../hooks/use-mobile';
 
 const MainAppBar = ({
   darkMode,
   setDarkMode,
   setShowSetupModal,
+  onMenuClick,
   handleMenuOpen,
   handleMenuClose,
   anchorElMenu,
@@ -34,6 +37,7 @@ const MainAppBar = ({
   loadStateInputRef,
   handleLoadStateFromFile,
 }) => {
+  const isMobile = useIsMobile();
   return (
     <AppBar
       position="fixed"
@@ -44,18 +48,22 @@ const MainAppBar = ({
       }}
     >
       <Toolbar>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            flexGrow: 1,
-          }}
-        >
+        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
+          {isMobile && (
+            <IconButton
+              color="inherit"
+              aria-label="open drawer"
+              edge="start"
+              onClick={onMenuClick}
+              sx={{ mr: 2 }}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
           <img src="/logo.svg" alt="Midiator Logo" style={{ height: '40px' }} />
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0, sm: 1 } }}>
           <Tooltip title={darkMode ? 'Alternar para modo claro' : 'Alternar para modo escuro'}>
             <IconButton
               onClick={() => setDarkMode(!darkMode)}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -75,32 +75,46 @@ const Sidebar = ({
   darkMode,
   steps,
   activeStep,
-  setActiveStep,
   csvData,
   backgroundImage,
   visibleFields,
   totalFields,
   styledFields,
+  variant,
+  onClose,
+  onStepClick,
 }) => {
+  const drawerWidth = 320;
+
+  const handleStepClick = (index) => {
+    onStepClick(index);
+  };
+
   return (
     <Drawer
-      variant="persistent"
+      variant={variant}
       anchor="left"
       open={sidebarOpen}
+      onClose={onClose}
       sx={{
-        width: sidebarOpen ? 320 : 0,
+        width: variant === 'persistent' && sidebarOpen ? drawerWidth : 0,
         flexShrink: 0,
         '& .MuiDrawer-paper': {
-          width: 320,
+          width: drawerWidth,
           boxSizing: 'border-box',
-          mt: 8,
+          mt: { xs: 0, sm: 8 },
           borderRight: '1px solid',
           borderColor: 'divider',
           background: darkMode ? '#1e293b' : '#ffffff',
+          height: { xs: '100%', sm: 'calc(100% - 64px)' },
+          top: { xs: 0, sm: 64 },
         },
       }}
+      ModalProps={{
+        keepMounted: true, // Better open performance on mobile.
+      }}
     >
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ p: 3, mt: { xs: 8, sm: 0 } }}>
         <Typography variant="h6" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
           Etapas do Processo
         </Typography>
@@ -109,15 +123,14 @@ const Sidebar = ({
             <StepIndicator
               key={index}
               step={step}
-              index={index}
               isActive={activeStep === index}
               isCompleted={index < activeStep}
-              onClick={() => setActiveStep(index)}
+              onClick={() => handleStepClick(index)}
             />
           ))}
         </List>
 
-        <Box sx={{ mt: 4 }}>
+        <Box sx={{ mt: 4, display: { xs: 'none', sm: 'block' } }}>
           <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 600 }}>
             Status do Projeto
           </Typography>


### PR DESCRIPTION
This commit introduces responsive behavior to the main application layout, specifically for the sidebar and main content area, to improve the user experience on mobile devices.

Key changes include:

- **Refactored Sidebar:** The `Sidebar` component now accepts a `variant` prop, allowing it to switch between `persistent` for desktop and `temporary` for mobile.
- **Responsive Layout in App.jsx:** The main application component now uses the `useIsMobile` hook to conditionally render the `Sidebar` variant. The main content area's margin and width are dynamically adjusted to ensure it takes up the full screen on mobile.
- **Mobile Navigation:** A hamburger menu icon has been added to the `MainAppBar` to toggle the sidebar on mobile. The floating toggle button is now hidden on mobile.
- **Improved UX:** The sidebar now automatically closes on mobile after a navigation item is clicked. The initial state of the sidebar on mobile is set to closed.
- **Code Cleanup:** Fixed a duplicate import in `CampaignStandardsModal.jsx` and an unused prop in `Sidebar.jsx` that were identified during testing and linting.