### PR TITLE
Fix: Prevent crash when rendering LinkedIn profiles

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -160,10 +160,17 @@ const Publisher = ({
       setProfileError('');
       try {
         const profiles = await getLinkedInProfiles();
-        setLinkedinProfiles(profiles);
-        // Only set a default profile if one isn't already selected (e.g., from a loaded state)
-        if (profiles.length > 0 && !selectedProfile) {
-          setSelectedProfile(profiles[0].urn);
+        // Ensure profiles is an array before setting
+        if (Array.isArray(profiles)) {
+          setLinkedinProfiles(profiles);
+          // Set a default profile only if one isn't already selected and the first profile is valid
+          if (profiles.length > 0 && profiles[0] && profiles[0].urn && !selectedProfile) {
+            setSelectedProfile(profiles[0].urn);
+          }
+        } else {
+            // Handle cases where the API might not return an array
+            setLinkedinProfiles([]);
+            console.warn("LinkedIn API did not return a valid array of profiles.");
         }
       } catch (error) {
         console.error("Erro ao buscar perfis do LinkedIn:", error);
@@ -416,7 +423,7 @@ const Publisher = ({
                 <Select
                   labelId="linkedin-profile-select-label"
                   id="linkedin-profile-select"
-                  value={selectedProfile}
+                  value={selectedProfile || ''}
                   label="Publicar como"
                   onChange={(e) => setSelectedProfile(e.target.value)}
                   disabled={isLoadingProfiles || isPublishingLi}


### PR DESCRIPTION
This commit fixes a runtime error (`TypeError: Cannot read properties of undefined (reading 'value')`) that occurred in the Publisher component when rendering the LinkedIn profile selection dropdown.

The error was caused by the component attempting to map over an array of profiles that could potentially contain null or undefined entries, or by trying to set a default profile from an invalid object, leading to an `undefined` state.

The fix is two-fold:
1.  The `useEffect` hook that fetches profiles now defensively checks that the API response is a valid array and that the first profile is a valid object with a `urn` before setting it as the default.
2.  The `Select` component's `value` prop is now set to `selectedProfile || ''`, which prevents `undefined` from ever being passed as the value, making the component more resilient.