### PR TITLE
Fix: Resolve erro de personaFields e revisa layout do memorial

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -318,7 +318,7 @@ function App() {
     problema,
     solucao,
     campaignContent,
-    personaFields,
+    persona,
     autor,
     instrucoes,
     formato,
@@ -756,7 +756,7 @@ function App() {
         problema,
         solucao,
         campaignContent,
-        personaFields,
+        persona,
         autor,
         instrucoes,
         formato,
@@ -805,7 +805,7 @@ function App() {
       setProblema(loadedState.problema || '');
       setSolucao(loadedState.solucao || '');
       setCampaignContent(loadedState.campaignContent || null);
-      setPersonaFields(loadedState.personaFields || {});
+      setPersona(loadedState.persona || {});
       setAutor(loadedState.autor || '');
       setInstrucoes(loadedState.instrucoes || '');
       setFormato(loadedState.formato || '');

--- a/src/components/MemorialDescritivo/AuthorSection.jsx
+++ b/src/components/MemorialDescritivo/AuthorSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Typography, Box } from '@mui/material';
-import SectionCard from '../common/SectionCard';
 import parse from 'html-react-parser';
 
 const DetailItem = ({ title, value, isHtml = false }) => {
@@ -39,7 +38,7 @@ const AuthorSection = ({ author }) => {
   } = author;
 
   return (
-    <SectionCard>
+    <Box>
       <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
         Definições do Autor
       </Typography>
@@ -52,7 +51,7 @@ const AuthorSection = ({ author }) => {
       <DetailItem title="Domínio de Referência" value={dominioReferencia} />
       <DetailItem title="Site para Exclusão de Referência" value={siteExclusao} />
 
-    </SectionCard>
+    </Box>
   );
 };
 

--- a/src/components/MemorialDescritivo/ContentSection.jsx
+++ b/src/components/MemorialDescritivo/ContentSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Typography, Box, Paper } from '@mui/material';
-import SectionCard from '../common/SectionCard';
 import parse from 'html-react-parser';
 
 const DetailItem = ({ title, value, isHtml = false, sx = {} }) => {
@@ -34,17 +33,17 @@ const ContentSection = ({
 
   return (
     <>
-      <SectionCard>
+      <Box>
         <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
           Diretrizes da Campanha
         </Typography>
         <DetailItem title="Problema / Dor" value={problema} />
         <DetailItem title="Solução / Proposta" value={solucao} />
         <DetailItem title="Proporção" value={aspectRatio} />
-      </SectionCard>
+      </Box>
 
       {hasCampaignContent && (
-        <SectionCard>
+        <Box sx={{ mt: 4 }}>
           <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
             Conteúdo Principal Gerado
           </Typography>
@@ -54,11 +53,11 @@ const ContentSection = ({
            {campaignContent.hashtags && campaignContent.hashtags.length > 0 &&
              <DetailItem title="Hashtags" value={campaignContent.hashtags.join(', ')} />
            }
-        </SectionCard>
+        </Box>
       )}
 
       {followupPosts && followupPosts.length > 0 && (
-        <SectionCard>
+        <Box sx={{ mt: 4 }}>
           <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
             Posts de Acompanhamento
           </Typography>
@@ -71,7 +70,7 @@ const ContentSection = ({
                 {post.cta && <Typography variant="caption" color="text.secondary">CTA: {post.cta}</Typography>}
             </Paper>
           ))}
-        </SectionCard>
+        </Box>
       )}
     </>
   );

--- a/src/components/MemorialDescritivo/InstructionsSection.jsx
+++ b/src/components/MemorialDescritivo/InstructionsSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Typography, Box } from '@mui/material';
-import SectionCard from '../common/SectionCard';
 import parse from 'html-react-parser';
 
 const DetailItem = ({ title, value, isHtml = false }) => {
@@ -31,13 +30,13 @@ const InstructionsSection = ({ formato, instrucoes }) => {
   }
 
   return (
-    <SectionCard>
+    <Box>
       <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
         Diretrizes de Geração
       </Typography>
       <DetailItem title="Formato do Conteúdo" value={formato} isHtml={true} />
       <DetailItem title="Instruções para a IA" value={instrucoes} isHtml={true} />
-    </SectionCard>
+    </Box>
   );
 };
 

--- a/src/components/MemorialDescritivo/PersonaSection.jsx
+++ b/src/components/MemorialDescritivo/PersonaSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Typography, Box, Grid, List, ListItem, ListItemIcon, ListItemText, Chip } from '@mui/material';
-import SectionCard from '../common/SectionCard';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import parse from 'html-react-parser';
 
@@ -70,10 +69,10 @@ const PersonaSection = ({ persona }) => {
     return result.charAt(0).toUpperCase() + result.slice(1);
   };
 
-  const htmlFields = ['mentalidadeValores', 'contextoCultural'];
+  const htmlFields = ['mentalidadeValores', 'contextoCultural', 'dores', 'necessidades', 'motivacoes', 'crencasLimitantes', 'sonhosAspiracoes', 'jornada'];
 
   return (
-    <SectionCard>
+    <Box>
       <Typography variant="h4" component="h2" sx={{ mb: 4 }}>
         Persona
       </Typography>
@@ -87,7 +86,7 @@ const PersonaSection = ({ persona }) => {
           />
         ))}
       </Grid>
-    </SectionCard>
+    </Box>
   );
 };
 


### PR DESCRIPTION
Esta mudança corrige um erro de `ReferenceError: personaFields is not defined` que ocorria ao carregar a aplicação. O erro foi causado por uma inconsistência na nomeação de uma variável de estado, que foi corrigida de `personaFields` para `persona` em `App.jsx`.

Além disso, o layout do Memorial da Campanha foi revisado para melhorar a apresentação das informações. Os componentes `SectionCard` foram removidos para criar uma visualização mais unificada e fluida, e foi garantido que todos os campos com conteúdo HTML sejam renderizados corretamente, em vez de exibir tags HTML.