### PR TITLE
refactor: Remove legacy logo and company image system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -209,8 +209,6 @@ function App() {
     blur: 0,
     opacity: 100,
   });
-  const [includeLogo, setIncludeLogo] = useState(true);
-  const [includeEmpresa, setIncludeEmpresa] = useState(true);
   const [brandElements, setBrandElements] = useState([]); // State for brand elements
   const [showSetupModal, setShowSetupModal] = useState(false);
   const [showCampaignStandardsModal, setShowCampaignStandardsModal] = useState(false);
@@ -1370,8 +1368,6 @@ function App() {
                   onSelectFieldExternal={setSelectedField}
                   originalImageSize={originalImageSize}
                   imageFilters={imageFilters}
-                  includeLogo={includeLogo}
-                  includeEmpresa={includeEmpresa}
                   brandElements={brandElements}
                   setBrandElements={setBrandElements}
                 />
@@ -1387,10 +1383,6 @@ function App() {
                     csvHeaders={csvHeaders}
                     imageFilters={imageFilters}
                     setImageFilters={setImageFilters}
-                    includeLogo={includeLogo}
-                    setIncludeLogo={setIncludeLogo}
-                    includeEmpresa={includeEmpresa}
-                    setIncludeEmpresa={setIncludeEmpresa}
                     brandElements={brandElements}
                     setBrandElements={setBrandElements}
                   />
@@ -1414,8 +1406,6 @@ function App() {
               onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate}
               originalImageSize={originalImageSize}
               imageFilters={imageFilters}
-              includeLogo={includeLogo}
-              includeEmpresa={includeEmpresa}
               brandElements={brandElements}
               onBrandElementsChange={setBrandElements}
             />
@@ -1623,10 +1613,6 @@ function App() {
             csvHeaders={csvHeaders}
             imageFilters={imageFilters}
             setImageFilters={setImageFilters}
-            includeLogo={includeLogo}
-            setIncludeLogo={setIncludeLogo}
-            includeEmpresa={includeEmpresa}
-            setIncludeEmpresa={setIncludeEmpresa}
             brandElements={brandElements}
             setBrandElements={setBrandElements}
           />

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -93,8 +93,6 @@ const FieldPositioner = ({
   originalImageSize,
   darkMode,
   imageFilters,
-  includeLogo,
-  includeEmpresa,
   brandElements,
   setBrandElements,
 }) => {
@@ -117,11 +115,7 @@ const FieldPositioner = ({
       try {
         const composedUrl = await composeImage(
           backgroundImage,
-          '/logo.png',
-          '/empresa.png',
-          imageFilters,
-          includeLogo,
-          includeEmpresa
+          imageFilters
           // Do not pass brandElements here to prevent ghosting.
           // They are rendered as interactive DraggableElement components on top.
         );

--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -14,10 +14,6 @@ const FormattingDrawer = ({
   csvHeaders,
   imageFilters,
   setImageFilters,
-  includeLogo,
-  setIncludeLogo,
-  includeEmpresa,
-  setIncludeEmpresa,
   brandElements,
   setBrandElements
 }) => {
@@ -39,10 +35,6 @@ const FormattingDrawer = ({
           csvHeaders={csvHeaders}
           imageFilters={imageFilters}
           setImageFilters={setImageFilters}
-          includeLogo={includeLogo}
-          setIncludeLogo={setIncludeLogo}
-          includeEmpresa={includeEmpresa}
-          setIncludeEmpresa={setIncludeEmpresa}
           brandElements={brandElements}
           setBrandElements={setBrandElements}
         />

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -51,10 +51,6 @@ const FormattingPanel = ({
   csvHeaders,
   imageFilters,
   setImageFilters,
-  includeLogo,
-  setIncludeLogo,
-  includeEmpresa,
-  setIncludeEmpresa,
   brandElements,
   setBrandElements
 }) => {
@@ -483,15 +479,6 @@ const FormattingPanel = ({
           </AccordionSummary>
           <AccordionDetails>
             <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-              <FormControlLabel
-                control={<Switch checked={includeLogo} onChange={(e) => setIncludeLogo(e.target.checked)} />}
-                label="Incluir Logo"
-              />
-              <FormControlLabel
-                control={<Switch checked={includeEmpresa} onChange={(e) => setIncludeEmpresa(e.target.checked)} />}
-                label="Incluir Imagem da Empresa"
-              />
-              <Divider sx={{ my: 2 }} />
               <BrandElementManager
                 onElementSelect={(newElement) => {
                   setBrandElements(prev => [...prev, newElement]);

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -54,8 +54,6 @@ const GeneratedImageEditor = ({
   globalBackgroundImage, // Imagem de fundo global, como fallback
   originalImageSize,
   imageFilters, // Adicionado
-  includeLogo, // Adicionado
-  includeEmpresa, // Adicionado
   brandElements
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
@@ -70,8 +68,6 @@ const GeneratedImageEditor = ({
 
   // Local state for image filters and toggles
   const [editedImageFilters, setEditedImageFilters] = useState(imageFilters);
-  const [editedIncludeLogo, setEditedIncludeLogo] = useState(includeLogo);
-  const [editedIncludeEmpresa, setEditedIncludeEmpresa] = useState(includeEmpresa);
 
   const handleInternalFieldSelection = useCallback((fieldToSelect) => {
     setSelectedFieldInternal(fieldToSelect);
@@ -109,14 +105,12 @@ const GeneratedImageEditor = ({
       // Reset filter and toggle states when the editor is opened for a new image
       // TODO: In the future, this could be initialized from imageData if custom filters are saved per image
       setEditedImageFilters(imageFilters);
-      setEditedIncludeLogo(includeLogo);
-      setEditedIncludeEmpresa(includeEmpresa);
       setEditedBrandElements(JSON.parse(JSON.stringify(brandElements || [])));
     } else {
       // If essential data is missing, ensure we are not in an initialized state.
       setStylesAreInitialized(false);
     }
-  }, [open, imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, includeLogo, includeEmpresa, brandElements]);
+  }, [open, imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, brandElements]);
 
   if (!imageData) {
     return null;
@@ -185,8 +179,6 @@ const GeneratedImageEditor = ({
                 onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
                 originalImageSize={originalImageSize}
                 imageFilters={editedImageFilters}
-                includeLogo={editedIncludeLogo}
-                includeEmpresa={editedIncludeEmpresa}
                 brandElements={editedBrandElements}
                 setBrandElements={setEditedBrandElements}
               />
@@ -202,10 +194,6 @@ const GeneratedImageEditor = ({
                   csvHeaders={editorCsvHeaders}
                   imageFilters={editedImageFilters}
                   setImageFilters={setEditedImageFilters}
-                  includeLogo={editedIncludeLogo}
-                  setIncludeLogo={setEditedIncludeLogo}
-                  includeEmpresa={editedIncludeEmpresa}
-                  setIncludeEmpresa={setEditedIncludeEmpresa}
                   brandElements={editedBrandElements}
                   setBrandElements={setEditedBrandElements}
                 />

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -52,8 +52,6 @@ const ImageGeneratorFrontendOnly = ({
   onThumbnailRecordTextUpdate, // <-- ADICIONADO: Callback para atualizar o CSV em App.jsx
   originalImageSize,
   imageFilters,
-  includeLogo,
-  includeEmpresa,
   brandElements,
   onBrandElementsChange
 }) => {
@@ -246,11 +244,7 @@ const ImageGeneratorFrontendOnly = ({
       console.log('[generateImages] Calling composeImage for the main generation.');
       const composedBackgroundImageUrl = await composeImage(
         backgroundImage,
-        '/logo.png',
-        '/empresa.png',
         imageFilters,
-        includeLogo,
-        includeEmpresa,
         brandElements
       );
       console.log('[generateImages] composeImage finished for the main generation.');
@@ -586,11 +580,7 @@ const ImageGeneratorFrontendOnly = ({
       console.log(`[regenerateSingleImage] Calling composeImage for index ${index}.`);
       const composedBackgroundImageUrl = await composeImage(
         currentBackgroundImage,
-        '/logo.png',
-        '/empresa.png',
         imageFilters,
-        includeLogo,
-        includeEmpresa,
         elementsToUse
       );
       console.log(`[regenerateSingleImage] composeImage finished for index ${index}.`);
@@ -1234,8 +1224,6 @@ const ImageGeneratorFrontendOnly = ({
             globalBackgroundImage={backgroundImage}
             originalImageSize={imageToEdit.customOriginalImageSize || originalImageSize} // Pass custom size if available
             imageFilters={imageFilters}
-            includeLogo={includeLogo}
-            includeEmpresa={includeEmpresa}
             brandElements={brandElements}
           />
         );

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -34,50 +34,21 @@ const loadImage = (src) => {
  */
 export const composeImage = async (
   backgroundImageUrl,
-  logoUrl,
-  companyImageUrl,
   imageFilters = {},
-  includeLogo = true,
-  includeEmpresa = true,
   brandElements = []
 ) => {
   console.log('[composeImage] Starting composition with:', {
     backgroundImageUrl,
-    logoUrl,
-    companyImageUrl,
     imageFilters,
-    includeLogo,
-    includeEmpresa,
     brandElements
   });
   try {
-    const companyBackgroundColor = '#808080'; // A neutral gray
-
     let backgroundSrc = backgroundImageUrl;
     if (!backgroundImageUrl.startsWith('data:') && !backgroundImageUrl.startsWith('http')) {
       backgroundSrc = `data:image/png;base64,${backgroundImageUrl}`;
     }
 
-    const imagePromises = [loadImage(backgroundSrc)];
-    if (includeLogo && logoUrl) {
-      imagePromises.push(loadImage(logoUrl));
-    }
-    if (includeEmpresa && companyImageUrl) {
-      imagePromises.push(loadImage(companyImageUrl));
-    }
-
-    const images = await Promise.all(imagePromises);
-    const bgImg = images[0];
-    let logoImg = null;
-    let companyImg = null;
-    let currentImageIndex = 1;
-
-    if (includeLogo && logoUrl) {
-      logoImg = images[currentImageIndex++];
-    }
-    if (includeEmpresa && companyImageUrl) {
-      companyImg = images[currentImageIndex];
-    }
+    const bgImg = await loadImage(backgroundSrc);
 
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
@@ -91,30 +62,6 @@ export const composeImage = async (
     ctx.filter = filterString;
     ctx.drawImage(bgImg, 0, 0, targetWidth, targetHeight);
     ctx.filter = 'none';
-
-    const margin = targetWidth * 0.02;
-
-    if (includeLogo && logoImg) {
-      const logoHeight = targetHeight * 0.1;
-      const logoScale = logoHeight / logoImg.height;
-      const logoWidth = logoImg.width * logoScale;
-      ctx.drawImage(logoImg, margin, margin, logoWidth, logoHeight);
-      console.log(`[composeImage] Drawing logo at (${margin}, ${margin})`);
-    }
-
-    if (includeEmpresa && companyImg) {
-      const companyImgHeight = targetHeight * 0.1;
-      const companyImgScale = companyImgHeight / companyImg.height;
-      const companyImgWidth = companyImg.width * companyImgScale;
-
-      ctx.fillStyle = companyBackgroundColor;
-      ctx.fillRect(0, targetHeight - companyImgHeight, targetWidth, companyImgHeight);
-
-      const companyImgX = targetWidth - companyImgWidth - margin;
-      const companyImgY = targetHeight - companyImgHeight;
-      ctx.drawImage(companyImg, companyImgX, companyImgY, companyImgWidth, companyImgHeight);
-      console.log(`[composeImage] Drawing company image at (${companyImgX}, ${companyImgY})`);
-    }
 
     // Draw brand elements
     for (const element of brandElements) {


### PR DESCRIPTION
This commit removes the old, fixed system for including a `logo.png` and `empresa.png` in the generated images. This functionality is now completely replaced by the new, more flexible "Brand Elements" feature.

The following changes were made:
-   Removed the `includeLogo` and `includeEmpresa` state and props from `App.jsx` and all child components.
-   Removed the UI switches for these options from `FormattingPanel.jsx` and `FormattingDrawer.jsx`.
-   Simplified the `composeImage` function in `imageComposer.js` to no longer accept or process the legacy logo and company image URLs.
-   Updated all calls to `composeImage` throughout the application to use the new, simpler signature.

This change streamlines the UI and codebase, making the brand elements feature the single source of truth for adding images to the canvas.