### PR TITLE
fix: Remove dangling references to includeLogo

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -129,7 +129,7 @@ const FieldPositioner = ({
     };
 
     generateComposedImage();
-  }, [backgroundImage, imageFilters, includeLogo, includeEmpresa]);
+  }, [backgroundImage, imageFilters]);
 
   // Campos que devem usar renderização HTML
   const htmlFields = ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'];


### PR DESCRIPTION
This commit fixes a ReferenceError crash caused by leftover variable references after a recent refactoring.

The `includeLogo` and `includeEmpresa` variables were still present in the dependency array of a `useEffect` hook in `FieldPositioner.jsx`, even after they were removed as props. This caused the application to crash when the component rendered.

These dangling references have now been removed, resolving the error.