### PR TITLE
feat: Refactor AI Palette Generation into a Wizard

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -51,10 +51,10 @@ import ColorThief from 'colorthief';
 
 import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
-import PaletteReportModal from './PaletteReportModal';
 import PersonaGenerationModal from './PersonaGenerationModal';
 import PersonaWizard from './PersonaWizard';
 import AutorWizard from './AutorWizard';
+import PaletteWizard from './PaletteWizard';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
 import { callGeminiApi } from '../utils/geminiAPI';
@@ -81,20 +81,6 @@ function TabPanel(props) {
   );
 }
 
-const briefingOptions = {
-    objetivo: ['Branding', 'Site', 'Produto', 'Campanha de Marketing'],
-    publicoAlvo: ['Mulheres 30-45 anos', 'Jovens Gamers', 'Executivos C-Level', 'Famílias com Crianças'],
-    mensagemPrincipal: ['Confiança', 'Inovação', 'Sustentabilidade', 'Acessibilidade', 'Luxo'],
-    atmosfera: ['Calmo e Sereno', 'Energético e Vibrante', 'Premium e Sofisticado', 'Divertido e Descontraído'],
-};
-
-const briefingLabels = {
-    objetivo: 'Objetivo',
-    publicoAlvo: 'Público-alvo',
-    mensagemPrincipal: 'Mensagem Principal',
-    atmosfera: 'Atmosfera',
-};
-
 const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
@@ -107,16 +93,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const imageInputRef = useRef(null);
 
   // State for AI Palette Generation
-  const [briefing, setBriefing] = useState({
-    objetivo: '',
-    publicoAlvo: '',
-    mensagemPrincipal: '',
-    atmosfera: '',
-    details: '',
-  });
   const [isGenerating, setIsGenerating] = useState(false);
-  const [generatedPalette, setGeneratedPalette] = useState(null);
-  const [showReportModal, setShowReportModal] = useState(false);
 
   // State for AI Persona Generation
   const [personaDescription, setPersonaDescription] = useState('');
@@ -129,10 +106,8 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
   const [showAutorWizard, setShowAutorWizard] = useState(false);
 
-  const handleBriefingChange = (e) => {
-    const { name, value } = e.target;
-    setBriefing(prev => ({ ...prev, [name]: value }));
-  };
+  // State for AI Palette Wizard
+  const [showPaletteWizard, setShowPaletteWizard] = useState(false);
 
   const handleGeneratePersonaWithAI = async (description, callback) => {
     const apiKey = getGeminiApiKey();
@@ -240,36 +215,6 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
       toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console do navegador para detalhes.');
     } finally {
       setIsGeneratingAutor(false);
-    }
-  };
-
-  const handleGenerateClick = async () => {
-    setIsGenerating(true);
-    setGeneratedPalette(null);
-    try {
-      const fullBriefing = `
-- Objetivo: ${briefing.objetivo}
-- Público-alvo: ${briefing.publicoAlvo}
-- Mensagem principal: ${briefing.mensagemPrincipal}
-- Atmosfera desejada: ${briefing.atmosfera}
-- Detalhes adicionais: ${briefing.details}
-      `;
-      const result = await onGeneratePalette(fullBriefing.trim());
-      setGeneratedPalette(result);
-      setShowReportModal(true); // Open the report modal
-    } catch (error) {
-      toast.error('Erro ao gerar paleta de cores. Tente novamente.');
-      console.error("Error generating color palette:", error);
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const applyGeneratedPalette = () => {
-    if (generatedPalette && generatedPalette.palette) {
-      const newColors = generatedPalette.palette.map(p => p.hex);
-      setColors(newColors);
-      toast.success('Paleta de cores aplicada!');
     }
   };
 
@@ -916,46 +861,15 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
               {/* AI Palette Generator */}
               <Box>
-                <Typography variant="h6" gutterBottom>Gerar Paleta com IA</Typography>
-                <Grid container spacing={2}>
-                  {Object.keys(briefingOptions).map(key => (
-                    <Grid item xs={12} sm={6} key={key}>
-                      <FormControl fullWidth>
-                        <InputLabel>{briefingLabels[key]}</InputLabel>
-                        <Select
-                          name={key}
-                          value={briefing[key]}
-                          label={briefingLabels[key]}
-                          onChange={handleBriefingChange}
-                        >
-                          {briefingOptions[key].map(option => (
-                            <MenuItem key={option} value={option}>{option}</MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    </Grid>
-                  ))}
-                </Grid>
-                <TextField
-                  name="details"
-                  label="Detalhes Adicionais do Briefing"
-                  multiline
-                  rows={4}
-                  value={briefing.details}
-                  onChange={handleBriefingChange}
-                  fullWidth
-                  placeholder="INCLUINDO:
-- Quaisquer cores proibidas ou obrigatórias"
-                  margin="normal"
-                />
-                <Button
-                  variant="contained"
-                  startIcon={<AutoAwesomeIcon />}
-                  onClick={handleGenerateClick}
-                  disabled={isGenerating || !onGeneratePalette}
-                >
-                  {isGenerating ? <CircularProgress size={24} /> : 'Gerar Paleta'}
-                </Button>
+                  <Typography variant="h6" gutterBottom>Gerar Paleta com IA</Typography>
+                  <Button
+                      variant="contained"
+                      startIcon={<AutoAwesomeIcon />}
+                      onClick={() => setShowPaletteWizard(true)}
+                      disabled={!onGeneratePalette}
+                  >
+                      Assistente de Geração de Paleta
+                  </Button>
               </Box>
             </TabPanel>
           </Box>
@@ -972,14 +886,6 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
         content={getCurrentContent()}
         onSave={handleSaveEditor}
         onClose={handleCloseEditor}
-      />
-
-      <PaletteReportModal
-        open={showReportModal}
-        onClose={() => setShowReportModal(false)}
-        paletteData={generatedPalette}
-        onApplyPalette={applyGeneratedPalette}
-        briefing={briefing}
       />
 
       <PersonaGenerationModal
@@ -1017,10 +923,32 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
         isGeneratingAutor={isGeneratingAutor}
       />
 
+      <PaletteWizard
+        open={showPaletteWizard}
+        onClose={() => setShowPaletteWizard(false)}
+        onSave={(newPalette) => {
+            setColors(newPalette);
+            toast.success('Paleta de cores aplicada!');
+        }}
+        onGenerate={async (briefing, callback) => {
+            setIsGenerating(true);
+            try {
+                const result = await onGeneratePalette(briefing);
+                callback(result);
+            } catch (error) {
+                toast.error('Erro ao gerar paleta de cores. Tente novamente.');
+                console.error("Error generating color palette:", error);
+            } finally {
+                setIsGenerating(false);
+            }
+        }}
+        isGenerating={isGenerating}
+      />
+
       <MemorialDescritivoModal
         open={showMemorialModal}
         onClose={() => setShowMemorialModal(false)}
-        campaignData={{ persona, autor, instrucoes, formato, colors, briefing }}
+        campaignData={{ persona, autor, instrucoes, formato, colors }}
       />
     </>
   );

--- a/src/components/PaletteReport.jsx
+++ b/src/components/PaletteReport.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Divider,
+  Grid,
+  Paper,
+  Chip,
+} from '@mui/material';
+
+const PaletteReport = ({ paletteData, briefing }) => {
+  if (!paletteData || !briefing) return null;
+
+  return (
+    <Paper elevation={0} className="printable-section" sx={{ p: 4, fontFamily: 'serif' }}>
+      <Box sx={{ textAlign: 'center', mb: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Georgia, serif', fontWeight: 'bold' }}>
+          Memorial Descritivo de Cores
+        </Typography>
+        <Typography variant="subtitle1" color="text.secondary">
+          Análise e Justificativa da Paleta de Cores para a Campanha
+        </Typography>
+      </Box>
+
+      <Divider sx={{ my: 3 }} />
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>1. Briefing Criativo</Typography>
+        <Typography variant="body1" paragraph>
+          A paleta de cores a seguir foi gerada com base nos seguintes parâmetros criativos fornecidos:
+        </Typography>
+        <Paper variant="outlined" sx={{ p: 2, backgroundColor: 'background.default' }}>
+          <Typography variant="body2"><strong>Objetivo:</strong> {briefing.objetivo}</Typography>
+          <Typography variant="body2"><strong>Público-alvo:</strong> {briefing.publicoAlvo}</Typography>
+          <Typography variant="body2"><strong>Mensagem Principal:</strong> {briefing.mensagemPrincipal}</Typography>
+          <Typography variant="body2"><strong>Atmosfera Desejada:</strong> {briefing.atmosfera}</Typography>
+          {briefing.details && <Typography variant="body2"><strong>Detalhes Adicionais:</strong> {briefing.details}</Typography>}
+        </Paper>
+      </Box>
+
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>2. Harmonia da Paleta</Typography>
+        <Typography variant="body1">
+          A harmonia de cores selecionada foi a <strong>{paletteData.harmony}</strong>. Esta escolha visa criar um equilíbrio visual coeso e psicologicamente alinhado aos objetivos do briefing.
+        </Typography>
+      </Box>
+
+      <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>3. Detalhamento da Paleta</Typography>
+      <Grid container spacing={3}>
+        {paletteData.palette.map((color, index) => (
+          <Grid item xs={12} key={index}>
+            <Paper variant="outlined" sx={{ p: 2 }}>
+              <Grid container spacing={2} alignItems="center">
+                <Grid item xs={12} sm={2}>
+                  <Box sx={{ width: '100%', height: 80, borderRadius: 2, backgroundColor: color.hex }} />
+                </Grid>
+                <Grid item xs={12} sm={10}>
+                  <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>{index + 1}. {color.name}</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    <strong>Função:</strong> {color.role}
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontStyle: 'italic', mb: 1 }}>
+                    {color.justification}
+                  </Typography>
+                  <Chip label={`HEX: ${color.hex}`} size="small" sx={{ mr: 1 }} />
+                  <Chip label={`RGB: ${color.rgb}`} size="small" />
+                </Grid>
+              </Grid>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Paper>
+  );
+};
+
+export default PaletteReport;

--- a/src/components/PaletteReportModal.jsx
+++ b/src/components/PaletteReportModal.jsx
@@ -5,16 +5,11 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  Box,
-  Typography,
   IconButton,
-  Divider,
-  Grid,
-  Paper,
-  Chip,
 } from '@mui/material';
 import { Close as CloseIcon, Print as PrintIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
+import PaletteReport from './PaletteReport';
 
 const PaletteReportModal = ({ open, onClose, paletteData, onApplyPalette, briefing }) => {
   const handlePrint = () => {
@@ -58,65 +53,7 @@ const PaletteReportModal = ({ open, onClose, paletteData, onApplyPalette, briefi
             }
           `}
         </style>
-        <Paper elevation={0} className="printable-section" sx={{ p: 4, fontFamily: 'serif' }}>
-          <Box sx={{ textAlign: 'center', mb: 4 }}>
-            <Typography variant="h4" component="h1" gutterBottom sx={{ fontFamily: 'Georgia, serif', fontWeight: 'bold' }}>
-              Memorial Descritivo de Cores
-            </Typography>
-            <Typography variant="subtitle1" color="text.secondary">
-              Análise e Justificativa da Paleta de Cores para a Campanha
-            </Typography>
-          </Box>
-
-          <Divider sx={{ my: 3 }} />
-
-          <Box sx={{ mb: 4 }}>
-            <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>1. Briefing Criativo</Typography>
-            <Typography variant="body1" paragraph>
-              A paleta de cores a seguir foi gerada com base nos seguintes parâmetros criativos fornecidos:
-            </Typography>
-            <Paper variant="outlined" sx={{ p: 2, backgroundColor: 'background.default' }}>
-              <Typography variant="body2"><strong>Objetivo:</strong> {briefing.objective}</Typography>
-              <Typography variant="body2"><strong>Público-alvo:</strong> {briefing.targetAudience}</Typography>
-              <Typography variant="body2"><strong>Mensagem Principal:</strong> {briefing.mainMessage}</Typography>
-              <Typography variant="body2"><strong>Atmosfera Desejada:</strong> {briefing.atmosphere}</Typography>
-              {briefing.details && <Typography variant="body2"><strong>Detalhes Adicionais:</strong> {briefing.details}</Typography>}
-            </Paper>
-          </Box>
-
-          <Box sx={{ mb: 4 }}>
-            <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>2. Harmonia da Paleta</Typography>
-            <Typography variant="body1">
-              A harmonia de cores selecionada foi a <strong>{paletteData.harmony}</strong>. Esta escolha visa criar um equilíbrio visual coeso e psicologicamente alinhado aos objetivos do briefing.
-            </Typography>
-          </Box>
-
-          <Typography variant="h5" gutterBottom sx={{ fontFamily: 'Georgia, serif' }}>3. Detalhamento da Paleta</Typography>
-          <Grid container spacing={3}>
-            {paletteData.palette.map((color, index) => (
-              <Grid item xs={12} key={index}>
-                <Paper variant="outlined" sx={{ p: 2 }}>
-                  <Grid container spacing={2} alignItems="center">
-                    <Grid item xs={12} sm={2}>
-                      <Box sx={{ width: '100%', height: 80, borderRadius: 2, backgroundColor: color.hex }} />
-                    </Grid>
-                    <Grid item xs={12} sm={10}>
-                      <Typography variant="h6" component="h3" sx={{ fontWeight: 'bold' }}>{index + 1}. {color.name}</Typography>
-                      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                        <strong>Função:</strong> {color.role}
-                      </Typography>
-                      <Typography variant="body2" sx={{ fontStyle: 'italic', mb: 1 }}>
-                        {color.justification}
-                      </Typography>
-                      <Chip label={`HEX: ${color.hex}`} size="small" sx={{ mr: 1 }} />
-                      <Chip label={`RGB: ${color.rgb}`} size="small" />
-                    </Grid>
-                  </Grid>
-                </Paper>
-              </Grid>
-            ))}
-          </Grid>
-        </Paper>
+        <PaletteReport paletteData={paletteData} briefing={briefing} />
       </DialogContent>
       <DialogActions sx={{ p: 2 }} className="no-print">
         <Button onClick={handlePrint} startIcon={<PrintIcon />}>

--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -1,0 +1,196 @@
+import React, { useState, useEffect } from 'react';
+import { useIsMobile } from '../hooks/use-mobile';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Stepper,
+  Step,
+  StepLabel,
+  Box,
+  TextField,
+  Typography,
+  Grid,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Paper,
+} from '@mui/material';
+import PaletteReport from './PaletteReport';
+
+const steps = [
+  'Definir Briefing',
+  'Analisar Resultado',
+];
+
+const briefingOptions = {
+    objetivo: ['Branding', 'Site', 'Produto', 'Campanha de Marketing'],
+    publicoAlvo: ['Mulheres 30-45 anos', 'Jovens Gamers', 'Executivos C-Level', 'Famílias com Crianças'],
+    mensagemPrincipal: ['Confiança', 'Inovação', 'Sustentabilidade', 'Acessibilidade', 'Luxo'],
+    atmosfera: ['Calmo e Sereno', 'Energético e Vibrante', 'Premium e Sofisticado', 'Divertido e Descontraído'],
+};
+
+const briefingLabels = {
+    objetivo: 'Objetivo',
+    publicoAlvo: 'Público-alvo',
+    mensagemPrincipal: 'Mensagem Principal',
+    atmosfera: 'Atmosfera',
+};
+
+const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
+  const isMobile = useIsMobile();
+  const [activeStep, setActiveStep] = useState(0);
+  const [briefing, setBriefing] = useState({});
+  const [generatedPalette, setGeneratedPalette] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setBriefing({
+        objetivo: '',
+        publicoAlvo: '',
+        mensagemPrincipal: '',
+        atmosfera: '',
+        details: '',
+      });
+      setGeneratedPalette(null);
+      setActiveStep(0);
+    }
+  }, [open]);
+
+  const handleNext = () => {
+    if (activeStep === 0) {
+      const fullBriefing = `
+- Objetivo: ${briefing.objetivo}
+- Público-alvo: ${briefing.publicoAlvo}
+- Mensagem principal: ${briefing.mensagemPrincipal}
+- Atmosfera desejada: ${briefing.atmosfera}
+- Detalhes adicionais: ${briefing.details}
+      `;
+      onGenerate(fullBriefing.trim(), (palette) => {
+        setGeneratedPalette(palette);
+        setActiveStep(1);
+      });
+    } else {
+      onSave(generatedPalette.palette.map(p => p.hex));
+      onClose();
+    }
+  };
+
+  const handleBack = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setBriefing(prev => ({ ...prev, [name]: value }));
+  };
+
+  const getStepContent = (step) => {
+    switch (step) {
+      case 0:
+        return (
+          <Box>
+            <Typography variant="h6" gutterBottom>Gerar Paleta com IA</Typography>
+            <Grid container spacing={2}>
+              {Object.keys(briefingOptions).map(key => (
+                <Grid item xs={12} sm={6} key={key}>
+                  <FormControl fullWidth>
+                    <InputLabel>{briefingLabels[key]}</InputLabel>
+                    <Select
+                      name={key}
+                      value={briefing[key] || ''}
+                      label={briefingLabels[key]}
+                      onChange={handleChange}
+                    >
+                      {briefingOptions[key].map(option => (
+                        <MenuItem key={option} value={option}>{option}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid>
+              ))}
+            </Grid>
+            <TextField
+              name="details"
+              label="Detalhes Adicionais do Briefing"
+              multiline
+              rows={4}
+              value={briefing.details}
+              onChange={handleChange}
+              fullWidth
+              placeholder="INCLUINDO:
+- Quaisquer cores proibidas ou obrigatórias"
+              margin="normal"
+            />
+          </Box>
+        );
+      case 1:
+        return (
+          <Box>
+            <Typography variant="h6" gutterBottom>Resultado da Geração</Typography>
+            {generatedPalette ? (
+              <PaletteReport paletteData={generatedPalette} briefing={briefing} />
+            ) : (
+              <Typography>A paleta gerada será exibida aqui.</Typography>
+            )}
+          </Box>
+        );
+      default:
+        return 'Unknown step';
+    }
+  };
+
+  const isNextDisabled = () => {
+      if (activeStep === 0) {
+          return isGenerating || !briefing.objetivo || !briefing.publicoAlvo || !briefing.mensagemPrincipal || !briefing.atmosfera;
+      }
+      if (activeStep === 1) {
+          return !generatedPalette;
+      }
+      return false;
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
+      <DialogTitle>
+        Assistente de Geração de Paleta de Cores
+        <Typography variant="body2">Passo {activeStep + 1} de {steps.length}</Typography>
+      </DialogTitle>
+      <DialogContent sx={{ minHeight: '50vh' }}>
+        <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+        {isGenerating && activeStep === 0 ? (
+            <Box sx={{display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%'}}>
+                <CircularProgress />
+                <Typography sx={{ml: 2}}>Gerando paleta...</Typography>
+            </Box>
+        ) : getStepContent(activeStep)}
+      </DialogContent>
+      <DialogActions sx={{ p: 3 }}>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Box sx={{ flex: '1 1 auto' }} />
+        <Button onClick={handleBack} disabled={activeStep === 0 || isGenerating}>
+          Voltar
+        </Button>
+        <Button
+            onClick={handleNext}
+            variant="contained"
+            disabled={isNextDisabled()}
+        >
+          {activeStep === 0 ? 'Gerar Paleta' : 'Salvar Paleta'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PaletteWizard;


### PR DESCRIPTION
This commit refactors the "Gerar Paleta com IA" (Generate Palette with AI) feature into a dedicated wizard component, `PaletteWizard.jsx`. This change improves the user experience by making it consistent with the Persona and Author creation flows.

- **New PaletteWizard Component**: A new `PaletteWizard.jsx` component has been created to encapsulate the entire palette generation process, from briefing to displaying the results.
- **Updated CampaignStandardsModal**: The "Cores" (Colors) tab in the main modal has been updated to remove the inline form and now features a button that launches the new wizard.
- **Reusable PaletteReport Component**: The content of the old `PaletteReportModal` has been extracted into a reusable `PaletteReport.jsx` component, which is now used by both the `PaletteWizard` and the `PaletteReportModal` to display the generated palette's details, reducing code duplication.
- **Code Cleanup**: Unused state and functions related to the old inline form have been removed from `CampaignStandardsModal.jsx`.