### PR TITLE
feat: Refactor Author entity and enhance creation wizard

### DIFF
--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -1,0 +1,235 @@
+import React, { useState, useEffect } from 'react';
+import { useIsMobile } from '../hooks/use-mobile';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stepper,
+  Step,
+  StepLabel,
+  Box,
+  TextField,
+  Typography,
+  Grid,
+  CircularProgress,
+  Alert,
+  MenuItem,
+} from '@mui/material';
+import RichTextEditor from './RichTextEditor';
+
+const steps = [
+  'Início Rápido com IA',
+  'Revisão Detalhada',
+];
+
+const TIPO_ORGANIZACAO_OPTIONS = ['Braço de tecnologia', 'Agência de marketing', 'Consultoria', 'Startup', 'Empresa de Software (SaaS)', 'E-commerce', 'Outro'];
+
+const AutorWizard = ({ open, onClose, onSave, onGenerate, isGeneratingAutor, autor }) => {
+  const isMobile = useIsMobile();
+  const [activeStep, setActiveStep] = useState(0);
+  const [autorData, setAutorData] = useState(autor || {});
+
+  useEffect(() => {
+    if (open) {
+      setAutorData(autor || {
+        descricaoGeral: '',
+        dominioReferencia: '',
+        siteExclusao: '',
+        identidade: '',
+        descricao: '',
+        tipo: '',
+        objetivoEstrategico: '',
+        objetivoEngajamento: '',
+      });
+      setActiveStep(0); // Reset to first step when modal opens
+    }
+  }, [open, autor]);
+
+  const handleNext = () => {
+    if (activeStep === 0) { // Step "Início Rápido com IA"
+      onGenerate(
+        autorData.descricaoGeral,
+        autorData.dominioReferencia,
+        autorData.siteExclusao,
+        (generatedAutor) => {
+          setAutorData(prev => ({ ...prev, ...generatedAutor }));
+          setActiveStep(1);
+        }
+      );
+    } else {
+      handleSave();
+    }
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  const handleSave = () => {
+    onSave(autorData);
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setAutorData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleRichTextChange = (name, value) => {
+    setAutorData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const getStepContent = (step) => {
+    switch (step) {
+      case 0:
+        return (
+          <Box>
+            <Typography variant="h6" gutterBottom>Descreva o Autor para começar</Typography>
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Forneça uma breve descrição do perfil do autor (a empresa ou marca). A IA irá usar essa informação para preencher os campos detalhados.
+            </Alert>
+            <TextField
+              name="descricaoGeral"
+              label="Descrição Geral do Autor"
+              multiline
+              rows={6}
+              fullWidth
+              value={autorData.descricaoGeral || ''}
+              onChange={handleChange}
+              placeholder="Ex: 'Uma empresa de consultoria de marketing digital focada em startups de tecnologia, que busca se posicionar como líder de pensamento em SEO e marketing de conteúdo.'"
+              disabled={isGeneratingAutor}
+              sx={{ mb: 2 }}
+            />
+            <TextField
+              name="dominioReferencia"
+              label="Domínio de Referência (Opcional)"
+              fullWidth
+              value={autorData.dominioReferencia || ''}
+              onChange={handleChange}
+              placeholder="Ex: 'empresa.com.br'"
+              helperText="A IA usará este site como fonte de informação para entender o tom e o negócio."
+              disabled={isGeneratingAutor}
+              sx={{ mb: 2 }}
+            />
+            <TextField
+              name="siteExclusao"
+              label="Site para Excluir da Busca (Opcional)"
+              fullWidth
+              value={autorData.siteExclusao || ''}
+              onChange={handleChange}
+              placeholder="Ex: 'concorrente.com.br'"
+              helperText="A IA evitará este site em sua busca por informações."
+              disabled={isGeneratingAutor}
+            />
+          </Box>
+        );
+      case 1:
+        return (
+          <Box>
+            <Typography variant="h6" gutterBottom>Revisão e Detalhamento do Autor</Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              A IA preencheu os campos abaixo com base na sua descrição. Revise e ajuste se necessário.
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <TextField
+                  label="Identidade do Autor"
+                  name="identidade"
+                  value={autorData.identidade || ''}
+                  onChange={handleChange}
+                  fullWidth
+                  required
+                  variant="outlined"
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography variant="subtitle1" gutterBottom>Descrição da Empresa</Typography>
+                <RichTextEditor
+                    value={autorData.descricao || ''}
+                    onChange={(value) => handleRichTextChange('descricao', value)}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  select
+                  label="Tipo de Organização"
+                  name="tipo"
+                  value={autorData.tipo || ''}
+                  onChange={handleChange}
+                  fullWidth
+                  required
+                  variant="outlined"
+                >
+                    {TIPO_ORGANIZACAO_OPTIONS.map(option => <MenuItem key={option} value={option}>{option}</MenuItem>)}
+                </TextField>
+              </Grid>
+              <Grid item xs={12}>
+                <Typography variant="subtitle1" gutterBottom>Objetivo Estratégico</Typography>
+                <RichTextEditor
+                    value={autorData.objetivoEstrategico || ''}
+                    onChange={(value) => handleRichTextChange('objetivoEstrategico', value)}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <Typography variant="subtitle1" gutterBottom>Objetivo de Engajamento</Typography>
+                <RichTextEditor
+                    value={autorData.objetivoEngajamento || ''}
+                    onChange={(value) => handleRichTextChange('objetivoEngajamento', value)}
+                />
+              </Grid>
+            </Grid>
+          </Box>
+        );
+      default:
+        return 'Unknown step';
+    }
+  };
+
+  const isNextDisabled = () => {
+    if (activeStep === 0 && !(autorData.descricaoGeral || '').trim()) {
+      return true;
+    }
+    if (activeStep === 1 && !(autorData.identidade || '').trim()) {
+      return true;
+    }
+    return isGeneratingAutor;
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
+      <DialogTitle>
+        Assistente de Criação de Autor
+        <Typography variant="body2">Passo {activeStep + 1} de {steps.length}</Typography>
+      </DialogTitle>
+      <DialogContent sx={{ minHeight: '50vh' }}>
+        <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+        {getStepContent(activeStep)}
+      </DialogContent>
+      <DialogActions sx={{ p: 3 }}>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button onClick={handleSave} color="secondary">Salvar e Sair</Button>
+        <Box sx={{ flex: '1 1 auto' }} />
+        <Button onClick={handleBack} disabled={activeStep === 0}>
+          Voltar
+        </Button>
+        <Button
+            onClick={handleNext}
+            variant="contained"
+            disabled={isNextDisabled()}
+        >
+          {isGeneratingAutor && activeStep === 0 && <CircularProgress size={24} />}
+          {!isGeneratingAutor && (activeStep === 0 ? 'Gerar com IA' : 'Finalizar e Salvar')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AutorWizard;

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -54,6 +54,7 @@ import HtmlDisplayField from './HtmlDisplayField';
 import PaletteReportModal from './PaletteReportModal';
 import PersonaGenerationModal from './PersonaGenerationModal';
 import PersonaWizard from './PersonaWizard';
+import AutorWizard from './AutorWizard';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
 import { callGeminiApi } from '../utils/geminiAPI';
@@ -98,7 +99,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
   const [persona, setPersona] = useState({});
-  const [autor, setAutor] = useState('');
+  const [autor, setAutor] = useState({});
   const [instrucoes, setInstrucoes] = useState('');
   const [formato, setFormato] = useState('');
   const [colors, setColors] = useState([]);
@@ -123,6 +124,10 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [showPersonaGenModal, setShowPersonaGenModal] = useState(false);
   const [showPersonaWizard, setShowPersonaWizard] = useState(false);
   const [showMemorialModal, setShowMemorialModal] = useState(false);
+
+  // State for AI Autor Generation
+  const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
+  const [showAutorWizard, setShowAutorWizard] = useState(false);
 
   const handleBriefingChange = (e) => {
     const { name, value } = e.target;
@@ -183,6 +188,58 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
       toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console do navegador para detalhes.');
     } finally {
       setIsGeneratingPersona(false);
+    }
+  };
+
+  const handleGenerateAutorWithAI = async (descricaoGeral, dominioReferencia, siteExclusao, callback) => {
+    const apiKey = getGeminiApiKey();
+    if (!apiKey) {
+      toast.error('Chave de API do Gemini não configurada.');
+      return;
+    }
+
+    setIsGeneratingAutor(true);
+    const prompt = `
+      Com base na descrição do autor, preencha os campos do objeto JSON abaixo.
+
+      **Descrição do Autor:**
+      ${descricaoGeral}
+
+      **Instruções Adicionais:**
+      - Use o site ${dominioReferencia ? `\`${dominioReferencia}\`` : 'fornecido'} como principal fonte de referência para entender o tom, a linguagem e a área de atuação.
+      - ${siteExclusao ? `NÃO use o site \`${siteExclusao}\` como referência.` : ''}
+      - As respostas devem ser concisas e diretas.
+
+      **Campos para preencher (use exatamente estes nomes de chave):**
+      - identidade: (string) O nome da empresa ou marca.
+      - descricao: (string em HTML) Uma breve descrição da empresa, detalhando sua área de atuação, especializações e foco.
+      - tipo: (string) Uma classificação da natureza da empresa (ex: "Braço de tecnologia", "Agência de marketing", "Consultoria").
+      - objetivoEstrategico: (string em HTML) A meta de longo prazo da mensagem (posicionamento da marca, construção de autoridade, etc.).
+      - objetivoEngajamento: (string em HTML) O tipo de interação que a mensagem deve estimular (gerar comentários, compartilhamentos, etc.).
+
+      Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, markdown, ou qualquer outra formatação.
+    `;
+
+    try {
+      const response = await callGeminiApi(prompt, apiKey);
+      const cleanedResponse = response.replace(/```json/g, '').replace(/```/g, '').trim();
+
+      if (!cleanedResponse) {
+        toast.error('A IA retornou uma resposta vazia.');
+        return;
+      }
+
+      const generatedAutor = JSON.parse(cleanedResponse);
+
+      if (callback) {
+        callback(generatedAutor);
+      }
+
+    } catch (error) {
+      console.error("Erro ao gerar ou processar autor com IA:", error);
+      toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console do navegador para detalhes.');
+    } finally {
+      setIsGeneratingAutor(false);
     }
   };
 
@@ -248,8 +305,9 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
   const handleSaveEditor = (newContent) => {
     if (editingField === 'persona') {
       setPersona(newContent);
-    } else if (editingField === 'autor') {
-      setAutor(newContent);
+    } else if (editingField.startsWith('autor.')) {
+      const fieldName = editingField.split('.')[1];
+      setAutor(prev => ({ ...prev, [fieldName]: newContent }));
     } else if (editingField === 'instrucoes') {
       setInstrucoes(newContent);
     } else if (editingField === 'formato') {
@@ -260,7 +318,10 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
   const getCurrentContent = () => {
     if (editingField === 'persona') return persona;
-    if (editingField === 'autor') return autor;
+    if (editingField.startsWith('autor.')) {
+        const fieldName = editingField.split('.')[1];
+        return autor[fieldName] || '';
+    }
     if (editingField === 'instrucoes') return instrucoes;
     if (editingField === 'formato') return formato;
     return '';
@@ -268,7 +329,11 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
   const getEditorTitle = () => {
     if (editingField === 'persona') return 'Editar Persona';
-    if (editingField === 'autor') return 'Editar Autor';
+    if (editingField === 'autor.identidade') return 'Editar Identidade do Autor';
+    if (editingField === 'autor.descricao') return 'Editar Descrição da Empresa';
+    if (editingField === 'autor.tipo') return 'Editar Tipo de Organização';
+    if (editingField === 'autor.objetivoEstrategico') return 'Editar Objetivo Estratégico';
+    if (editingField === 'autor.objetivoEngajamento') return 'Editar Objetivo de Engajamento';
     if (editingField === 'instrucoes') return 'Editar Instruções';
     if (editingField === 'formato') return 'Editar Formato';
     return 'Editar';
@@ -724,13 +789,52 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
               </Grid>
             </TabPanel>
             <TabPanel value={value} index={1}>
-              <HtmlDisplayField
-                title="Autor"
-                tooltip="Descreva o autor ou a voz da marca que está criando o conteúdo. Qual o tom, estilo e perspectiva?"
-                htmlContent={autor}
-                onClick={() => handleOpenEditor('autor')}
-                placeholder="Clique para editar o autor..."
-              />
+              <Stack spacing={2}>
+                <Button
+                  variant="contained"
+                  startIcon={<Add />}
+                  onClick={() => setShowAutorWizard(true)}
+                  sx={{ alignSelf: 'flex-start' }}
+                >
+                  Assistente de Criação de Autor
+                </Button>
+
+                <HtmlDisplayField
+                  title="Identidade do Autor"
+                  tooltip="O nome da empresa ou marca que está publicando o conteúdo. Ex: ACME Corporation."
+                  htmlContent={autor?.identidade}
+                  onClick={() => handleOpenEditor('autor.identidade')}
+                  placeholder="Clique para editar a identidade..."
+                />
+                <HtmlDisplayField
+                  title="Descrição da Empresa"
+                  tooltip="Uma breve descrição que detalha a área de atuação, as especializações e o foco do negócio."
+                  htmlContent={autor?.descricao}
+                  onClick={() => handleOpenEditor('autor.descricao')}
+                  placeholder="Clique para editar a descrição..."
+                />
+                <HtmlDisplayField
+                  title="Tipo de Organização"
+                  tooltip="Uma classificação que define a natureza da empresa (ex: 'braço de tecnologia', 'agência de marketing')."
+                  htmlContent={autor?.tipo}
+                  onClick={() => handleOpenEditor('autor.tipo')}
+                  placeholder="Clique para editar o tipo..."
+                />
+                <HtmlDisplayField
+                  title="Objetivo Estratégico"
+                  tooltip="A meta de longo prazo da mensagem (posicionamento da marca, construção de autoridade, etc.)."
+                  htmlContent={autor?.objetivoEstrategico}
+                  onClick={() => handleOpenEditor('autor.objetivoEstrategico')}
+                  placeholder="Clique para editar o objetivo estratégico..."
+                />
+                <HtmlDisplayField
+                  title="Objetivo de Engajamento"
+                  tooltip="O tipo de interação que a mensagem deve estimular no público."
+                  htmlContent={autor?.objetivoEngajamento}
+                  onClick={() => handleOpenEditor('autor.objetivoEngajamento')}
+                  placeholder="Clique para editar o objetivo de engajamento..."
+                />
+              </Stack>
             </TabPanel>
             <TabPanel value={value} index={2}>
               <HtmlDisplayField
@@ -897,6 +1001,19 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
         }}
         onGenerate={handleGeneratePersonaWithAI}
         isGeneratingPersona={isGeneratingPersona}
+      />
+
+      <AutorWizard
+        open={showAutorWizard}
+        onClose={() => setShowAutorWizard(false)}
+        autor={autor}
+        onSave={(newAutor) => {
+          setAutor(newAutor);
+          setShowAutorWizard(false);
+          toast.success('Autor salvo com sucesso!');
+        }}
+        onGenerate={handleGenerateAutorWithAI}
+        isGeneratingAutor={isGeneratingAutor}
       />
 
       <MemorialDescritivoModal

--- a/src/components/MemorialDescritivoModal.jsx
+++ b/src/components/MemorialDescritivoModal.jsx
@@ -59,7 +59,7 @@ const MemorialDescritivoModal = ({ open, onClose, campaignData }) => {
 
   if (!campaignData) return null;
 
-  const { persona = {}, autor = '', formato = '', instrucoes = '', colors = [], briefing = {} } = campaignData;
+  const { persona = {}, autor = {}, formato = '', instrucoes = '', colors = [], briefing = {} } = campaignData;
 
   const renderPersonaField = (label, value, explanation) => {
     let displayValue = 'Não definido';
@@ -151,9 +151,11 @@ const MemorialDescritivoModal = ({ open, onClose, campaignData }) => {
           </Section>
 
           <Section title="2.2. Autor (Voz da Marca)" subtitle="O tom, estilo e perspectiva que a marca usará.">
-             <Box sx={{ mt: 1 }}>
-                {autor ? parse(autor) : <Typography variant="body2">Não definido</Typography>}
-             </Box>
+            <Field label="Identidade do Autor" value={autor.identidade} explanation="O nome da empresa ou marca que está publicando o conteúdo." />
+            <Field label="Descrição da Empresa" value={autor.descricao} explanation="Detalhes sobre a área de atuação, especializações e foco do negócio." />
+            <Field label="Tipo de Organização" value={autor.tipo} explanation="A natureza da empresa (ex: 'braço de tecnologia', 'agência de marketing')." />
+            <Field label="Objetivo Estratégico" value={autor.objetivoEstrategico} explanation="A meta de longo prazo da mensagem." />
+            <Field label="Objetivo de Engajamento" value={autor.objetivoEngajamento} explanation="O tipo de interação que a mensagem deve estimular no público." />
           </Section>
 
           <Section title="2.3. Formato do Conteúdo" subtitle="A estrutura e o layout das peças de conteúdo.">
@@ -169,10 +171,10 @@ const MemorialDescritivoModal = ({ open, onClose, campaignData }) => {
           </Section>
 
           <Section title="2.5. Briefing da Paleta de Cores" subtitle="Os parâmetros usados para a geração da paleta de cores com IA.">
-            <Field label="Objetivo" value={briefing.objective} explanation="O principal objetivo da campanha (ex: Branding, Vendas)." />
-            <Field label="Público-alvo" value={briefing.targetAudience} explanation="O grupo demográfico ou perfil de cliente que a campanha visa atingir." />
-            <Field label="Mensagem Principal" value={briefing.mainMessage} explanation="A ideia central ou o sentimento que a campanha deve comunicar." />
-            <Field label="Atmosfera Desejada" value={briefing.atmosphere} explanation="A sensação ou o ambiente que o design visual deve criar." />
+            <Field label="Objetivo" value={briefing.objetivo} explanation="O principal objetivo da campanha (ex: Branding, Vendas)." />
+            <Field label="Público-alvo" value={briefing.publicoAlvo} explanation="O grupo demográfico ou perfil de cliente que a campanha visa atingir." />
+            <Field label="Mensagem Principal" value={briefing.mensagemPrincipal} explanation="A ideia central ou o sentimento que a campanha deve comunicar." />
+            <Field label="Atmosfera Desejada" value={briefing.atmosfera} explanation="A sensação ou o ambiente que o design visual deve criar." />
             <Field label="Detalhes Adicionais" value={briefing.details} explanation="Quaisquer outras instruções, como cores proibidas ou obrigatórias." />
           </Section>
 

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -20,7 +20,21 @@ export function saveCampaignPrompt(promptData) {
  * @returns {{persona: object, autor: string, instrucoes: string, formato: string, colors: string[]}} O objeto do prompt ou um objeto com campos vazios.
  */
 export function getCampaignPrompt() {
-  const defaultPrompt = { persona: {}, autor: '', instrucoes: '', formato: '', colors: [] };
+  const defaultPrompt = {
+    persona: {},
+    autor: {
+      identidade: '',
+      descricao: '',
+      tipo: '',
+      objetivoEstrategico: '',
+      objetivoEngajamento: '',
+      dominioReferencia: '',
+      siteExclusao: '',
+    },
+    instrucoes: '',
+    formato: '',
+    colors: []
+  };
 
   if (typeof window !== 'undefined' && window.localStorage) {
     try {
@@ -33,7 +47,6 @@ export function getCampaignPrompt() {
       try {
         parsedData = JSON.parse(storedData);
       } catch (e) {
-        // Lida com o caso em que storedData não é um JSON válido (formato antigo de string)
         console.log("Migrando prompt do formato antigo (string) para o novo (objeto).");
         const migratedData = { ...defaultPrompt, instrucoes: storedData };
         saveCampaignPrompt(migratedData);
@@ -41,7 +54,6 @@ export function getCampaignPrompt() {
       }
 
       if (typeof parsedData !== 'object' || parsedData === null) {
-        // O valor armazenado é JSON válido, mas não um objeto (ex: "null", "true", "123")
         return defaultPrompt;
       }
 
@@ -50,35 +62,34 @@ export function getCampaignPrompt() {
         parsedData.persona = {};
       }
 
+      // Migração para o campo autor: se for uma string, converte para o novo formato de objeto.
+      if (typeof parsedData.autor === 'string') {
+        console.log("Migrando autor do formato antigo (string) para o novo (objeto).");
+        parsedData.autor = {
+          ...defaultPrompt.autor,
+          identidade: parsedData.autor,
+        };
+      } else if (typeof parsedData.autor !== 'object' || parsedData.autor === null) {
+        parsedData.autor = { ...defaultPrompt.autor };
+      }
+
+
       // Migração para remover o campo aspectRatio
       if (parsedData.aspectRatio) {
         delete parsedData.aspectRatio;
-        // O objeto atualizado será salvo na próxima vez que o usuário salvar.
-      }
-
-      const finalData = {
-        ...defaultPrompt,
-        ...parsedData,
-      };
-
-      if (finalData.persona && typeof finalData.persona === 'object') {
-        const personaString = Object.entries(finalData.persona)
-          .map(([key, value]) => {
-            if (!value) return null; // Ignora campos vazios, nulos ou undefined
-            const formattedValue = Array.isArray(value) ? value.join(', ') : value;
-            if (!formattedValue) return null; // Ignora se o valor formatado for vazio
-            // Formata a chave para ser mais legível (ex: 'posicaoCargo' -> 'Posição/Cargo')
-            const formattedKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
-            return `${formattedKey}: ${formattedValue}`;
-          })
-          .filter(Boolean) // Remove entradas nulas
-          .join('\n');
-        finalData.persona = personaString;
-      } else {
-        finalData.persona = '';
       }
 
       // Mescla com os padrões para garantir que todas as chaves estejam presentes
+      const finalData = {
+        ...defaultPrompt,
+        ...parsedData,
+        // Garante que a estrutura aninhada de autor também seja mesclada
+        autor: {
+          ...defaultPrompt.autor,
+          ...(parsedData.autor || {}),
+        },
+      };
+
       return finalData;
 
     } catch (error) {

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -3,6 +3,21 @@ import { callGeminiApi, generateImage } from './geminiAPI.js';
 import { getGeminiApiKey } from './geminiCredentials.js';
 import { stripHtml } from '../lib/utils.js';
 
+const formatObjectForPrompt = (obj) => {
+  if (!obj || typeof obj !== 'object') return '';
+  return Object.entries(obj)
+    .map(([key, value]) => {
+      if (!value) return null;
+      const formattedValue = Array.isArray(value) ? value.join(', ') : value;
+      if (!formattedValue) return null;
+      const formattedKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, (str) => str.toUpperCase());
+      return `${formattedKey}: ${stripHtml(formattedValue)}`;
+    })
+    .filter(Boolean)
+    .join('\n');
+};
+
+
 /**
  * Generates the main campaign content using an AI API.
  */
@@ -14,9 +29,12 @@ export const generateCampaignContent = async ({ problema, solucao }) => {
 
   const { persona, autor, instrucoes, formato } = getCampaignPrompt();
 
+  const personaString = formatObjectForPrompt(persona);
+  const autorString = formatObjectForPrompt(autor);
+
   const promptCompleto = `
-    Persona: ${stripHtml(persona)}
-    Autor: ${stripHtml(autor)}
+    Persona: ${personaString}
+    Autor: ${autorString}
     Formato: ${stripHtml(formato)}
     Problema: ${stripHtml(problema)}
     Solução: ${stripHtml(solucao)}
@@ -72,13 +90,16 @@ export const generateCampaignImage = async ({ content, aspectRatio }) => {
   }
 
   const { persona, autor, colors } = getCampaignPrompt();
+  const personaString = formatObjectForPrompt(persona);
+  const autorString = formatObjectForPrompt(autor);
+
   const colorPalettePrompt = colors && colors.length > 0
     ? `A imagem deve usar predominantemente a seguinte paleta de cores: ${colors.join(', ')}.`
     : '';
 
   const imagePrompt = `
-    Persona: ${stripHtml(persona)}
-    Autor: ${stripHtml(autor)}
+    Persona: ${personaString}
+    Autor: ${autorString}
     Resumo do Conteúdo: ${stripHtml(content.titulo)}. ${stripHtml(content.conteudo)}
     Razão de Aspecto: ${aspectRatio}
     ${colorPalettePrompt}
@@ -134,6 +155,8 @@ export const generateFollowupPosts = async ({ content, followupPostsQuantity }) 
   }
 
   const { persona } = getCampaignPrompt();
+  const personaString = formatObjectForPrompt(persona);
+
   const prompt = 
   `Você é um especialista em marketing de conteúdo e copywriting.
 Sua tarefa é criar ${followupPostsQuantity} posts sequenciais seguindo o modelo AIDA (Atenção → Interesse → Desejo → Ação), usando o conteúdo principal como base.
@@ -143,7 +166,7 @@ O tema abordado é: [${stripHtml(content.titulo)} - ${stripHtml(content.conteudo
 
 PERSONAS-ALVO:
 
-${stripHtml(persona)}
+${personaString}
 
 ESTRUTURA DA SEQUÊNCIA (AIDA + formatos variados):
 Post 1 — Atenção (Gancho Impactante)


### PR DESCRIPTION
I've completed a major refactoring of the "Autor" (Author) entity, changing it from a simple string to a structured object. I also added a new creation wizard for the author, similar to the persona wizard.

- **New Author Data Structure**: The `autor` is now an object with fields for `identidade`, `descricao`, `tipo`, `objetivoEstrategico`, and `objetivoEngajamento`.
- **New Author Wizard**: I created a new `AutorWizard.jsx` component to guide you through creating an author profile with AI assistance. It takes a general description, a reference domain, and an exclusion site to generate the structured data.
- **Updated UI**: I updated the "Autor" tab in the `CampaignStandardsModal` to display the new structured fields and to launch the new wizard.
- **Data Migration**: I've added logic to the `getCampaignPrompt` utility to automatically migrate old string-based `autor` data to the new object structure.
- **Prompt Integration**: I updated the AI prompt generation in `generationHandlers.js` to use the new structured `autor` and `persona` data, providing more context to the AI.
- **Memorial Descritivo**: The "Memorial Descritivo" now correctly displays the new detailed author information.