### PR TITLE
Fix: Address multiple UI/UX issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -131,6 +131,8 @@ function App() {
   const [solucao, setSolucao] = useState('');
   const [isGeneratingCampaign, setIsGeneratingCampaign] = useState(false);
   const [campaignContent, setCampaignContent] = useState(null);
+  const [campaignGenerationFailed, setCampaignGenerationFailed] = useState(false);
+  const [generationError, setGenerationError] = useState('');
   const [editingField, setEditingField] = useState(null);
   const [personaFields, setPersonaFields] = useState({});
   const [autor, setAutor] = useState('');
@@ -951,6 +953,8 @@ function App() {
 
   const handleGenerateCampaignContent = async (regenerate = false) => {
     setIsGeneratingCampaign(true);
+    setCampaignGenerationFailed(false);
+    setGenerationError('');
     try {
       const normalizedContent = await generateCampaignContent({ problema, solucao });
       setCampaignContent(normalizedContent);
@@ -971,8 +975,11 @@ function App() {
       }
     } catch (error) {
       console.error("Erro ao gerar conteúdo da campanha:", error);
-      toast.error(`Ocorreu um erro ao gerar o conteúdo da campanha: ${error.message}`);
+      const errorMessage = error.message || 'Ocorreu um erro desconhecido.';
+      toast.error(`Ocorreu um erro ao gerar o conteúdo da campanha: ${errorMessage}`);
       setCampaignContent(null);
+      setCampaignGenerationFailed(true);
+      setGenerationError(errorMessage);
     } finally {
       setIsGeneratingCampaign(false);
     }
@@ -1201,9 +1208,10 @@ function App() {
         >
           {/* Passo 0: Campanha */}
           {activeStep === 0 && (
-            <Campaign
-              steps={steps}
-              problema={problema}
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <Campaign
+                steps={steps}
+                problema={problema}
               setProblema={setProblema}
               solucao={solucao}
               setSolucao={setSolucao}
@@ -1213,6 +1221,8 @@ function App() {
               setAspectRatio={setAspectRatio}
               isGeneratingCampaign={isGeneratingCampaign}
               campaignContent={campaignContent}
+              campaignGenerationFailed={campaignGenerationFailed}
+              generationError={generationError}
               handleGenerateCampaignContent={handleGenerateCampaignContent}
               handleResetCampaign={handleResetCampaign}
               handleExportHtml={() => exportHtml({
@@ -1243,6 +1253,7 @@ function App() {
               handleGenerateImage={handleGenerateImage}
               setCampaignContent={setCampaignContent}
             />
+            </Box>
           )}
 
           {/* Passo 1: Definir Dados Iniciais */}
@@ -1519,7 +1530,6 @@ function App() {
             aria-label="edit"
             sx={{ position: 'fixed', bottom: 16, right: 16 }}
             onClick={() => setIsDrawerOpen(true)}
-            disabled={!selectedField}
           >
             <Edit />
           </Fab>
@@ -1532,6 +1542,12 @@ function App() {
             fieldPositions={fieldPositions}
             setFieldPositions={setFieldPositions}
             csvHeaders={csvHeaders}
+            imageFilters={imageFilters}
+            setImageFilters={setImageFilters}
+            includeLogo={includeLogo}
+            setIncludeLogo={setIncludeLogo}
+            includeEmpresa={includeEmpresa}
+            setIncludeEmpresa={setIncludeEmpresa}
           />
         </>
       )}

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -15,10 +15,12 @@ import {
   AccordionSummary,
   AccordionDetails,
   Chip,
+  Alert,
 } from '@mui/material';
 import {
     Campaign as CampaignIcon,
     ExpandMore as ExpandMoreIcon,
+    Image as ImageIcon,
 } from '@mui/icons-material';
 
 const Campaign = ({
@@ -33,6 +35,8 @@ const Campaign = ({
     setAspectRatio,
     isGeneratingCampaign,
     campaignContent,
+    campaignGenerationFailed,
+    generationError,
     handleGenerateCampaignContent,
     handleResetCampaign,
     handleExportHtml,
@@ -136,6 +140,24 @@ const Campaign = ({
                         </Button>
                     )}
                 </Box>
+
+                {campaignGenerationFailed && (
+                    <Box sx={{ mt: 3, textAlign: 'center' }}>
+                        <Alert severity="error" sx={{ mb: 2 }}>
+                            <strong>Ocorreu um erro ao gerar o conteúdo:</strong> {generationError}
+                        </Alert>
+                        <Button
+                            variant="contained"
+                            color="secondary"
+                            size="large"
+                            onClick={() => handleGenerateImage()}
+                            disabled={isGeneratingImage}
+                            startIcon={<ImageIcon />}
+                        >
+                            {isGeneratingImage ? 'Gerando Imagem...' : 'Tentar Gerar Apenas a Imagem'}
+                        </Button>
+                    </Box>
+                )}
 
                 {campaignContent && (
                     <Box sx={{ mt: 4 }}>

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -379,7 +379,13 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth={false} fullScreen>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="lg"
+        fullScreen={isMobile}
+      >
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <Box>
                 Padrões de Campanha

--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -12,12 +12,18 @@ const FormattingDrawer = ({
   fieldPositions,
   setFieldPositions,
   csvHeaders,
+  imageFilters,
+  setImageFilters,
+  includeLogo,
+  setIncludeLogo,
+  includeEmpresa,
+  setIncludeEmpresa,
 }) => {
   return (
     <Drawer anchor="right" open={open} onClose={onClose} sx={{ zIndex: 1400 }}>
-      <Box sx={{ width: 320, p: 2 }}>
+      <Box sx={{ width: 320, p: 2, overflowY: 'auto' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-          <Typography variant="h6">Editar Campo</Typography>
+          <Typography variant="h6">Editar Propriedades</Typography>
           <IconButton onClick={onClose}>
             <Close />
           </IconButton>
@@ -29,6 +35,12 @@ const FormattingDrawer = ({
           fieldPositions={fieldPositions}
           setFieldPositions={setFieldPositions}
           csvHeaders={csvHeaders}
+          imageFilters={imageFilters}
+          setImageFilters={setImageFilters}
+          includeLogo={includeLogo}
+          setIncludeLogo={setIncludeLogo}
+          includeEmpresa={includeEmpresa}
+          setIncludeEmpresa={setIncludeEmpresa}
         />
       </Box>
     </Drawer>


### PR DESCRIPTION
In this commit, I've resolved four separate issues related to the campaign generation and editing interface.

1.  **Image Generation Fallback:** When the initial AI content generation fails, you are now presented with an error message and a new button to attempt generating only the campaign image. This provides a better experience for you in case of partial failures.

2.  **Small Screen Editing:**
    - The floating edit button on small screens is now always enabled, allowing you to access global settings (like image filters) even without a specific field selected.
    - I fixed a `TypeError` related to 'brightness' that occurred in the editing drawer on mobile by passing the required `imageFilters` state.

3.  **Campaign Panel Alignment:** I've centered the campaign data panel correctly on large screens, especially when the sidebar is open, improving the overall layout and visual balance.

4.  **Campaign Standards Modal:** I've made the Campaign Standards screen responsive. It now behaves as a large modal on desktop screens and a full-screen view on mobile devices, as you requested.