### PR TITLE
Fix: Add missing import in FieldPositioner

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -22,6 +22,7 @@ import {
   Edit
 } from '@mui/icons-material';
 import DraggableElement from './DraggableElement';
+import FormattingPanel from './FormattingPanel';
 import FormattingDrawer from './FormattingDrawer'; // Import the new drawer
 
 const COMPLETE_DEFAULT_STYLE_FOR_FIELD_POSITIONER = {


### PR DESCRIPTION
This commit fixes a runtime error (`ReferenceError: FormattingPanel is not defined`) that occurred in the FieldPositioner component.

The error was caused by the `FormattingPanel` component being rendered within `FieldPositioner` without being imported. This commit adds the necessary import statement.