### PR TITLE
fix: Use default prompt behavior for Google Sign-In

### DIFF
--- a/src/utils/googleDriveAPI.js
+++ b/src/utils/googleDriveAPI.js
@@ -201,9 +201,9 @@ class GoogleDriveAPI {
       this.signInResolver = resolve;
       this.signInRejecter = reject;
 
-      // Prompt for consent only if necessary.
-      // An empty prompt is usually sufficient if the user has already granted consent.
-      this.tokenClient.requestAccessToken({ prompt: '' });
+      // Let GIS library handle the prompt logic.
+      // It will show the consent screen only when necessary.
+      this.tokenClient.requestAccessToken();
     });
   }
 


### PR DESCRIPTION
This commit resolves a recurring 'Pop up Window Closed' error during Google Drive authentication. The issue was caused by explicitly passing `{ prompt: '' }` to the `requestAccessToken` method, which suppresses the consent UI and fails immediately if the user has not previously granted consent.

By removing this parameter, we now rely on the default behavior of the Google Identity Services library, which correctly determines when to show the consent and account selection popups.

This change builds upon previous fixes that improved the re-initialization logic of the API client. The combination of these changes should provide a stable and correct authentication flow.