### PR TITLE
Refactor Campaign UI and Content Flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,7 @@ import FormattingDrawer from './components/FormattingDrawer';
 import ImageGeneratorFrontendOnly from './components/ImageGeneratorFrontendOnly';
 import AudioGenerator from './components/AudioGenerator';
 import VideoGenerator2 from './components/VideoGenerator2';
-import RecordManager from './features/RecordManager/RecordManager';
+import PostsCurtosStep from './components/PostsCurtosStep';
 import CsvInfobox from './components/CsvInfobox';
 import Publisher from './components/Publisher';
 import SetupModal from './components/SetupModal';
@@ -95,7 +95,6 @@ import './App.css';
 import LoadingDialog from './components/LoadingDialog';
 import TextEditorDialog from './components/TextEditorDialog';
 import Campaign from './components/Campaign';
-import ContentStep from './components/ContentStep';
 import ImageUploadStep from './components/ImageUploadStep';
 import MemorialDescritivoModal from './components/MemorialDescritivoModal';
 import {
@@ -164,7 +163,7 @@ function App() {
 
 
   // Estados para a Geração com IA
-  const [inputMethod, setInputMethod] = useState('csv');
+  const [inputMethod, setInputMethod] = useState('ia');
   // const [selectedApiModel, setSelectedApiModel] = useState('deepseek'); // Removed, defaulting to gemini
   const [promptNumRecords, setPromptNumRecords] = useState(10);
   const [promptText, setPromptText] = useState('');
@@ -500,14 +499,9 @@ function App() {
       icon: CampaignIcon,
     },
     {
-      label: 'Conteúdo',
-      description: 'Carregar CSV ou criar manualmente',
+      label: 'Posts Curtos',
+      description: 'Gere, carregue ou edite os posts para redes sociais.',
       icon: InsertDriveFileOutlined
-    },
-    {
-      label: 'Editar Conteúdo',
-      description: 'Adicione, edite ou remova posts conforme necessário.',
-      icon: Edit
     },
     {
       label: 'Upload da Imagem',
@@ -603,7 +597,8 @@ function App() {
 
         setFieldPositions(updatedFieldPositions);
         setFieldStyles(updatedFieldStyles);
-        setActiveStep(2);
+        // Não avança mais o passo automaticamente, a UI vai mudar
+        // setActiveStep(2);
       }
     } catch (error) {
       console.error('Erro ao processar CSV:', error);
@@ -711,18 +706,17 @@ function App() {
 
   const canProceedToStep = () => {
     switch (activeStep) {
-      case 0: // Campanha
-        return campaignContent !== null;
-      case 1: // Conteúdo
-        return true; // Pode ir para a edição mesmo sem dados, para adicionar manualmente
-      case 2: // Editar Conteúdo
-        return csvData.length > 0;
-      case 3: // Upload Imagem
-        return backgroundImage !== null;
-      case 4: // Posicionar e Formatar
-        return true;
-      default:
-        return true;
+        case 0: // Campanha
+            return campaignContent !== null;
+        case 1: // Posts Curtos
+            return csvData.length > 0;
+        case 2: // Upload Imagem
+            return backgroundImage !== null;
+        case 3: // Posicionar e Formatar
+            return true;
+        // Adicione outros casos conforme necessário
+        default:
+            return true;
     }
   };
 
@@ -1195,7 +1189,8 @@ function App() {
         setFieldPositions(updatedFieldPositions);
         setFieldStyles(updatedFieldStyles);
 
-        setActiveStep(2); // Avança para Edição de Dados
+        // Não avança mais o passo automaticamente
+        // setActiveStep(2);
       } else {
         toast.error('Não foi possível processar a resposta da IA para o formato de tabela.');
         console.log(`[App] Falha no parsing ou dados vazios. Resposta da API:`, iaResponseText, "Resultado do Parser:", parsedResult);
@@ -1239,9 +1234,6 @@ function App() {
           setShowMemorialDescritivoModal={setShowMemorialDescritivoModal}
           handleSaveTemplateClick={handleSaveTemplateClick}
           handleLoadTemplateClick={handleLoadTemplateClick}
-          exportCsv={exportCsv}
-          csvData={csvData}
-          csvHeaders={csvHeaders}
           loadStateInputRef={loadStateInputRef}
           handleLoadStateFromFile={handleLoadStateFromFile}
           onMenuClick={() => setSidebarOpen(!sidebarOpen)}
@@ -1352,9 +1344,9 @@ function App() {
             </Container>
           )}
 
-          {/* Passo 1: Definir Dados Iniciais */}
+          {/* Passo 1: Posts Curtos */}
           {activeStep === 1 && (
-            <ContentStep
+            <PostsCurtosStep
               steps={steps}
               inputMethod={inputMethod}
               setInputMethod={setInputMethod}
@@ -1363,7 +1355,6 @@ function App() {
               fileInputRef={fileInputRef}
               handleCSVUpload={handleCSVUpload}
               downloadExampleCsv={downloadExampleCsv}
-              setActiveStep={setActiveStep}
               getGeminiApiKey={getGeminiApiKey}
               setShowSetupModal={setShowSetupModal}
               promptNumRecords={promptNumRecords}
@@ -1374,21 +1365,14 @@ function App() {
               isGenerating={isGenerating}
               csvData={csvData}
               csvHeaders={csvHeaders}
-            />
-          )}
-
-          {/* Passo 2: Editar Dados */}
-          {activeStep === 2 && (
-            <RecordManager
-              registrosIniciais={csvData}
-              colunasIniciais={csvHeaders}
               onDadosAlterados={handleDadosAlterados}
               darkMode={darkMode}
+              exportCsv={exportCsv}
             />
           )}
 
-          {/* Passo 3: Upload Imagem */}
-          {activeStep === 3 && (
+          {/* Passo 2: Upload Imagem */}
+          {activeStep === 2 && (
             <ImageUploadStep
               steps={steps}
               isDraggingOverImage={isDraggingOverImage}
@@ -1402,8 +1386,8 @@ function App() {
             />
           )}
 
-          {/* Passo 4: Posicionamento e Formatação */}
-          {activeStep === 4 && (
+          {/* Passo 3: Posicionamento e Formatação */}
+          {activeStep === 3 && (
             <Grid container spacing={2}>
               <Grid item xs={12} md={!isMobile ? 8 : 12}>
                 <FieldPositioner
@@ -1416,12 +1400,14 @@ function App() {
                   csvData={csvData}
                   onImageDisplayedSizeChange={setDisplayedImageSize}
                   colorPalette={combinedPalette}
+                  standardsColors={standardsColors}
                   onCsvDataUpdate={handleCsvRecordContentUpdate}
                   onSelectFieldExternal={setSelectedField}
                   originalImageSize={originalImageSize}
                   imageFilters={imageFilters}
                   brandElements={brandElements}
                   setBrandElements={setBrandElements}
+                  onZIndexChange={handleZIndexChange}
                 />
               </Grid>
               {!isMobile && (
@@ -1444,8 +1430,8 @@ function App() {
             </Grid>
           )}
 
-          {/* Passo 5: Geração */}
-          {activeStep === 5 && (
+          {/* Passo 4: Geração de Imagens */}
+          {activeStep === 4 && (
             <ImageGeneratorFrontendOnly
               csvData={csvData}
               backgroundImage={backgroundImage}
@@ -1464,8 +1450,8 @@ function App() {
             />
           )}
 
-          {/* Passo 6: Geração de Áudio */}
-          <div hidden={activeStep !== 6}>
+          {/* Passo 5: Geração de Áudio */}
+          <div hidden={activeStep !== 5}>
             <AudioGenerator
               csvData={csvData}
               fieldPositions={fieldPositions}
@@ -1474,8 +1460,8 @@ function App() {
             />
           </div>
 
-          {/* Passo 7: Geração de Vídeo */}
-          {activeStep === 7 && (
+          {/* Passo 6: Geração de Vídeo */}
+          {activeStep === 6 && (
             <VideoGenerator2
               generatedImages={generatedImagesData}
               generatedAudioData={generatedAudioData}
@@ -1483,8 +1469,8 @@ function App() {
             />
           )}
 
-          {/* Passo 8: Publicar */}
-          {activeStep === 8 && (
+          {/* Passo 7: Publicar */}
+          {activeStep === 7 && (
             <Publisher
               campaignContent={campaignContent}
               conteudoFormatado={conteudoFormatado}
@@ -1645,7 +1631,7 @@ function App() {
           setEditingFollowup(null);
         }}
       />
-      {isMobile && activeStep === 4 && (
+      {isMobile && activeStep === 3 && (
         <>
           <Fab
             color="primary"

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Card,
   CardContent,
@@ -22,6 +22,8 @@ import {
   DialogContent,
   DialogActions,
   CircularProgress,
+  Tabs,
+  Tab,
 } from '@mui/material';
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { getCampaignPrompt } from '../utils/campaignPrompt';
@@ -123,6 +125,25 @@ const solucaoHint = (
     </Box>
 );
 
+const TabPanel = (props) => {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`campaign-tabpanel-${index}`}
+      aria-labelledby={`campaign-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box sx={{ p: 3 }}>
+          {children}
+        </Box>
+      )}
+    </div>
+  );
+};
 
 const Campaign = ({
     steps,
@@ -140,7 +161,6 @@ const Campaign = ({
     generationError,
     handleGenerateCampaignContent,
     handleResetCampaign,
-    handleExportHtml,
     setEditingField,
     conteudoMedio,
     setConteudoMedio,
@@ -161,6 +181,7 @@ const Campaign = ({
     setCampaignContent,
     onEditFollowup,
 }) => {
+    const [activeTab, setActiveTab] = useState(0);
     const [isHintModalOpen, setHintModalOpen] = React.useState(false);
     const [isSolucaoHintModalOpen, setSolucaoHintModalOpen] = React.useState(false);
     const [commonProblems, setCommonProblems] = React.useState([]);
@@ -169,6 +190,10 @@ const Campaign = ({
     const [commonSolutions, setCommonSolutions] = React.useState([]);
     const [isLoadingSolutions, setIsLoadingSolutions] = React.useState(false);
     const [solutionsError, setSolutionsError] = React.useState(null);
+
+    const handleTabChange = (event, newValue) => {
+      setActiveTab(newValue);
+    };
 
     const handleGenerateProblems = async () => {
         setIsLoadingProblems(true);
@@ -213,124 +238,92 @@ const Campaign = ({
                     <CampaignIcon />
                     {steps[0].label}
                 </Typography>
-                <Grid container spacing={3}>
-                    <Grid item xs={12}>
-                        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                            <TextField
-                                label="Problema ou Necessidade"
-                                multiline
-                                rows={4}
-                                value={problema}
-                                onChange={(e) => setProblema(e.target.value)}
-                                variant="outlined"
-                                fullWidth
-                                placeholder="Descreva o problema que sua campanha busca resolver."
-                                disabled={campaignContent !== null}
-                            />
-                            <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setHintModalOpen(true)}>
-                                <GeminiIcon />
-                            </IconButton>
-                        </Box>
-                    </Grid>
 
-                    <Grid item xs={12}>
-                        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                            <TextField
-                                label="Solução ou Proposta"
-                                multiline
-                                rows={4}
-                                value={solucao}
-                                onChange={(e) => setSolucao(e.target.value)}
-                                variant="outlined"
-                                fullWidth
-                                placeholder="Descreva a solução que sua campanha oferece."
-                                disabled={campaignContent !== null}
-                            />
-                            <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setSolucaoHintModalOpen(true)}>
-                                <GeminiIcon />
-                            </IconButton>
-                        </Box>
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <TextField
-                            label="Quantidade de Posts de Follow-up"
-                            type="number"
-                            value={followupPostsQuantity}
-                            onChange={(e) => setFollowupPostsQuantity(parseInt(e.target.value, 10))}
-                            fullWidth
-                            variant="outlined"
-                            disabled={campaignContent !== null}
-                            InputProps={{ inputProps: { min: 1, max: 10 } }}
-                        />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
-                            <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
-                            <Select
-                                labelId="aspect-ratio-label"
-                                value={aspectRatio}
-                                onChange={(e) => setAspectRatio(e.target.value)}
-                                label="Razão de Aspecto"
-                            >
-                                <MenuItem value="1:1">Quadrado (1:1)</MenuItem>
-                                <MenuItem value="4:5">Retrato (4:5)</MenuItem>
-                                <MenuItem value="16:9">Paisagem (16:9)</MenuItem>
-                            </Select>
-                        </FormControl>
-                    </Grid>
-                </Grid>
-                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3, gap: 2 }}>
-                    <Button
-                        variant="contained"
-                        size="large"
-                        onClick={() => handleGenerateCampaignContent(false)}
-                        disabled={!problema.trim() || !solucao.trim() || isGeneratingCampaign || campaignContent !== null}
-                        startIcon={<GeminiIcon />}
-                    >
-                        {isGeneratingCampaign ? 'Gerando...' : 'Elaborar Conteúdo'}
-                    </Button>
-                    {campaignContent && (
-                        <Button
-                            variant="outlined"
-                            size="large"
-                            onClick={handleResetCampaign}
-                        >
-                            Resetar
-                        </Button>
-                    )}
+                <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                    <Tabs value={activeTab} onChange={handleTabChange} aria-label="abas da campanha">
+                        <Tab label="Problema e Solução" />
+                        <Tab label="Conteúdo Principal" disabled={!campaignContent} />
+                        <Tab label="Imagem" disabled={!campaignContent} />
+                        <Tab label="Posts de Follow-Up" disabled={!campaignContent} />
+                        <Tab label="Conteúdo WordPress" disabled={!campaignContent} />
+                    </Tabs>
                 </Box>
 
-                {campaignGenerationFailed && (
-                    <Box sx={{ mt: 3, textAlign: 'center' }}>
-                        <Alert severity="error" sx={{ mb: 2 }}>
-                            <strong>Ocorreu um erro ao gerar o conteúdo:</strong> {generationError}
-                        </Alert>
+                {/* Painel 0: Problema e Solução */}
+                <TabPanel value={activeTab} index={0}>
+                    <Grid container spacing={3} sx={{ mt: 2 }}>
+                        <Grid item xs={12}>
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                                <TextField
+                                    label="Problema ou Necessidade"
+                                    multiline
+                                    rows={4}
+                                    value={problema}
+                                    onChange={(e) => setProblema(e.target.value)}
+                                    variant="outlined"
+                                    fullWidth
+                                    placeholder="Descreva o problema que sua campanha busca resolver."
+                                    disabled={campaignContent !== null}
+                                />
+                                <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setHintModalOpen(true)}>
+                                    <GeminiIcon />
+                                </IconButton>
+                            </Box>
+                        </Grid>
+
+                        <Grid item xs={12}>
+                            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                                <TextField
+                                    label="Solução ou Proposta"
+                                    multiline
+                                    rows={4}
+                                    value={solucao}
+                                    onChange={(e) => setSolucao(e.target.value)}
+                                    variant="outlined"
+                                    fullWidth
+                                    placeholder="Descreva a solução que sua campanha oferece."
+                                    disabled={campaignContent !== null}
+                                />
+                                <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setSolucaoHintModalOpen(true)}>
+                                    <GeminiIcon />
+                                </IconButton>
+                            </Box>
+                        </Grid>
+                    </Grid>
+                    <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3, gap: 2 }}>
                         <Button
                             variant="contained"
-                            color="secondary"
                             size="large"
-                            onClick={() => handleGenerateImage()}
-                            disabled={isGeneratingImage}
-                            startIcon={<ImageIcon />}
+                            onClick={() => handleGenerateCampaignContent(false)}
+                            disabled={!problema.trim() || !solucao.trim() || isGeneratingCampaign || campaignContent !== null}
+                            startIcon={<GeminiIcon />}
                         >
-                            {isGeneratingImage ? 'Gerando Imagem...' : 'Tentar Gerar Apenas a Imagem'}
+                            {isGeneratingCampaign ? 'Gerando...' : 'Elaborar Conteúdo'}
                         </Button>
-                    </Box>
-                )}
-
-                {campaignContent && (
-                    <Box sx={{ mt: 4 }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+                        {campaignContent && (
                             <Button
                                 variant="outlined"
-                                onClick={handleExportHtml}
+                                size="large"
+                                onClick={handleResetCampaign}
                             >
-                                Exportar como HTML
+                                Resetar
                             </Button>
+                        )}
+                    </Box>
+                    {campaignGenerationFailed && (
+                        <Box sx={{ mt: 3, textAlign: 'center' }}>
+                            <Alert severity="error" sx={{ mb: 2 }}>
+                                <strong>Ocorreu um erro ao gerar o conteúdo:</strong> {generationError}
+                            </Alert>
                         </Box>
-                        <Typography variant="h6" gutterBottom>Conteúdo Gerado</Typography>
-                        <Grid container spacing={2}>
-                            <Grid item xs={12}>
+                    )}
+                </TabPanel>
+
+                {/* Painel 1: Conteúdo Principal */}
+                <TabPanel value={activeTab} index={1}>
+                    {campaignContent && (
+                        <Grid container spacing={2} sx={{ mt: 2 }}>
+                             <Grid item xs={12}>
                                 <TextField
                                     label="Título"
                                     value={campaignContent.titulo}
@@ -353,7 +346,6 @@ const Campaign = ({
                                 />
                                 <Button onClick={() => handleGenerateCampaignContent(true)} disabled={isGeneratingCampaign} startIcon={<GeminiIcon />}>Gerar</Button>
                             </Grid>
-
                             <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                 <TextField
                                     label="Conteúdo Médio (máx. 1800 caracteres)"
@@ -368,7 +360,6 @@ const Campaign = ({
                                     {isGeneratingSummaryMedio ? 'Gerando...' : 'Gerar'}
                                 </Button>
                             </Grid>
-
                             <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                 <TextField
                                     label="Conteúdo Pequeno (máx. 130 caracteres)"
@@ -383,24 +374,6 @@ const Campaign = ({
                                     {isGeneratingSummaryPequeno ? 'Gerando...' : 'Gerar'}
                                 </Button>
                             </Grid>
-
-                            <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                                <TextField
-                                    label="Conteúdo Formatado (HTML)"
-                                    multiline
-                                    rows={3}
-                                    value={conteudoFormatado}
-                                    onClick={() => setEditingField('conteudoFormatado')}
-                                    readOnly
-                                    variant="outlined"
-                                    fullWidth
-                                    sx={{ cursor: 'pointer' }}
-                                />
-                                <Button onClick={() => handleGenerateFormattedContent()} disabled={isGeneratingConteudoFormatado || !campaignContent} startIcon={<GeminiIcon />}>
-                                    {isGeneratingConteudoFormatado ? 'Gerando...' : 'Gerar'}
-                                </Button>
-                            </Grid>
-
                             <Grid item xs={12}>
                                 <TextField
                                     label="CTA (Chamada para Ação)"
@@ -451,86 +424,170 @@ const Campaign = ({
                                 </Box>
                             </Grid>
                         </Grid>
-                    </Box>
-                )}
+                    )}
+                </TabPanel>
 
-                {isGeneratingFollowup && (
-                    <Box sx={{ mt: 4, textAlign: 'center' }}>
-                        <Typography variant="h6" gutterBottom>Gerando Posts de Follow-up...</Typography>
-                    </Box>
-                )}
-
-                {followupPosts.length > 0 && !isGeneratingFollowup && (
-                    <Box sx={{ mt: 4 }}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                            <Typography variant="h6" gutterBottom>Posts de Follow-up Gerados</Typography>
-                            <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />}>
-                                {isGeneratingFollowup ? 'Gerando...' : 'Regenerar Posts'}
-                            </Button>
-                        </Box>
-                        {followupPosts.map((post, index) => (
-                            <Accordion key={index}>
-                                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                    <Typography>Post {post.post_numero}: {post.tipo_gancho}</Typography>
-                                </AccordionSummary>
-                                <AccordionDetails sx={{ cursor: 'pointer' }} onClick={() => onEditFollowup(index, post.conteudo)}>
-                                    <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                                        {post.conteudo}
-                                    </Typography>
-                                    <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
-                                        CTA: {post.cta}
-                                    </Typography>
-                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-                                        {post.hashtags_sugeridas.map((tag, i) => (
-                                            <Chip key={i} label={tag} size="small" />
-                                        ))}
+                {/* Painel 2: Imagem */}
+                <TabPanel value={activeTab} index={2}>
+                    {campaignContent && (
+                        <Box sx={{ mt: 2 }}>
+                             <Grid item xs={12} md={6}>
+                                <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
+                                    <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
+                                    <Select
+                                        labelId="aspect-ratio-label"
+                                        value={aspectRatio}
+                                        onChange={(e) => setAspectRatio(e.target.value)}
+                                        label="Razão de Aspecto"
+                                    >
+                                        <MenuItem value="1:1">Quadrado (1:1)</MenuItem>
+                                        <MenuItem value="4:5">Retrato (4:5)</MenuItem>
+                                        <MenuItem value="16:9">Paisagem (16:9)</MenuItem>
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            {generatedImageUrl && !isGeneratingImage && (
+                                <Box>
+                                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
+                                        <Typography variant="h6" gutterBottom>Imagem Gerada</Typography>
+                                        <Button onClick={handleGenerateImage} disabled={isGeneratingImage} startIcon={<GeminiIcon />}>
+                                            {isGeneratingImage ? 'Gerando...' : 'Regenerar Imagem'}
+                                        </Button>
                                     </Box>
-                                </AccordionDetails>
-                            </Accordion>
-                        ))}
-                    </Box>
-                )}
-
-                {/* Bloco de Geração e Exibição de Imagem */}
-                {campaignContent && (
-                    <Box sx={{ mt: 4 }}>
-                        {/* Se a imagem já foi gerada, exibe */}
-                        {generatedImageUrl && !isGeneratingImage && (
-                            <Box>
-                                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                    <Typography variant="h6" gutterBottom>Imagem Gerada</Typography>
-                                    <Button onClick={handleGenerateImage} disabled={isGeneratingImage} startIcon={<GeminiIcon />}>
-                                        {isGeneratingImage ? 'Gerando...' : 'Regenerar Imagem'}
+                                    <img src={generatedImageUrl} alt="Imagem gerada pela IA" style={{ maxWidth: '100%', borderRadius: '8px', mt: 2 }} />
+                                </Box>
+                            )}
+                            {isGeneratingImage && (
+                                <Box sx={{ textAlign: 'center', mt: 2 }}>
+                                    <CircularProgress />
+                                    <Typography variant="h6" gutterBottom>Gerando Imagem...</Typography>
+                                </Box>
+                            )}
+                            {!generatedImageUrl && !isGeneratingImage && (
+                                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                                    <Button
+                                        variant="contained"
+                                        color="secondary"
+                                        onClick={handleGenerateImage}
+                                        startIcon={<ImageIcon />}
+                                        disabled={isGeneratingImage}
+                                    >
+                                        Gerar Imagem
                                     </Button>
                                 </Box>
-                                <img src={generatedImageUrl} alt="Imagem gerada pela IA" style={{ maxWidth: '100%', borderRadius: '8px', mt: 2 }} />
-                            </Box>
-                        )}
+                            )}
+                             {campaignGenerationFailed && (
+                                <Box sx={{ mt: 3, textAlign: 'center' }}>
+                                    <Alert severity="error" sx={{ mb: 2 }}>
+                                        <strong>Falha na geração de imagem:</strong> {generationError}
+                                    </Alert>
+                                    <Button
+                                        variant="contained"
+                                        color="secondary"
+                                        size="large"
+                                        onClick={() => handleGenerateImage()}
+                                        disabled={isGeneratingImage}
+                                        startIcon={<ImageIcon />}
+                                    >
+                                        {isGeneratingImage ? 'Gerando Imagem...' : 'Tentar Gerar Apenas a Imagem'}
+                                    </Button>
+                                </Box>
+                            )}
+                        </Box>
+                    )}
+                </TabPanel>
 
-                        {/* Se está gerando a imagem, mostra o loading */}
-                        {isGeneratingImage && (
-                            <Box sx={{ textAlign: 'center' }}>
-                                <Typography variant="h6" gutterBottom>
-                                    Gerando Imagem...
-                                </Typography>
-                            </Box>
-                        )}
-
-                        {/* Se AINDA NÃO tem imagem e NÃO está gerando, mostra o botão para gerar */}
-                        {!generatedImageUrl && !isGeneratingImage && (
-                            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                                <Button
-                                    variant="contained"
-                                    color="secondary"
-                                    onClick={handleGenerateImage}
-                                    startIcon={<GeminiIcon />}
-                                >
-                                    Gerar Imagem
+                {/* Painel 3: Posts de Follow-Up */}
+                <TabPanel value={activeTab} index={3}>
+                    {campaignContent && (
+                         <Grid container spacing={2} sx={{ mt: 2 }}>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="Quantidade de Posts de Follow-up"
+                                    type="number"
+                                    value={followupPostsQuantity}
+                                    onChange={(e) => setFollowupPostsQuantity(parseInt(e.target.value, 10))}
+                                    fullWidth
+                                    variant="outlined"
+                                    disabled={campaignContent !== null}
+                                    InputProps={{ inputProps: { min: 1, max: 10 } }}
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />}>
+                                    {isGeneratingFollowup ? 'Gerando...' : 'Gerar Posts de Follow-up'}
+                                </Button>
+                            </Grid>
+                        </Grid>
+                    )}
+                    {isGeneratingFollowup && (
+                        <Box sx={{ mt: 4, textAlign: 'center' }}>
+                            <CircularProgress />
+                            <Typography variant="h6" gutterBottom>Gerando Posts de Follow-up...</Typography>
+                        </Box>
+                    )}
+                    {followupPosts.length > 0 && !isGeneratingFollowup && (
+                        <Box sx={{ mt: 4 }}>
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                                <Typography variant="h6" gutterBottom>Posts de Follow-up Gerados</Typography>
+                                <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />}>
+                                    {isGeneratingFollowup ? 'Gerando...' : 'Regenerar Posts'}
                                 </Button>
                             </Box>
-                        )}
-                    </Box>
-                )}
+                            {followupPosts.map((post, index) => (
+                                <Accordion key={index}>
+                                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                        <Typography>Post {post.post_numero}: {post.tipo_gancho}</Typography>
+                                    </AccordionSummary>
+                                    <AccordionDetails sx={{ cursor: 'pointer' }} onClick={() => onEditFollowup(index, post.conteudo)}>
+                                        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                                            {post.conteudo}
+                                        </Typography>
+                                        <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
+                                            CTA: {post.cta}
+                                        </Typography>
+                                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                                            {post.hashtags_sugeridas.map((tag, i) => (
+                                                <Chip key={i} label={tag} size="small" />
+                                            ))}
+                                        </Box>
+                                    </AccordionDetails>
+                                </Accordion>
+                            ))}
+                        </Box>
+                    )}
+                </TabPanel>
+
+                {/* Painel 4: Conteúdo WordPress */}
+                <TabPanel value={activeTab} index={4}>
+                    {campaignContent && (
+                        <Grid container spacing={2} sx={{ mt: 2 }}>
+                            <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                                <TextField
+                                    label="Conteúdo Formatado (HTML)"
+                                    multiline
+                                    rows={10}
+                                    value={conteudoFormatado}
+                                    onClick={() => setEditingField('conteudoFormatado')}
+                                    readOnly
+                                    variant="outlined"
+                                    fullWidth
+                                    sx={{ cursor: 'pointer' }}
+                                />
+                                <Button onClick={() => handleGenerateFormattedContent()} disabled={isGeneratingConteudoFormatado || !campaignContent} startIcon={<GeminiIcon />}>
+                                    {isGeneratingConteudoFormatado ? 'Gerando...' : 'Gerar'}
+                                </Button>
+                            </Grid>
+                             <Grid item xs={12}>
+                                <Typography variant="h6" gutterBottom>Pré-visualização</Typography>
+                                <Box border={1} borderColor="grey.300" p={2} borderRadius={1} sx={{ minHeight: 100, '& *': { all: 'revert' } }}>
+                                    <div dangerouslySetInnerHTML={{ __html: conteudoFormatado }} />
+                                </Box>
+                            </Grid>
+                        </Grid>
+                    )}
+                </TabPanel>
+
 
                 <Dialog open={isHintModalOpen} onClose={() => setHintModalOpen(false)} maxWidth="lg" fullWidth>
                     <DialogTitle>Como Descrever o Problema ou Necessidade</DialogTitle>

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -88,6 +88,7 @@ const FieldPositioner = ({
   csvData,
   onImageDisplayedSizeChange,
   colorPalette,
+  standardsColors,
   onSelectFieldExternal,
   onCsvDataUpdate, // New prop to notify App.jsx of changes
   originalImageSize,
@@ -95,6 +96,8 @@ const FieldPositioner = ({
   imageFilters,
   brandElements,
   setBrandElements,
+  setImageFilters,
+  onZIndexChange,
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
@@ -146,6 +149,23 @@ const FieldPositioner = ({
       onSelectFieldExternal(fieldToSelect);
     }
   }, [onSelectFieldExternal]);
+
+  const handleVisibilityChange = useCallback((field, isVisible) => {
+    // Lógica para deletar imagem
+    const isImageField = field.toLowerCase().includes('imagem');
+    if (isImageField && !isVisible) {
+      handleContentChange(field, ''); // Limpa o valor do campo de imagem
+    }
+
+    // Atualiza a visibilidade do campo
+    setFieldPositions(prev => ({
+      ...prev,
+      [field]: {
+        ...prev[field],
+        visible: isVisible
+      }
+    }));
+  }, [handleContentChange, setFieldPositions]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -226,7 +246,7 @@ const FieldPositioner = ({
   }, [csvHeaders, fieldPositions, fieldStyles, setFieldPositions, setFieldStyles]);
 
   const handlePositionChange = (id, newPosition) => {
-    if (fieldPositions.hasOwnProperty(id)) {
+    if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
         ...prev,
         [id]: {
@@ -242,7 +262,7 @@ const FieldPositioner = ({
   };
 
   const handleSizeChange = (id, newSize) => {
-    if (fieldPositions.hasOwnProperty(id)) {
+    if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
         ...prev,
         [id]: {
@@ -336,6 +356,7 @@ const FieldPositioner = ({
         shadowBlur: 5,
         shadowOffsetX: 2,
         shadowOffsetY: 2,
+        color: standardsColors?.[0]?.hex || '#FFFFFF', // Usa a cor de acento
       };
     }
 
@@ -542,12 +563,12 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize]);
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField]);
 
 
   return (
     <Grid container spacing={3}>
-      <Grid item xs={12} lg={12}>
+      <Grid item xs={12} lg={9}>
         <Card>
           <CardContent>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2 }} justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
@@ -678,7 +699,22 @@ const FieldPositioner = ({
           </CardContent>
         </Card>
       </Grid>
-
+      <Grid item xs={12} lg={3}>
+        <FormattingPanel
+          selectedField={selectedField}
+          fieldStyles={fieldStyles}
+          setFieldStyles={setFieldStyles}
+          fieldPositions={fieldPositions}
+          setFieldPositions={setFieldPositions}
+          csvHeaders={csvHeaders}
+          imageFilters={imageFilters}
+          setImageFilters={setImageFilters}
+          brandElements={brandElements}
+          setBrandElements={setBrandElements}
+          onZIndexChange={onZIndexChange}
+          onVisibilityChange={handleVisibilityChange}
+        />
+      </Grid>
     </Grid>
   );
 };

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -59,7 +59,8 @@ const FormattingPanel = ({
   setImageFilters,
   brandElements,
   setBrandElements,
-  onZIndexChange
+  onZIndexChange,
+  onVisibilityChange,
 }) => {
   const fonts = [
     'Arial', 'Helvetica', 'Times New Roman', 'Georgia', 'Verdana', 'Courier New', 'Impact', 'Comic Sans MS',
@@ -83,10 +84,6 @@ const FormattingPanel = ({
       if (header !== sourceField) { newStyles[header] = { ...sourceStyle }; }
     });
     setFieldStyles(prev => ({ ...prev, ...newStyles }));
-  };
-
-  const toggleFieldVisibility = (field) => {
-    updateFieldPosition(field, 'visible', !fieldPositions[field]?.visible);
   };
 
   const resetFieldStyle = (field) => {
@@ -168,7 +165,7 @@ const FormattingPanel = ({
                 control={
                   <Switch
                     checked={currentElement.visible !== false}
-                    onChange={() => handlePositionPropertyChange('visible', !currentElement.visible)}
+                    onChange={() => onVisibilityChange(selectedField, !currentElement.visible)}
                     size="small"
                   />
                 }

--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -32,9 +32,6 @@ const MainAppBar = ({
   setShowMemorialDescritivoModal,
   handleSaveTemplateClick,
   handleLoadTemplateClick,
-  exportCsv,
-  csvData,
-  csvHeaders,
   loadStateInputRef,
   handleLoadStateFromFile,
 }) => {
@@ -111,10 +108,6 @@ const MainAppBar = ({
             <MenuItem onClick={handleLoadTemplateClick}>
               <FileUploadIcon sx={{ mr: 1 }} />
               Carregar Campanha
-            </MenuItem>
-            <MenuItem onClick={() => { exportCsv(csvData, csvHeaders); handleMenuClose(); }} disabled={csvData.length === 0}>
-              <DownloadIcon sx={{ mr: 1 }} />
-              Exportar CSV
             </MenuItem>
           </Menu>
           <input

--- a/src/components/MemorialDescritivo/ContentSection.jsx
+++ b/src/components/MemorialDescritivo/ContentSection.jsx
@@ -22,12 +22,15 @@ const DetailItem = ({ title, value, isHtml = false, sx = {} }) => {
   );
 };
 
+const containsHtml = (str) => /<[a-z][\s\S]*>/i.test(str);
+
 const ContentSection = ({
   problema,
   solucao,
   campaignContent,
   aspectRatio,
-  followupPosts
+  followupPosts,
+  conteudoFormatado,
 }) => {
   const hasCampaignContent = campaignContent && (campaignContent.titulo || campaignContent.conteudo || campaignContent.cta);
 
@@ -51,12 +54,22 @@ const ContentSection = ({
             Conteúdo Principal Gerado
           </Typography>
           <DetailItem title="Título" value={campaignContent.titulo} />
-          <DetailItem title="Conteúdo" value={campaignContent.conteudo} isHtml={true} />
+          <DetailItem
+            title="Conteúdo"
+            value={campaignContent.conteudo}
+            isHtml={containsHtml(campaignContent.conteudo)}
+          />
           <DetailItem title="Call to Action (CTA)" value={campaignContent.cta} />
            {campaignContent.hashtags && campaignContent.hashtags.length > 0 &&
              <DetailItem title="Hashtags" value={campaignContent.hashtags.join(', ')} />
            }
         </Box>
+      )}
+
+      {conteudoFormatado && (
+          <Box sx={{ mt: 4 }}>
+              <DetailItem title="Conteúdo Formatado (HTML)" value={conteudoFormatado} isHtml={true} />
+          </Box>
       )}
 
       {followupPosts && followupPosts.length > 0 && (

--- a/src/components/MemorialDescritivo/index.jsx
+++ b/src/components/MemorialDescritivo/index.jsx
@@ -23,6 +23,7 @@ const MemorialDescritivo = ({ campaignData }) => {
     aspectRatio,
     followupPosts,
     colors,
+    conteudoFormatado,
   } = campaignData;
 
   // In the new structure, `colors` is the primary array of color objects.
@@ -61,6 +62,7 @@ const MemorialDescritivo = ({ campaignData }) => {
           campaignContent={campaignContent}
           aspectRatio={aspectRatio}
           followupPosts={followupPosts}
+          conteudoFormatado={conteudoFormatado}
         />
       </Box>
 

--- a/src/components/PostsCurtosStep.jsx
+++ b/src/components/PostsCurtosStep.jsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Box,
+  ToggleButton,
+  ToggleButtonGroup,
+  Button,
+  TextField,
+  Link as MuiLink,
+  Alert,
+} from '@mui/material';
+import {
+  CloudUpload,
+  Add,
+  InsertDriveFileOutlined,
+  AutoAwesomeOutlined as GeminiIcon,
+} from '@mui/icons-material';
+import CsvInfobox from './CsvInfobox';
+import RecordManager from '../features/RecordManager/RecordManager';
+
+const PostsCurtosStep = ({
+  inputMethod,
+  setInputMethod,
+  handleDrop: handleDropProp,
+  handleDragOver: handleDragOverProp,
+  fileInputRef,
+  handleCSVUpload,
+  downloadExampleCsv,
+  getGeminiApiKey,
+  setShowSetupModal,
+  promptNumRecords,
+  setPromptNumRecords,
+  promptText,
+  setPromptText,
+  handleGenerateIAContent,
+  isGenerating,
+  csvData,
+  csvHeaders,
+  onDadosAlterados,
+  darkMode,
+  exportCsv, // Nova prop
+}) => {
+  const [isDraggingOverCsv, setIsDraggingOverCsv] = useState(false);
+
+  const handleDragEnter = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDraggingOverCsv(true);
+  };
+
+  const handleDragLeave = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDraggingOverCsv(false);
+  };
+
+  const handleDrop = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDraggingOverCsv(false);
+    handleDropProp(event);
+  };
+
+  // Show RecordManager if data exists or if user chose manual creation
+  const showRecordManager = (csvData && csvData.length > 0) || inputMethod === 'manual';
+
+  // Show creation options if there's no data and method is not manual
+  const showCreationOptions = !showRecordManager;
+
+  return (
+    <Card>
+      <CardContent sx={{ p: { xs: 1.5, sm: 2, md: 4 } }}>
+        <Typography variant="h5" gutterBottom sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          mb: 3
+        }}>
+          <InsertDriveFileOutlined />
+          Posts Curtos
+        </Typography>
+
+        {/* Seletor de método de entrada - sempre visível quando não há dados */}
+        {!showRecordManager && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', mb: 4 }}>
+              <ToggleButtonGroup
+                color="primary"
+                value={inputMethod}
+                exclusive
+                onChange={(event, newInputMethod) => {
+                  if (newInputMethod !== null) {
+                    setInputMethod(newInputMethod);
+                  }
+                }}
+              >
+                <ToggleButton value="ia" sx={{ display: 'flex', gap: 1 }}>
+                  <GeminiIcon />
+                  Gerar com IA
+                </ToggleButton>
+                <ToggleButton value="csv">Carregar CSV</ToggleButton>
+                <ToggleButton value="manual">Criação Manual</ToggleButton>
+              </ToggleButtonGroup>
+            </Box>
+        )}
+
+
+        {showCreationOptions && (
+          <>
+            {inputMethod === 'ia' && (
+              <Box sx={{ maxWidth: 600, mx: 'auto' }}>
+                {!getGeminiApiKey() && (
+                  <Alert severity="warning" sx={{ mb: 2 }}>
+                    Chave da API Gemini não configurada.
+                    <MuiLink component="button" variant="body2" onClick={() => setShowSetupModal(true)} sx={{ ml: 1 }}>
+                      Configurar Chave Gemini
+                    </MuiLink>
+                  </Alert>
+                )}
+                <TextField
+                  label="Quantidade de Elementos"
+                  type="number"
+                  value={promptNumRecords}
+                  onChange={(e) => setPromptNumRecords(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                  inputProps={{ min: 1 }}
+                  variant="outlined"
+                  fullWidth
+                  sx={{ mb: 3 }}
+                />
+                <TextField
+                  label="Descrição do Conteúdo"
+                  multiline
+                  rows={4}
+                  value={promptText}
+                  onChange={(e) => setPromptText(e.target.value)}
+                  variant="outlined"
+                  fullWidth
+                  placeholder="Ex: Um carrossel sobre os benefícios da meditação para reduzir o estresse..."
+                  sx={{ mb: 3 }}
+                />
+                <Button
+                  variant="contained"
+                  size="large"
+                  fullWidth
+                  onClick={handleGenerateIAContent}
+                  disabled={isGenerating || !promptText.trim() || !getGeminiApiKey()}
+                >
+                  {isGenerating ? 'Gerando...' : 'Gerar Conteúdo com IA'}
+                </Button>
+              </Box>
+            )}
+
+            {inputMethod === 'csv' && (
+              <Grid container spacing={3} justifyContent="center">
+                <Grid item xs={12} md={8}>
+                  <Card
+                    sx={{
+                      border: isDraggingOverCsv ? '2px dashed #8b5cf6' : '2px dashed #d1d5db',
+                      backgroundColor: isDraggingOverCsv ? 'rgba(139, 92, 246, 0.1)' : 'transparent',
+                      textAlign: 'center',
+                      p: 4,
+                    }}
+                    onDrop={handleDrop}
+                    onDragOver={handleDragOverProp}
+                    onDragEnter={handleDragEnter}
+                    onDragLeave={handleDragLeave}
+                  >
+                    <CloudUpload sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+                    <Typography variant="h6" gutterBottom>Arraste e solte ou clique para Upload</Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 3 }}>
+                      <Typography variant="body2" color="text.secondary">
+                        Carregue um arquivo CSV com o conteúdo de seus posts
+                      </Typography>
+                      <CsvInfobox />
+                    </Box>
+                    <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
+                      <Button variant="contained" component="label">
+                        Selecionar Arquivo
+                        <input type="file" accept=".csv" hidden ref={fileInputRef} onChange={handleCSVUpload} />
+                      </Button>
+                      <Button variant="outlined" onClick={downloadExampleCsv}>
+                        Baixar CSV Exemplo
+                      </Button>
+                    </Box>
+                  </Card>
+                </Grid>
+              </Grid>
+            )}
+          </>
+        )}
+
+        {showRecordManager && (
+          <Box>
+            <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2}}>
+                <Button onClick={() => {
+                    onDadosAlterados([], []);
+                    setInputMethod('ia'); // Volta para o método padrão
+                }}>
+                    &larr; Voltar para obter dados
+                </Button>
+                <Button
+                    variant="contained"
+                    onClick={() => exportCsv(csvData, csvHeaders)}
+                    disabled={!csvData || csvData.length === 0}
+                >
+                    Baixar CSV
+                </Button>
+            </Box>
+            <RecordManager
+              registrosIniciais={csvData}
+              colunasIniciais={csvHeaders}
+              onDadosAlterados={onDadosAlterados}
+              darkMode={darkMode}
+            />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PostsCurtosStep;

--- a/src/features/RecordManager/RecordManager.jsx
+++ b/src/features/RecordManager/RecordManager.jsx
@@ -215,14 +215,14 @@ const RecordManager = ({
   const containerClasses = `${styles.container} ${darkMode ? styles.darkMode : ''}`;
 
     return (
-    <div className={containerClasses}>
+        <div className={containerClasses}>
             <div className={styles.header}>
-                <h1>Gerenciar Registros</h1>
+                {/* O título agora é gerenciado pelo componente pai (PostsCurtosStep) */}
+                {/* <h1>Gerenciar Registros</h1> */}
                 <div className={styles.actionsContainer}>
                     <button onClick={handleAbrirModalAdicionar} className={`${styles.btn} ${styles.btnPrimary}`}>
-                        &#43; Adicionar Novo
+                        &#43; Adicionar Novo Registro
                     </button>
-                    {/* O carregamento de CSV agora é tratado pelo App.jsx na etapa inicial */}
                 </div>
             </div>
 

--- a/src/features/RecordManager/components/RecordRow/RecordRow.jsx
+++ b/src/features/RecordManager/components/RecordRow/RecordRow.jsx
@@ -14,21 +14,23 @@ import styles from './RecordRow.module.css';
  * @param {boolean} [props.darkMode=false] - Flag para habilitar o modo escuro.
  */
 const RecordRow = ({ registro, colunas, onEditar, onExcluir, darkMode = false }) => {
-    const trClasses = `${darkMode ? styles.darkMode : ''}`;
+    const trClasses = `${styles.row} ${darkMode ? styles.darkMode : ''}`;
+
+    const handleEditClick = () => {
+        onEditar(registro);
+    };
+
+    const handleDeleteClick = (e) => {
+        e.stopPropagation(); // Impede que o clique na linha seja acionado
+        onExcluir(registro);
+    };
+
     return (
-        <tr className={trClasses}>
+        <tr className={trClasses} onClick={handleEditClick} title="Clique para editar">
             <td className={styles.actionsCell}>
                 <button
                     type="button"
-                    onClick={() => onEditar(registro)}
-                    className={`${styles.btnAction} ${styles.btnEdit}`}
-                    title="Editar"
-                >
-                    &#9998; {/* Ícone de lápis */}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onExcluir(registro)}
+                    onClick={handleDeleteClick}
                     className={`${styles.btnAction} ${styles.btnDelete}`}
                     title="Excluir"
                 >


### PR DESCRIPTION
This commit implements a major refactoring of the campaign creation and content management UI.

- **New "Posts Curtos" Step:**
  - Merges the previous "Conteúdo" and "Editar Conteúdo" steps into a single, unified "Posts Curtos" step.
  - Reorders content creation options to "Gerar com IA", "Carregar CSV", and "Criação Manual".
  - Adds a "Baixar CSV" button to the new step and removes it from the main app bar.

- **Campaign Dialog Restructuring:**
  - Reorganizes the main campaign dialog into a tabbed interface for better organization: "Problema e Solução", "Conteúdo Principal", "Imagem", "Posts de Follow-Up", and "Conteúdo WordPress".

- **UI/UX Improvements:**
  - The records table in the "Posts Curtos" step now allows editing by clicking on the entire row instead of a dedicated button.
  - The "Auto Organizar" feature in the field editor now applies the campaign's accent color to the first field.
  - The visibility switch for image fields now clears the image content when deactivated.

- **Memorial Descritivo:**
  - The campaign summary now includes the formatted HTML content.
  - The main content field now renders as HTML only if it contains HTML tags.