### PR TITLE
fix: Corrige a renderização de elementos de imagem

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -625,7 +625,7 @@ const FieldPositioner = ({
               {renderableElements.map(element => (
                 <DraggableElement
                   key={element.id}
-                  element={element.type === 'image' ? element.position : { id: element.id, type: 'text' }}
+                  element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}
                   position={element.position}
                   style={element.style}
                   content={element.content}


### PR DESCRIPTION
- Garante que a propriedade `type` seja incluída no objeto `element` passado para o `DraggableElement`, resolvendo o problema que impedia a renderização de imagens de marca na tela.