### PR TITLE
Fix: Correct layout bug in Field Editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1388,46 +1388,26 @@ function App() {
 
           {/* Passo 3: Posicionamento e Formatação */}
           {activeStep === 3 && (
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={!isMobile ? 8 : 12}>
-                <FieldPositioner
-                  backgroundImage={backgroundImage}
-                  csvHeaders={csvHeaders}
-                  fieldPositions={fieldPositions}
-                  setFieldPositions={setFieldPositions}
-                  fieldStyles={fieldStyles}
-                  setFieldStyles={setFieldStyles}
-                  csvData={csvData}
-                  onImageDisplayedSizeChange={setDisplayedImageSize}
-                  colorPalette={combinedPalette}
-                  standardsColors={standardsColors}
-                  onCsvDataUpdate={handleCsvRecordContentUpdate}
-                  onSelectFieldExternal={setSelectedField}
-                  originalImageSize={originalImageSize}
-                  imageFilters={imageFilters}
-                  brandElements={brandElements}
-                  setBrandElements={setBrandElements}
-                  onZIndexChange={handleZIndexChange}
-                />
-              </Grid>
-              {!isMobile && (
-                <Grid item xs={12} md={4}>
-                  <FormattingPanel
-                    selectedField={selectedField}
-                    fieldStyles={fieldStyles}
-                    setFieldStyles={setFieldStyles}
-                    fieldPositions={fieldPositions}
-                    setFieldPositions={setFieldPositions}
-                    csvHeaders={csvHeaders}
-                    imageFilters={imageFilters}
-                    setImageFilters={setImageFilters}
-                    brandElements={brandElements}
-                    setBrandElements={setBrandElements}
-                    onZIndexChange={handleZIndexChange}
-                  />
-                </Grid>
-              )}
-            </Grid>
+            <FieldPositioner
+              backgroundImage={backgroundImage}
+              csvHeaders={csvHeaders}
+              fieldPositions={fieldPositions}
+              setFieldPositions={setFieldPositions}
+              fieldStyles={fieldStyles}
+              setFieldStyles={setFieldStyles}
+              csvData={csvData}
+              onImageDisplayedSizeChange={setDisplayedImageSize}
+              colorPalette={combinedPalette}
+              standardsColors={standardsColors}
+              onCsvDataUpdate={handleCsvRecordContentUpdate}
+              onSelectFieldExternal={setSelectedField}
+              originalImageSize={originalImageSize}
+              imageFilters={imageFilters}
+              setImageFilters={setImageFilters}
+              brandElements={brandElements}
+              setBrandElements={setBrandElements}
+              onZIndexChange={handleZIndexChange}
+            />
           )}
 
           {/* Passo 4: Geração de Imagens */}


### PR DESCRIPTION
This commit fixes a layout bug where the Formatting Panel was being rendered twice on desktop screens in the Field Editor step.

The issue was caused by the panel being rendered both in `App.jsx` and inside the `FieldPositioner` component. This commit removes the duplicate rendering from `App.jsx` and ensures that `FieldPositioner` correctly handles its own layout, resolving the visual glitch.