### PR TITLE
fix: Correctly handle null value in CampaignStandardsModal

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -317,6 +317,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
   };
 
   const getCurrentContent = () => {
+    if (!editingField) return '';
     if (editingField === 'persona') return persona;
     if (editingField.startsWith('autor.')) {
         const fieldName = editingField.split('.')[1];


### PR DESCRIPTION
This commit fixes a null pointer exception in the `getCurrentContent` function within the `CampaignStandardsModal` component.

The error occurred because `editingField` could be `null`, but the function attempted to call `.startsWith()` on it without a null check. This has been resolved by adding a check at the beginning of the function to return early if `editingField` is null.