### PR TITLE
fix: Restore responsive layout to SetupModal

### DIFF
--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { useIsMobile } from '../hooks/use-mobile.js';
 import {
   Dialog,
   DialogTitle,
@@ -58,6 +59,7 @@ function TabPanel(props) {
 }
 
 const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
+  const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
   const [showPasswordDialog, setShowPasswordDialog] = useState(false);
   const [passwordDialogAction, setPasswordDialogAction] = useState(null); // 'save' or 'load'
@@ -120,24 +122,25 @@ const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           Configurações
           <IconButton onClick={onClose}>
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <DialogContent sx={{ display: 'flex', p: 0, minHeight: '500px' }}>
+        <DialogContent sx={{ display: 'flex', p: 0, minHeight: '500px', flexDirection: isMobile ? 'column' : 'row' }}>
           <Tabs
-            orientation="vertical"
+            orientation={isMobile ? 'horizontal' : 'vertical'}
             variant="scrollable"
             value={value}
             onChange={handleChange}
-            aria-label="Vertical tabs example"
+            aria-label="Configuration tabs"
             sx={{
-              borderRight: 1,
+              borderRight: isMobile ? 0 : 1,
+              borderBottom: isMobile ? 1 : 0,
               borderColor: 'divider',
-              minWidth: 200,
+              minWidth: isMobile ? 'auto' : 200,
             }}
           >
             <Tab icon={<AutoAwesome />} iconPosition="start" label="Gemini" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(0)} />


### PR DESCRIPTION
This commit fixes a regression where the SetupModal was no longer displaying correctly on mobile devices.

The DialogContent's flex-direction and the Tabs' orientation are now conditional based on screen size, using the `useIsMobile` hook. This ensures the tabs switch from vertical on desktop to horizontal on mobile, as was the original behavior.