### PR TITLE
fix: Broaden Google Drive API scope to find folders you've created

### DIFF
--- a/src/utils/googleDriveAPI.js
+++ b/src/utils/googleDriveAPI.js
@@ -62,7 +62,7 @@ class GoogleDriveAPI {
       // 2. Configura o Token Client para autenticação
       this.tokenClient = window.google.accounts.oauth2.initTokenClient({
         client_id: clientId,
-        scope: 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/spreadsheets',
+        scope: 'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/spreadsheets',
         callback: (response) => {
           if (response.error) {
             const err = new Error(`Erro de autenticação: ${response.error}`);


### PR DESCRIPTION
This commit addresses an issue where the application could not find the 'midiator' folder even if it existed in your Google Drive.

The root cause was the use of the `drive.file` scope, which only grants access to files and folders created or opened by the application itself. This prevented the app from finding folders you created manually.

The API scope has been changed from `https://www.googleapis.com/auth/drive.file` to `https://www.googleapis.com/auth/drive`. This broader scope allows the application to search your entire Google Drive, enabling it to find the necessary 'midiator/elementos' folder structure as intended.