### PR TITLE
Feature: Auto-transition on campaign generation

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Card,
   CardContent,
@@ -190,6 +190,14 @@ const Campaign = ({
     const [commonSolutions, setCommonSolutions] = React.useState([]);
     const [isLoadingSolutions, setIsLoadingSolutions] = React.useState(false);
     const [solutionsError, setSolutionsError] = React.useState(null);
+
+    useEffect(() => {
+        // Quando o conteúdo da campanha é gerado com sucesso e o processo de geração termina,
+        // muda para a segunda aba.
+        if (campaignContent && !isGeneratingCampaign) {
+            setActiveTab(1);
+        }
+    }, [campaignContent, isGeneratingCampaign]);
 
     const handleTabChange = (event, newValue) => {
       setActiveTab(newValue);


### PR DESCRIPTION
This commit implements a user-requested enhancement to the campaign creation flow.

After the main campaign content is successfully generated on the first tab ("Problema e Solução"), the UI now automatically transitions to the second tab ("Conteúdo Principal"). This improves the user experience by guiding them to the next logical step in the process.

The change is implemented using a `useEffect` hook in the `Campaign.jsx` component that observes the `campaignContent` and `isGeneratingCampaign` state variables.