### PR TITLE
feat: Allow editing of followup posts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,6 +153,7 @@ function App() {
   const [followupPosts, setFollowupPosts] = useState([]);
   const [isGeneratingFollowup, setIsGeneratingFollowup] = useState(false);
   const [followupPostsQuantity, setFollowupPostsQuantity] = useState(5);
+  const [editingFollowup, setEditingFollowup] = useState(null);
 
   // Publisher State
   const [isScheduled, setIsScheduled] = useState(false);
@@ -1095,6 +1096,23 @@ function App() {
     setFollowupPostsQuantity(5);
   };
 
+  const handleEditFollowup = (index, content) => {
+    setEditingFollowup({ index, content });
+  };
+
+  const handleSaveFollowup = (newContent) => {
+    if (editingFollowup === null) return;
+
+    const updatedPosts = followupPosts.map((post, index) => {
+      if (index === editingFollowup.index) {
+        return { ...post, conteudo: newContent };
+      }
+      return post;
+    });
+    setFollowupPosts(updatedPosts);
+    setEditingFollowup(null);
+  };
+
   const handleGenerateSolucao = async () => {
     setIsGeneratingSolucao(true);
     try {
@@ -1299,6 +1317,7 @@ function App() {
               isGeneratingImage={isGeneratingImage}
               handleGenerateImage={handleGenerateImage}
               setCampaignContent={setCampaignContent}
+              onEditFollowup={handleEditFollowup}
             />
             </Container>
           )}
@@ -1557,24 +1576,45 @@ function App() {
         }
       />
       <TextEditorDialog
-        open={editingField !== null}
-        title={`Editar ${
-          editingField === 'conteudo' ? 'Conteúdo'
-          : editingField === 'cta' ? 'CTA'
-          : 'Conteúdo Formatado'
-        }`}
-        content={
-          editingField === 'conteudoFormatado' ? conteudoFormatado
-          : editingField ? campaignContent[editingField] : ''
+        open={editingField !== null || editingFollowup !== null}
+        title={
+          editingFollowup !== null
+            ? `Editar Post de Follow-up ${editingFollowup.index + 1}`
+            : `Editar ${
+                editingField === 'conteudo'
+                  ? 'Conteúdo'
+                  : editingField === 'cta'
+                  ? 'CTA'
+                  : 'Conteúdo Formatado'
+              }`
         }
-        onSave={(newContent) => {
-          if (editingField === 'conteudoFormatado') {
-            setConteudoFormatado(newContent);
-          } else {
-            setCampaignContent({ ...campaignContent, [editingField]: newContent });
-          }
+        content={
+          editingFollowup !== null
+            ? editingFollowup.content
+            : editingField === 'conteudoFormatado'
+            ? conteudoFormatado
+            : editingField
+            ? campaignContent[editingField]
+            : ''
+        }
+        onSave={
+          editingFollowup !== null
+            ? handleSaveFollowup
+            : (newContent) => {
+                if (editingField === 'conteudoFormatado') {
+                  setConteudoFormatado(newContent);
+                } else {
+                  setCampaignContent({
+                    ...campaignContent,
+                    [editingField]: newContent,
+                  });
+                }
+              }
+        }
+        onClose={() => {
+          setEditingField(null);
+          setEditingFollowup(null);
         }}
-        onClose={() => setEditingField(null)}
       />
       {isMobile && activeStep === 4 && (
         <>

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -60,6 +60,7 @@ const Campaign = ({
     isGeneratingImage,
     handleGenerateImage,
     setCampaignContent,
+    onEditFollowup,
 }) => {
     return (
         <Card>
@@ -327,7 +328,7 @@ const Campaign = ({
                                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                                     <Typography>Post {post.post_numero}: {post.tipo_gancho}</Typography>
                                 </AccordionSummary>
-                                <AccordionDetails>
+                                <AccordionDetails sx={{ cursor: 'pointer' }} onClick={() => onEditFollowup(index, post.conteudo)}>
                                     <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
                                         {post.conteudo}
                                     </Typography>

--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -11,7 +11,6 @@ import {
   Typography,
   IconButton
 } from '@mui/material';
-import { useIsMobile } from '../hooks/use-mobile.js';
 import {
   Close as CloseIcon,
   VpnKey,
@@ -59,7 +58,6 @@ function TabPanel(props) {
 }
 
 const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
-  const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
   const [showPasswordDialog, setShowPasswordDialog] = useState(false);
   const [passwordDialogAction, setPasswordDialogAction] = useState(null); // 'save' or 'load'
@@ -122,25 +120,24 @@ const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           Configurações
           <IconButton onClick={onClose}>
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <DialogContent sx={{ display: 'flex', p: 0, minHeight: '500px', flexDirection: isMobile ? 'column' : 'row' }}>
+        <DialogContent sx={{ display: 'flex', p: 0, minHeight: '500px' }}>
           <Tabs
-            orientation={isMobile ? 'horizontal' : 'vertical'}
+            orientation="vertical"
             variant="scrollable"
             value={value}
             onChange={handleChange}
             aria-label="Vertical tabs example"
             sx={{
-              borderRight: isMobile ? 0 : 1,
-              borderBottom: isMobile ? 1 : 0,
+              borderRight: 1,
               borderColor: 'divider',
-              minWidth: isMobile ? 'auto' : 200,
+              minWidth: 200,
             }}
           >
             <Tab icon={<AutoAwesome />} iconPosition="start" label="Gemini" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(0)} />


### PR DESCRIPTION
This change introduces the ability to edit followup posts generated during a campaign. You can now click on a followup post to open an editing modal and save your changes.