### PR TITLE
feat: Adiciona controles de ordem de camada (z-index)

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -580,6 +580,7 @@ const DraggableElement = ({
           width: `${position.width}%`,
           height: `${position.height}%`,
           transform: `rotate(${rotation || 0}deg)`,
+          zIndex: position.zIndex || 'auto',
         }}
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
         onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -498,6 +498,53 @@ const FieldPositioner = ({
     );
   }
 
+  const renderableElements = React.useMemo(() => {
+    const elements = [
+      ...(csvHeaders || [])
+        .map(header => {
+          const position = fieldPositions[header];
+          const style = fieldStyles[header];
+          if (!position || !position.visible) return null;
+
+          const record = csvData[currentPreviewIndex] || {};
+          const sampleData = record[header] !== undefined ? record[header] : `[${header}]`;
+
+          return {
+            id: header,
+            type: 'text',
+            position,
+            style,
+            content: sampleData,
+            zIndex: position.zIndex || 0,
+            rotation: position.rotation,
+            fontScale: (imageSize.width && originalImageSize?.width) ? imageSize.width / originalImageSize.width : 1,
+            enableHtmlRendering: isHtmlField(header),
+          };
+        })
+        .filter(Boolean),
+      ...(brandElements || [])
+        .map(element => {
+          if (!element.visible) return null;
+          return {
+            id: element.id,
+            type: 'image',
+            position: element,
+            style: { ...element.filters },
+            content: element.url,
+            zIndex: element.zIndex || 0,
+            rotation: element.rotation,
+            fontScale: 1,
+            enableHtmlRendering: false,
+          };
+        })
+        .filter(Boolean)
+    ];
+
+    elements.sort((a, b) => a.zIndex - b.zIndex);
+    return elements;
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize]);
+
+
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} lg={12}>
@@ -575,59 +622,26 @@ const FieldPositioner = ({
                 draggable={false}
               />
 
-              {csvHeaders && csvHeaders.length > 0
-                ? csvHeaders.map(header => {
-                  const position = fieldPositions[header];
-                  const style = fieldStyles[header];
-                  if (!position || !position.visible) return null;
-                  const record = csvData[currentPreviewIndex] || {};
-                  const sampleData = record[header] !== undefined ? record[header] : `[${header}]`;
-
-                  return (
-                    <DraggableElement
-                      key={header}
-                      element={{ id: header, type: 'text' }}
-                      position={position}
-                      style={style}
-                      content={sampleData}
-                      isSelected={selectedField === header}
-                      onSelect={handleFieldSelectInternal}
-                      onPositionChange={handlePositionChange}
-                      onSizeChange={handleSizeChange}
-                      containerSize={imageSize}
-                      onContentChange={handleContentChange}
-                      rotation={position.rotation}
-                      originalImageSize={originalImageSize}
-                      fontScale={(imageSize.width && originalImageSize?.width) ? imageSize.width / originalImageSize.width : 1}
-                      enableHtmlRendering={isHtmlField(header)}
-                      darkMode={darkMode}
-                    />
-                  );
-                })
-                : null}
-
-              {brandElements && brandElements.map(element => {
-                // The position and style for brand elements are stored directly on the element object.
-                return (
-                  <DraggableElement
-                    key={element.id}
-                    element={{ ...element, type: 'image' }} // Pass the whole element object
-                    position={element} // Position data is on the element itself
-                    style={{}} // Style for images might be different, or not applicable
-                    content={element.url} // The image URL
-                    isSelected={selectedField === element.id}
-                    onSelect={handleFieldSelectInternal}
-                    onPositionChange={handlePositionChange}
-                    onSizeChange={handleSizeChange}
-                    containerSize={imageSize}
-                    rotation={element.rotation}
-                    originalImageSize={originalImageSize}
-                    fontScale={1} // Not applicable for images
-                    enableHtmlRendering={false}
-                    darkMode={darkMode}
-                  />
-                );
-              })}
+              {renderableElements.map(element => (
+                <DraggableElement
+                  key={element.id}
+                  element={{ id: element.id, type: element.type }}
+                  position={element.position}
+                  style={element.style}
+                  content={element.content}
+                  isSelected={selectedField === element.id}
+                  onSelect={handleFieldSelectInternal}
+                  onPositionChange={handlePositionChange}
+                  onSizeChange={handleSizeChange}
+                  containerSize={imageSize}
+                  onContentChange={element.type === 'text' ? handleContentChange : undefined}
+                  rotation={element.rotation}
+                  originalImageSize={originalImageSize}
+                  fontScale={element.fontScale}
+                  enableHtmlRendering={element.enableHtmlRendering}
+                  darkMode={darkMode}
+                />
+              ))}
             </Box>
 
             {csvData && csvData.length > 1 && (

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -18,7 +18,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Chip
+  Chip,
+  Tooltip,
+  IconButton
 } from '@mui/material';
 import {
   ExpandMore,
@@ -35,7 +37,11 @@ import {
   VerticalAlignBottom,
   FormatBold,
   FormatItalic,
-  FormatUnderlined
+  FormatUnderlined,
+  FlipToFront,
+  FlipToBack,
+  ArrowUpward,
+  ArrowDownward
 } from '@mui/icons-material';
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 
@@ -52,7 +58,8 @@ const FormattingPanel = ({
   imageFilters,
   setImageFilters,
   brandElements,
-  setBrandElements
+  setBrandElements,
+  onZIndexChange
 }) => {
   const fonts = [
     'Arial', 'Helvetica', 'Times New Roman', 'Georgia', 'Verdana', 'Courier New', 'Impact', 'Comic Sans MS',
@@ -246,6 +253,31 @@ const FormattingPanel = ({
                         { value: 360, label: '360°' },
                       ]}
                     />
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Typography variant="caption" display="block" gutterBottom>Ordem das Camadas</Typography>
+                    <ToggleButtonGroup size="small" fullWidth aria-label="layer order controls">
+                      <Tooltip title="Enviar para o Fundo">
+                        <ToggleButton value="back" onClick={() => onZIndexChange(selectedField, 'back')}>
+                          <FlipToBack />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title="Recuar">
+                        <ToggleButton value="backward" onClick={() => onZIndexChange(selectedField, 'backward')}>
+                          <ArrowDownward />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title="Avançar">
+                        <ToggleButton value="forward" onClick={() => onZIndexChange(selectedField, 'forward')}>
+                          <ArrowUpward />
+                        </ToggleButton>
+                      </Tooltip>
+                      <Tooltip title="Trazer para Frente">
+                        <ToggleButton value="front" onClick={() => onZIndexChange(selectedField, 'front')}>
+                          <FlipToFront />
+                        </ToggleButton>
+                      </Tooltip>
+                    </ToggleButtonGroup>
                   </Grid>
                 </Grid>
               </AccordionDetails>

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -79,35 +79,102 @@ const GeneratedImageEditor = ({
     }
   }, []); // setEditedRecord is stable
 
-  useEffect(() => {
-    // Diagnostic logs from previous session removed.
-    // The console.log for imageData was already commented and can remain as such if desired for future debugging, or removed.
-    // For this cleanup, we ensure active diagnostic logs are removed.
+  const handleZIndexChange = (elementId, action) => {
+    if (!elementId) return;
 
+    let allElements = [
+      ...Object.entries(editedPositions).map(([id, pos]) => ({ id, zIndex: pos.zIndex, isBrand: false })),
+      ...editedBrandElements.map(el => ({ id: el.id, zIndex: el.zIndex, isBrand: true })),
+    ];
+
+    allElements.sort((a, b) => (a.zIndex || 0) - (b.zIndex || 0));
+
+    const currentIndex = allElements.findIndex(el => el.id === elementId);
+    if (currentIndex === -1) return;
+
+    const [currentElement] = allElements.splice(currentIndex, 1);
+
+    switch (action) {
+      case 'front':
+        allElements.push(currentElement);
+        break;
+      case 'back':
+        allElements.unshift(currentElement);
+        break;
+      case 'forward':
+        allElements.splice(Math.min(currentIndex + 1, allElements.length), 0, currentElement);
+        break;
+      case 'backward':
+        allElements.splice(Math.max(currentIndex - 1, 0), 0, currentElement);
+        break;
+      default:
+        allElements.splice(currentIndex, 0, currentElement);
+        return;
+    }
+
+    const newPositions = { ...editedPositions };
+    const newBrandElements = [...editedBrandElements];
+
+    allElements.forEach((el, index) => {
+      el.zIndex = index;
+      if (el.isBrand) {
+        const brandEl = newBrandElements.find(b => b.id === el.id);
+        if (brandEl) brandEl.zIndex = index;
+      } else {
+        if (newPositions[el.id]) {
+          newPositions[el.id].zIndex = index;
+        }
+      }
+    });
+
+    setEditedPositions(newPositions);
+    setEditedBrandElements(newBrandElements);
+  };
+
+  useEffect(() => {
     if (imageData && initialFieldPositions && initialFieldStyles) {
       setSelectedFieldInternal(null);
-      setEditedPositions(JSON.parse(JSON.stringify(initialFieldPositions)));
-      setEditedRecord(JSON.parse(JSON.stringify(imageData.record))); // Initialize editedRecord
 
-      // Initialize editedStyles
+      const positions = JSON.parse(JSON.stringify(initialFieldPositions));
+      const brands = JSON.parse(JSON.stringify(brandElements || []));
+
+      // Use a set to track assigned z-indices and find the max
+      const zIndices = new Set();
+      Object.values(positions).forEach(p => { if (p.zIndex !== undefined) zIndices.add(p.zIndex); });
+      brands.forEach(b => { if (b.zIndex !== undefined) zIndices.add(b.zIndex); });
+      let zIndexCounter = zIndices.size > 0 ? Math.max(...zIndices) + 1 : 0;
+
+      // Assign zIndex to text fields if they don't have one
+      globalCsvHeaders.forEach(header => {
+        if (!positions[header]) positions[header] = {};
+        if (positions[header].zIndex === undefined) {
+          positions[header].zIndex = zIndexCounter++;
+        }
+      });
+
+      // Assign zIndex to brand elements if they don't have one
+      brands.forEach(el => {
+        if (el.zIndex === undefined) {
+          el.zIndex = zIndexCounter++;
+        }
+      });
+
+      setEditedPositions(positions);
+      setEditedBrandElements(brands);
+      setEditedRecord(JSON.parse(JSON.stringify(imageData.record)));
+
       const newEditedStyles = {};
-      // Iterate over all possible headers to ensure FormattingPanel has complete style info
-      // and that FieldPositioner receives a style object for every field it might render.
       globalCsvHeaders.forEach(field => {
         newEditedStyles[field] = {
-          ...COMPLETE_DEFAULT_STYLE, // Start with all defaults defined in GeneratedImageEditor
-          ...(initialFieldStyles && initialFieldStyles[field] ? initialFieldStyles[field] : {}), // Override with specific styles for this field from prop
+          ...COMPLETE_DEFAULT_STYLE,
+          ...(initialFieldStyles?.[field] || {}),
         };
       });
       setEditedStyles(newEditedStyles);
-      setStylesAreInitialized(true); // Mark styles as initialized and ready for rendering children
+      setStylesAreInitialized(true);
 
-      // Reset filter and toggle states when the editor is opened for a new image
-      // TODO: In the future, this could be initialized from imageData if custom filters are saved per image
       setEditedImageFilters(imageFilters);
-      setEditedBrandElements(JSON.parse(JSON.stringify(brandElements || [])));
     } else {
-      // If essential data is missing, ensure we are not in an initialized state.
       setStylesAreInitialized(false);
     }
   }, [open, imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, brandElements]);
@@ -196,6 +263,7 @@ const GeneratedImageEditor = ({
                   setImageFilters={setEditedImageFilters}
                   brandElements={editedBrandElements}
                   setBrandElements={setEditedBrandElements}
+                  onZIndexChange={handleZIndexChange}
                 />
               </Grid>
             )}
@@ -228,6 +296,7 @@ const GeneratedImageEditor = ({
             fieldPositions={editedPositions}
             setFieldPositions={setEditedPositions}
             csvHeaders={editorCsvHeaders}
+            onZIndexChange={handleZIndexChange}
           />
         </>
       )}


### PR DESCRIPTION
- Adiciona botões na interface para enviar elementos para o fundo, recuar, avançar e trazer para a frente.
- Implementa a lógica de gerenciamento de z-index para todos os elementos no editor, incluindo inicialização para elementos existentes.
- Refatora o componente de renderização para ordenar os elementos com base em seu z-index antes de exibi-los.
- Aplica o z-index ao estilo do elemento para controlar a ordem de empilhamento no navegador.