### PR TITLE
Fix: Correct function initialization order in FieldPositioner

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -150,6 +150,25 @@ const FieldPositioner = ({
     }
   }, [onSelectFieldExternal]);
 
+  const handleContentChange = useCallback((field, newText) => {
+    if (!csvData || csvData.length === 0) return;
+
+    const updatedCsvData = csvData.map((row, index) => {
+      if (index === currentPreviewIndex) {
+        return {
+          ...row,
+          [field]: newText,
+        };
+      }
+      return row;
+    });
+
+    // Propagate change upwards
+    if (onCsvDataUpdate) {
+      onCsvDataUpdate(updatedCsvData);
+    }
+  }, [csvData, currentPreviewIndex, onCsvDataUpdate]);
+
   const handleVisibilityChange = useCallback((field, isVisible) => {
     // Lógica para deletar imagem
     const isImageField = field.toLowerCase().includes('imagem');
@@ -449,24 +468,6 @@ const FieldPositioner = ({
     setIsInteracting(false);
   };
 
-  const handleContentChange = useCallback((field, newText) => {
-    if (!csvData || csvData.length === 0) return;
-
-    const updatedCsvData = csvData.map((row, index) => {
-      if (index === currentPreviewIndex) {
-        return {
-          ...row,
-          [field]: newText,
-        };
-      }
-      return row;
-    });
-
-    // Propagate change upwards
-    if (onCsvDataUpdate) {
-      onCsvDataUpdate(updatedCsvData);
-    }
-  }, [csvData, currentPreviewIndex, onCsvDataUpdate]);
 
   // Navigation handlers
   const handleNextPreview = () => {


### PR DESCRIPTION
This commit fixes a runtime error (`ReferenceError: Cannot access 'handleContentChange' before initialization`) that occurred in the FieldPositioner component.

The error was caused by `handleVisibilityChange` being defined before `handleContentChange`, which it depends on. The order of these function declarations has been swapped to ensure all functions are initialized before they are called.