### PR TITLE
feat(campaign): Refactor Memorial Descritivo and data flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -124,8 +124,8 @@ function App() {
   const [csvData, setCsvData] = useState([]);
   const [csvHeaders, setCsvHeaders] = useState([]);
   const [backgroundImage, setBackgroundImage] = useState(null);
-  const [colorPalette, setColorPalette] = useState([]);
-  const [campaignColors, setCampaignColors] = useState([]);
+  const [colorPalette, setColorPalette] = useState([]); // Colors from image
+  const [standardsColors, setStandardsColors] = useState([]); // Colors from campaign standards
 
   // Estados para a Campanha
   const [problema, setProblema] = useState('');
@@ -135,8 +135,8 @@ function App() {
   const [campaignGenerationFailed, setCampaignGenerationFailed] = useState(false);
   const [generationError, setGenerationError] = useState('');
   const [editingField, setEditingField] = useState(null);
-  const [personaFields, setPersonaFields] = useState({});
-  const [autor, setAutor] = useState('');
+  const [persona, setPersona] = useState({});
+  const [autor, setAutor] = useState({});
   const [instrucoes, setInstrucoes] = useState('');
   const [formato, setFormato] = useState('');
   const [aspectRatio, setAspectRatio] = useState('1:1');
@@ -170,19 +170,25 @@ function App() {
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const loadCampaignColors = useCallback(() => {
-    const { colors } = getCampaignPrompt();
-    setCampaignColors(colors || []);
+  const loadCampaignStandards = useCallback(() => {
+    const { persona: personaData, autor: autorData, instrucoes: instrucoesData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
+    setPersona(personaData || {});
+    setAutor(autorData || {});
+    setInstrucoes(instrucoesData || '');
+    setFormato(formatoData || '');
+    setStandardsColors(colorsData || []);
   }, []);
 
   useEffect(() => {
-    loadCampaignColors();
-  }, [loadCampaignColors]);
+    loadCampaignStandards();
+  }, [loadCampaignStandards]);
 
   const combinedPalette = useMemo(() => {
-    const allColors = [...(colorPalette || []), ...(campaignColors || [])];
+    // This palette is used for the color picker in the field formatter.
+    // It should combine colors from the standards and colors extracted from the image.
+    const allColors = [...(standardsColors.map(c => c.hex) || []), ...(colorPalette || [])];
     return [...new Set(allColors)];
-  }, [colorPalette, campaignColors]);
+  }, [colorPalette, standardsColors]);
   const [fieldPositions, setFieldPositions] = useState({});
   const [fieldStyles, setFieldStyles] = useState({});
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
@@ -287,7 +293,7 @@ function App() {
       problema,
       solucao,
       campaignContent,
-      personaFields,
+      persona,
       autor,
       instrucoes,
       formato,
@@ -369,7 +375,7 @@ function App() {
         setProblema(savedState.problema || '');
         setSolucao(savedState.solucao || '');
         setCampaignContent(savedState.campaignContent || null);
-        setPersonaFields(savedState.personaFields || {});
+        setPersona(savedState.persona || {});
         setAutor(savedState.autor || '');
         setInstrucoes(savedState.instrucoes || '');
         setFormato(savedState.formato || '');
@@ -422,15 +428,6 @@ function App() {
       setSidebarOpen(false);
     }
   }, [isMobile]);
-
-  useEffect(() => {
-    const { persona: personaData, autor, instrucoes, formato, aspectRatio } = getCampaignPrompt();
-    setPersonaFields(personaData || {});
-    setAutor(autor);
-    setInstrucoes(instrucoes);
-    setFormato(formato);
-    setAspectRatio(aspectRatio || '1:1');
-  }, []);
 
   useEffect(() => {
     const handleLinkedinCallback = async () => {
@@ -1134,13 +1131,13 @@ function App() {
     problema,
     solucao,
     campaignContent,
-    personaFields,
+    persona,
     autor,
     formato,
+    instrucoes,
     aspectRatio,
     followupPosts,
-    colorPalette,
-    campaignColors,
+    colors: standardsColors,
   };
 
   return (
@@ -1498,8 +1495,9 @@ function App() {
         open={showCampaignStandardsModal}
         onClose={() => {
           setShowCampaignStandardsModal(false);
-          loadCampaignColors();
+          loadCampaignStandards();
         }}
+        onShowMemorial={() => setShowMemorialDescritivoModal(true)}
         onGeneratePalette={async (briefing) => {
           try {
             const palette = await generateColorPalette(briefing);

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -81,7 +81,7 @@ function TabPanel(props) {
   );
 }
 
-const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
+const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemorial }) => {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
   const [persona, setPersona] = useState({});
@@ -100,7 +100,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [isGeneratingPersona, setIsGeneratingPersona] = useState(false);
   const [showPersonaGenModal, setShowPersonaGenModal] = useState(false);
   const [showPersonaWizard, setShowPersonaWizard] = useState(false);
-  const [showMemorialModal, setShowMemorialModal] = useState(false);
 
   // State for AI Autor Generation
   const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
@@ -506,10 +505,10 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
               size="small"
               variant="outlined"
               startIcon={<DescriptionIcon />}
-              onClick={() => setShowMemorialModal(true)}
+              onClick={onShowMemorial}
               sx={{ ml: 2 }}
             >
-              Gerar Memorial Descritivo
+              Ver Memorial Descritivo
             </Button>
           </Box>
           <IconButton onClick={onClose} aria-label="Fechar">
@@ -977,11 +976,6 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
         isGenerating={isGenerating}
       />
 
-      <MemorialDescritivoModal
-        open={showMemorialModal}
-        onClose={() => setShowMemorialModal(false)}
-        campaignData={{ persona, autor, instrucoes, formato, colors }}
-      />
     </>
   );
 };

--- a/src/components/MemorialDescritivo/ContentSection.jsx
+++ b/src/components/MemorialDescritivo/ContentSection.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { Typography, Box, Divider } from '@mui/material';
+import { Typography, Box, Paper } from '@mui/material';
 import SectionCard from '../common/SectionCard';
-import CategoryAccordion from '../common/CategoryAccordion';
 import parse from 'html-react-parser';
 
-const DetailItem = ({ title, value, isHtml = false }) => {
+const DetailItem = ({ title, value, isHtml = false, sx = {} }) => {
   if (!value) return null;
   return (
-    <Box sx={{ mb: 3 }}>
+    <Box sx={{ mb: 3, ...sx }}>
       <Typography variant="h6" component="h4" color="primary.main" sx={{ mb: 1 }}>
         {title}
       </Typography>
@@ -15,10 +14,10 @@ const DetailItem = ({ title, value, isHtml = false }) => {
         borderLeft: '3px solid',
         borderColor: 'primary.light',
         pl: 2,
-        '& p': { mb: 1.5 },
+        '& p, & li': { mb: 1.5 },
         '& ul, & ol': { pl: 2.5 },
       }}>
-        {isHtml ? <Typography component="div" variant="body1">{parse(value)}</Typography> : <Typography variant="body1">{value}</Typography>}
+        {isHtml && typeof value === 'string' ? <Typography component="div" variant="body1">{parse(value)}</Typography> : <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>{value}</Typography>}
       </Box>
     </Box>
   );
@@ -28,7 +27,6 @@ const ContentSection = ({
   problema,
   solucao,
   campaignContent,
-  formato,
   aspectRatio,
   followupPosts
 }) => {
@@ -42,7 +40,6 @@ const ContentSection = ({
         </Typography>
         <DetailItem title="Problema / Dor" value={problema} />
         <DetailItem title="Solução / Proposta" value={solucao} />
-        <DetailItem title="Formato" value={formato} />
         <DetailItem title="Proporção" value={aspectRatio} />
       </SectionCard>
 
@@ -54,20 +51,25 @@ const ContentSection = ({
           <DetailItem title="Título" value={campaignContent.titulo} />
           <DetailItem title="Conteúdo" value={campaignContent.conteudo} isHtml={true} />
           <DetailItem title="Call to Action (CTA)" value={campaignContent.cta} />
+           {campaignContent.hashtags && campaignContent.hashtags.length > 0 &&
+             <DetailItem title="Hashtags" value={campaignContent.hashtags.join(', ')} />
+           }
         </SectionCard>
       )}
 
       {followupPosts && followupPosts.length > 0 && (
         <SectionCard>
-          <Typography variant="h4" component="h2" sx={{ mb: 2 }}>
+          <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
             Posts de Acompanhamento
           </Typography>
           {followupPosts.map((post, index) => (
-            <CategoryAccordion key={index} title={post.titulo || `Post ${index + 1}`}>
-              <Box>
-                {post.conteudo && <Typography component="div">{parse(post.conteudo)}</Typography>}
-              </Box>
-            </CategoryAccordion>
+            <Paper key={index} variant="outlined" sx={{ p: 2, mb: 2 }}>
+                <Typography variant="h6" component="h5" gutterBottom>
+                    {post.titulo || `Post ${index + 1}`}
+                </Typography>
+                {post.conteudo && <Typography component="div" variant="body2" sx={{mb: 1}}>{parse(post.conteudo)}</Typography>}
+                {post.cta && <Typography variant="caption" color="text.secondary">CTA: {post.cta}</Typography>}
+            </Paper>
           ))}
         </SectionCard>
       )}

--- a/src/components/MemorialDescritivo/InstructionsSection.jsx
+++ b/src/components/MemorialDescritivo/InstructionsSection.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Typography, Box } from '@mui/material';
+import SectionCard from '../common/SectionCard';
+import parse from 'html-react-parser';
+
+const DetailItem = ({ title, value, isHtml = false }) => {
+  if (!value) return null;
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Typography variant="h6" component="h4" color="primary.main" sx={{ mb: 1 }}>
+        {title}
+      </Typography>
+      <Box sx={{
+        borderLeft: '3px solid',
+        borderColor: 'primary.light',
+        pl: 2,
+        '& p, & li': { mb: 1.5 },
+        '& ul, & ol': { pl: 2.5 },
+        whiteSpace: 'pre-wrap'
+      }}>
+        {isHtml && typeof value === 'string' ? <Typography component="div" variant="body1">{parse(value)}</Typography> : <Typography variant="body1">{value}</Typography>}
+      </Box>
+    </Box>
+  );
+};
+
+
+const InstructionsSection = ({ formato, instrucoes }) => {
+  if (!formato && !instrucoes) {
+    return null;
+  }
+
+  return (
+    <SectionCard>
+      <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
+        Diretrizes de Geração
+      </Typography>
+      <DetailItem title="Formato do Conteúdo" value={formato} isHtml={true} />
+      <DetailItem title="Instruções para a IA" value={instrucoes} isHtml={true} />
+    </SectionCard>
+  );
+};
+
+export default InstructionsSection;

--- a/src/components/MemorialDescritivo/PersonaSection.jsx
+++ b/src/components/MemorialDescritivo/PersonaSection.jsx
@@ -1,83 +1,87 @@
 import React from 'react';
-import { Typography, Box, Grid, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
+import { Typography, Box, Grid, List, ListItem, ListItemIcon, ListItemText, Chip } from '@mui/material';
 import SectionCard from '../common/SectionCard';
-import CategoryAccordion from '../common/CategoryAccordion';
-import InfoChip from '../common/InfoChip';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-const renderValue = (value) => {
-  if (Array.isArray(value)) {
-    return (
-      <List dense>
-        {value.map((item, index) => (
-          <ListItem key={index} sx={{ p: 0 }}>
-            <ListItemIcon sx={{ minWidth: 'auto', mr: 1 }}>
-              <ChevronRightIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary={item} />
-          </ListItem>
-        ))}
-      </List>
-    );
+const DetailItem = ({ title, value }) => {
+  if (!value || (Array.isArray(value) && value.length === 0)) {
+    return null;
   }
-  if (typeof value === 'string' && value.includes(',')) {
-    return (
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-        {value.split(',').map((item, index) => (
-          <InfoChip key={index} label={item.trim()} />
-        ))}
-      </Box>
-    );
-  }
-  return <Typography variant="body1">{value}</Typography>;
+
+  const renderValue = () => {
+    if (Array.isArray(value)) {
+      // Check if it's a list of strings to be rendered as chips
+      if (value.every(item => typeof item === 'string' && !item.includes(' '))) {
+         return (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {value.map((item, index) => (
+              <Chip key={index} label={item.trim()} />
+            ))}
+          </Box>
+        );
+      }
+      // Otherwise, render as a list
+      return (
+        <List dense sx={{ p: 0 }}>
+          {value.map((item, index) => (
+            <ListItem key={index} sx={{ p: 0 }}>
+              <ListItemIcon sx={{ minWidth: 'auto', mr: 1, color: 'primary.main' }}>
+                <ChevronRightIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary={item} />
+            </ListItem>
+          ))}
+        </List>
+      );
+    }
+    // Render simple string value
+    return <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>{value}</Typography>;
+  };
+
+  return (
+    <Grid item xs={12} md={6}>
+        <Box>
+            <Typography variant="h6" component="h4" color="primary.main" sx={{ mb: 1 }}>
+                {title}
+            </Typography>
+            <Box sx={{
+                borderLeft: '3px solid',
+                borderColor: 'primary.light',
+                pl: 2,
+            }}>
+                {renderValue()}
+            </Box>
+        </Box>
+    </Grid>
+  );
 };
+
 
 const PersonaSection = ({ persona }) => {
   if (!persona || Object.keys(persona).length === 0) {
     return null;
   }
 
-  // Separate fields that should be accordions
-  const accordionFields = {};
-  const gridFields = {};
-
-  Object.entries(persona).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
-      accordionFields[key] = value;
-    } else {
-      gridFields[key] = value;
-    }
-  });
+  // Create a more readable title from a camelCase key
+  const formatTitle = (key) => {
+    const result = key.replace(/([A-Z])/g, ' $1');
+    return result.charAt(0).toUpperCase() + result.slice(1);
+  };
 
   return (
     <SectionCard>
       <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
         Persona
       </Typography>
-
-      <Grid container spacing={3}>
-        {Object.entries(gridFields).map(([key, value]) => (
-          <Grid item xs={12} md={6} key={key}>
-            <Typography variant="h6" component="h4" sx={{ mb: 1 }}>
-              {key.replace(/_/g, ' ')}
-            </Typography>
-            {renderValue(value)}
-          </Grid>
+      <Grid container spacing={4}>
+        {Object.entries(persona).map(([key, value]) => (
+          <DetailItem
+            key={key}
+            title={formatTitle(key)}
+            value={value}
+          />
         ))}
       </Grid>
-
-      {Object.keys(accordionFields).length > 0 && (
-        <Box sx={{ mt: 4 }}>
-          <Typography variant="h5" component="h3" sx={{ mb: 2 }}>
-            Dores, Desafios e Outros Detalhes
-          </Typography>
-          {Object.entries(accordionFields).map(([key, value]) => (
-            <CategoryAccordion key={key} title={key.replace(/_/g, ' ')}>
-              {renderValue(value)}
-            </CategoryAccordion>
-          ))}
-        </Box>
-      )}
     </SectionCard>
   );
 };

--- a/src/components/MemorialDescritivo/index.jsx
+++ b/src/components/MemorialDescritivo/index.jsx
@@ -4,6 +4,7 @@ import Header from './Header';
 import PersonaSection from './PersonaSection';
 import AuthorSection from './AuthorSection';
 import ContentSection from './ContentSection';
+import InstructionsSection from './InstructionsSection';
 import ColorPalette from './ColorPalette';
 
 const MemorialDescritivo = ({ campaignData }) => {
@@ -15,17 +16,18 @@ const MemorialDescritivo = ({ campaignData }) => {
     problema,
     solucao,
     campaignContent,
-    personaFields,
+    persona,
     autor,
     formato,
+    instrucoes,
     aspectRatio,
     followupPosts,
-    colorPalette,
-    campaignColors
+    colors,
   } = campaignData;
 
-  const combinedColors = [...(colorPalette || []), ...(campaignColors || [])];
-  const uniqueColors = [...new Set(combinedColors)];
+  // In the new structure, `colors` is the primary array of color objects.
+  // The old `colorPalette` and `campaignColors` are deprecated.
+  const uniqueColors = colors || [];
 
   return (
     <Container maxWidth="md" sx={{ py: { xs: 3, md: 6 } }}>
@@ -36,7 +38,6 @@ const MemorialDescritivo = ({ campaignData }) => {
           problema={problema}
           solucao={solucao}
           campaignContent={campaignContent}
-          formato={formato}
           aspectRatio={aspectRatio}
           followupPosts={followupPosts}
         />
@@ -45,7 +46,13 @@ const MemorialDescritivo = ({ campaignData }) => {
       <Divider sx={{ my: 6 }} />
 
       <Box sx={{ my: 4 }}>
-        <PersonaSection persona={personaFields} />
+        <InstructionsSection formato={formato} instrucoes={instrucoes} />
+      </Box>
+
+      <Divider sx={{ my: 6 }} />
+
+      <Box sx={{ my: 4 }}>
+        <PersonaSection persona={persona} />
       </Box>
 
       <Divider sx={{ my: 6 }} />


### PR DESCRIPTION
This commit implements your significant feedback for the Memorial Descritivo feature and consolidates its data management.

**Changes:**
- **Refactored Memorial Components:**
  - Removed all accordions from the memorial report to display all information directly, per your request.
  - Added a new `InstructionsSection` to ensure `formato` and `instrucoes` are displayed.
  - Updated the `ColorPalette` component to display detailed information (name, role, justification) instead of just a color swatch.

- **Consolidated Data Flow:**
  - The main `App.jsx` component is now the single source of truth for the memorial's data.
  - Removed the duplicate memorial instance from `CampaignStandardsModal`.
  - The `CampaignStandardsModal` now opens the main, data-consistent memorial from the `App` component.
  - Refactored state management in `App.jsx` and `CampaignStandardsModal` to support these changes, including the new rich color object structure.

- **Includes Previous Bug Fix:**
  - This commit also includes the prior fix for the non-existent `WordPress` icon in `SetupModal.jsx`.