### PR TITLE
Fix: Brand element visibility switch deletes the element

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -60,7 +60,7 @@ const FormattingPanel = ({
   brandElements,
   setBrandElements,
   onZIndexChange,
-  onVisibilityChange,
+  onDeselectField,
 }) => {
   const fonts = [
     // Sans-serif
@@ -156,6 +156,9 @@ const FormattingPanel = ({
     setBrandElements(prev => prev.filter(el => el.id !== elementId));
     // Also deselect the element
     setCurrentElement(null);
+    if (onDeselectField) {
+      onDeselectField();
+    }
   };
 
   return (
@@ -173,7 +176,17 @@ const FormattingPanel = ({
                 control={
                   <Switch
                     checked={currentElement.visible !== false}
-                    onChange={() => onVisibilityChange(selectedField, !currentElement.visible)}
+                    onChange={(e) => {
+                      const isVisible = e.target.checked;
+                      if (isTextField) {
+                        updateFieldPosition(selectedField, 'visible', isVisible);
+                      } else {
+                        // For brand elements, hiding means deleting.
+                        if (!isVisible) {
+                          handleDeleteBrandElement(selectedField);
+                        }
+                      }
+                    }}
                     size="small"
                   />
                 }

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -79,6 +79,10 @@ const GeneratedImageEditor = ({
     }
   }, []); // setEditedRecord is stable
 
+  const handleDeselectField = () => {
+    setSelectedFieldInternal(null);
+  };
+
   useEffect(() => {
     if (imageData && initialFieldPositions && initialFieldStyles) {
       setSelectedFieldInternal(null);
@@ -211,6 +215,7 @@ const GeneratedImageEditor = ({
                   setImageFilters={setEditedImageFilters}
                   brandElements={editedBrandElements}
                   setBrandElements={setEditedBrandElements}
+                  onDeselectField={handleDeselectField}
                 />
               </Grid>
             )}


### PR DESCRIPTION
The 'Visible' switch for a brand element in the Formatting Panel now correctly deletes the element, mimicking the 'Delete Element' button's behavior. This resolves a bug where clicking the switch would cause a crash due to a missing 'onVisibilityChange' prop.

- Modified `FormattingPanel.jsx` to change the Switch behavior.
- For brand elements, toggling visibility off now calls `handleDeleteBrandElement`.
- For text fields, it correctly updates the `visible` property using `updateFieldPosition`.
- Added an `onDeselectField` callback to `GeneratedImageEditor.jsx` to clear the selection after an element is deleted, preventing errors from stale state.