### PR TITLE
fix: Ensure proper re-initialization of Google Drive API

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -26,10 +26,9 @@ export const AuthProvider = ({ children }) => {
     }
 
     try {
-      // Força a reinicialização se as chaves mudaram.
-      if (!googleDriveAPI.isInitialized) {
-        toast.info('Inicializando API do Google...');
-        await googleDriveAPI.initialize(apiKey, clientId);
+      const initResult = await googleDriveAPI.initialize(apiKey, clientId);
+      if (initResult.reinitialized) {
+        toast.info('API do Google inicializada.');
       }
 
       if (!googleDriveAPI.isUserSignedIn()) {

--- a/src/utils/googleDriveAPI.js
+++ b/src/utils/googleDriveAPI.js
@@ -14,6 +14,8 @@ class GoogleDriveAPI {
     // Promise handlers for discrete signIn calls
     this.signInResolver = null;
     this.signInRejecter = null;
+    this.apiKey = null;
+    this.clientId = null;
   }
 
   /**
@@ -24,18 +26,32 @@ class GoogleDriveAPI {
       return this.initPromise;
     }
 
-    if (this.isInitialized) {
-      return Promise.resolve(true);
+    // If already initialized with the same keys, do nothing.
+    if (this.isInitialized && this.apiKey === apiKey && this.clientId === clientId) {
+      return Promise.resolve({ reinitialized: false });
     }
+
+    // Reset for re-initialization
+    if (this.isInitialized) {
+        await this.signOut(); // Best effort to sign out from previous session
+    }
+
+    this.isInitialized = false;
+    this.tokenClient = null;
+    this.apiKey = apiKey;
+    this.clientId = clientId;
 
     this.initPromise = this._performInitialization(apiKey, clientId);
 
     try {
-      const result = await this.initPromise;
+      await this.initPromise;
       this.initPromise = null;
-      return result;
+      return { reinitialized: true };
     } catch (error) {
       this.initPromise = null;
+      this.isInitialized = false;
+      this.apiKey = null;
+      this.clientId = null;
       throw error;
     }
   }


### PR DESCRIPTION
This commit resolves a bug that caused a 'Pop up Window Closed' error during Google Drive authentication. The issue occurred when a user attempted to connect with new credentials after a previous attempt had failed or been made with different keys.

The root cause was that the Google API client was not being re-initialized correctly, leaving it in a stale state.

The fix involves:
- Making the `initialize` method in `googleDriveAPI.js` idempotent and capable of handling re-initialization. It now checks the provided API keys against the currently stored ones and resets the client state if they differ.
- On initialization failure, the state is now fully cleared to allow subsequent attempts to succeed.
- Simplifying the `connectGoogleDrive` function in `AuthContext.jsx` to call `initialize` on every attempt, delegating the state management to the `googleDriveAPI` class.