### PR TITLE
fix: Add responsive behavior to SetupModal

### DIFF
--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { useIsMobile } from '../hooks/use-mobile.js';
 import {
   Dialog,
   DialogTitle,
@@ -58,6 +59,7 @@ function TabPanel(props) {
 }
 
 const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
+  const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
   const [showPasswordDialog, setShowPasswordDialog] = useState(false);
   const [passwordDialogAction, setPasswordDialogAction] = useState(null); // 'save' or 'load'
@@ -120,7 +122,7 @@ const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           Configurações
           <IconButton onClick={onClose}>


### PR DESCRIPTION
This commit fixes a regression where the main SetupModal was no longer responsive on smaller screens.

The `useIsMobile` hook is now used to conditionally apply the `fullScreen` prop to the `Dialog` component, ensuring it correctly adapts to mobile viewports. This makes its behavior consistent with other modals in the application.