### PR TITLE
Fix: Constrain width of field editor image container

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -623,7 +623,9 @@ const FieldPositioner = ({
                 WebkitOverflowScrolling: 'touch',
                 '&.interacting': {
                   touchAction: 'none'
-                }
+                },
+                maxWidth: '800px',
+                mx: 'auto',
               }}
               onMouseDown={(e) => {
                 if (e.target.closest('.text-box')) return;


### PR DESCRIPTION
This commit addresses a layout issue where the image container in the Field Editor could become too wide on large screens.

A `maxWidth` of `800px` and horizontal auto margins have been applied to the main container in the `FieldPositioner` component. This ensures the editor remains at a reasonable and consistent width, improving the user experience.