### PR TITLE
Fix: Properly serialize persona object in campaign prompt

### DIFF
--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -56,11 +56,30 @@ export function getCampaignPrompt() {
         // O objeto atualizado será salvo na próxima vez que o usuário salvar.
       }
 
-      // Mescla com os padrões para garantir que todas as chaves estejam presentes
-      return {
+      const finalData = {
         ...defaultPrompt,
         ...parsedData,
       };
+
+      if (finalData.persona && typeof finalData.persona === 'object') {
+        const personaString = Object.entries(finalData.persona)
+          .map(([key, value]) => {
+            if (!value) return null; // Ignora campos vazios, nulos ou undefined
+            const formattedValue = Array.isArray(value) ? value.join(', ') : value;
+            if (!formattedValue) return null; // Ignora se o valor formatado for vazio
+            // Formata a chave para ser mais legível (ex: 'posicaoCargo' -> 'Posição/Cargo')
+            const formattedKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+            return `${formattedKey}: ${formattedValue}`;
+          })
+          .filter(Boolean) // Remove entradas nulas
+          .join('\n');
+        finalData.persona = personaString;
+      } else {
+        finalData.persona = '';
+      }
+
+      // Mescla com os padrões para garantir que todas as chaves estejam presentes
+      return finalData;
 
     } catch (error) {
       console.error("Erro ao recuperar o prompt de campanha:", error);


### PR DESCRIPTION
The `getCampaignPrompt` function was returning the `persona` data as a JavaScript object. When this object was used to build the final prompt string for the AI, it was being cast to a string as `[object Object]`, losing all the persona details.

This commit modifies `getCampaignPrompt` to serialize the persona object into a formatted, human-readable string. It iterates through the persona's key-value pairs, formats the keys from camelCase to Title Case (e.g., `posicaoCargo` -> `Posição Cargo`), joins array values, and filters out any empty or null fields.

This ensures that the AI receives a complete and clearly formatted description of the persona, resolving the bug and improving the quality of the generated prompt.