### PR TITLE
Fix: Improve image field detection for visibility toggle

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -171,13 +171,21 @@ const FieldPositioner = ({
   }, [csvData, currentPreviewIndex, onCsvDataUpdate]);
 
   const handleVisibilityChange = useCallback((field, isVisible) => {
-    // Lógica para deletar imagem
-    const isImageField = field.toLowerCase().includes('imagem');
+    // Get the current value of the field for the record being previewed
+    const currentValue = csvData?.[currentPreviewIndex]?.[field];
+
+    // A field is an "image field" if its content looks like a URL.
+    const isImageField = currentValue && typeof currentValue === 'string' && (
+        currentValue.startsWith('http') ||
+        currentValue.startsWith('data:image') ||
+        /\.(jpg|jpeg|png|gif|webp)$/i.test(currentValue)
+    );
+
     if (isImageField && !isVisible) {
-      handleContentChange(field, ''); // Limpa o valor do campo de imagem
+      handleContentChange(field, ''); // Clear the image URL
     }
 
-    // Atualiza a visibilidade do campo
+    // Always update the visibility
     setFieldPositions(prev => ({
       ...prev,
       [field]: {
@@ -185,7 +193,7 @@ const FieldPositioner = ({
         visible: isVisible
       }
     }));
-  }, [handleContentChange, setFieldPositions]);
+  }, [handleContentChange, setFieldPositions, csvData, currentPreviewIndex]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
This commit fixes a bug where toggling the visibility switch off for an image field did not delete the image's content.

The original implementation incorrectly identified an "image field" by checking if the column header contained the word "imagem". This was not robust.

The new implementation a more reliable method:
- It now inspects the *content* of the field for the currently previewed record.
- If the content string appears to be an image URL (e.g., starts with 'http' or ends with a common image extension), the field is treated as an image field.
- When the visibility for such a field is toggled off, its content (the URL) is now correctly cleared from the data.