### PR TITLE
fix: Resolve ReferenceError em MemorialDescritivo

### DIFF
--- a/src/components/MemorialDescritivo/index.jsx
+++ b/src/components/MemorialDescritivo/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Container, Divider } from '@mui/material';
+import { Box, Container, Divider, Typography } from '@mui/material';
 import Header from './Header';
 import PersonaSection from './PersonaSection';
 import AuthorSection from './AuthorSection';


### PR DESCRIPTION
Esta mudança corrige um `ReferenceError: Typography is not defined` que ocorria no componente `MemorialDescritivo`. O erro foi causado pela ausência da importação do componente `Typography` de `@mui/material` no arquivo `src/components/MemorialDescritivo/index.jsx`.

A importação foi adicionada, resolvendo o erro de renderização e garantindo que o memorial da campanha seja exibido corretamente.