### PR TITLE
fix: Unify Google Drive authentication in Image Generator

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -19,7 +19,8 @@ import {
   TextField,
   FormControlLabel,
   Switch,
-  Divider
+  Divider,
+  Tooltip
 } from '@mui/material';
 import {
   Download,
@@ -35,10 +36,10 @@ import {
   SwapHoriz,
   Share // <-- Adicionar ícone de compartilhamento
 } from '@mui/icons-material';
-import GoogleAuthSetup from './GoogleAuthSetup';
 import GeneratedImageEditor from './GeneratedImageEditor'; // Importar o novo editor
 import googleDriveAPI from '../utils/googleDriveAPI';
 import { composeImage } from '../utils/imageComposer';
+import { useAuth } from '../context/AuthContext';
 
 const ImageGeneratorFrontendOnly = ({
   csvData,
@@ -74,12 +75,12 @@ const ImageGeneratorFrontendOnly = ({
   const [showGeneratedImageEditor, setShowGeneratedImageEditor] = useState(false);
 
 
+  const { isGoogleDriveConnected } = useAuth();
+
   // Estados para integração Google Drive
   const [projectName, setProjectName] = useState('');
   const [isUploadingToDrive, setIsUploadingToDrive] = useState(false);
   const [driveResult, setDriveResult] = useState(null);
-  const [authConfigured, setAuthConfigured] = useState(false);
-  const [showAuthSetup, setShowAuthSetup] = useState(false);
   const [replacingImageIndex, setReplacingImageIndex] = useState(null);
 
   // Removed: const canvasRef = useRef(null);
@@ -773,11 +774,6 @@ const ImageGeneratorFrontendOnly = ({
 
   // Função para upload para Google Drive
   const uploadToGoogleDrive = async () => {
-    if (!authConfigured) {
-      setShowAuthSetup(true);
-      return;
-    }
-
     if (!projectName.trim()) {
       alert('Por favor, digite um nome para o projeto.');
       return;
@@ -900,17 +896,6 @@ const ImageGeneratorFrontendOnly = ({
       setIsUploadingToDrive(false); // Libera o estado da UI
     }
   };
-  // Callback para quando a autenticação for bem-sucedida
-  const handleAuthSuccess = () => {
-    setAuthConfigured(true);
-    setShowAuthSetup(false);
-  };
-
-  // Callback para quando houver erro na autenticação
-  const handleAuthError = (error) => {
-    console.error('Erro na autenticação:', error);
-    setAuthConfigured(false);
-  };
 
   return (
     <Box sx={{ mt: 3 }}>
@@ -985,16 +970,20 @@ const ImageGeneratorFrontendOnly = ({
                 </Grid>
 
                 <Grid item xs={12} md={6}>
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    onClick={uploadToGoogleDrive}
-                    disabled={isUploadingToDrive}
-                    startIcon={<CloudUpload />}
-                    fullWidth
-                  >
-                    {isUploadingToDrive ? 'Enviando...' : 'Enviar para Google Drive'}
-                  </Button>
+                  <Tooltip title={!isGoogleDriveConnected ? "Conecte-se ao Google Drive nas configurações para ativar esta opção" : ""}>
+                    <span>
+                      <Button
+                        variant="contained"
+                        color="secondary"
+                        onClick={uploadToGoogleDrive}
+                        disabled={isUploadingToDrive || !isGoogleDriveConnected}
+                        startIcon={<CloudUpload />}
+                        fullWidth
+                      >
+                        {isUploadingToDrive ? 'Enviando...' : 'Enviar para Google Drive'}
+                      </Button>
+                    </span>
+                  </Tooltip>
                 </Grid>
               </Grid>
 
@@ -1154,19 +1143,6 @@ const ImageGeneratorFrontendOnly = ({
           <Button onClick={() => downloadImage(selectedPreview)} startIcon={<Download />}>Download</Button>
           <Button onClick={closePreview}>Fechar</Button>
         </DialogActions>
-      </Dialog>
-
-      {/* Dialog de Configuração de Autenticação */}
-      <Dialog open={showAuthSetup} onClose={() => setShowAuthSetup(false)} maxWidth="md" fullWidth>
-        <DialogTitle>
-          Configuração Google Drive
-          <IconButton onClick={() => setShowAuthSetup(false)} sx={{ position: 'absolute', right: 8, top: 8 }}>
-            <Close />
-          </IconButton>
-        </DialogTitle>
-        <DialogContent>
-          <GoogleAuthSetup onAuthSuccess={handleAuthSuccess} onAuthError={handleAuthError} />
-        </DialogContent>
       </Dialog>
 
       {/* Removed: <canvas ref={canvasRef} style={{ display: 'none' }} /> */}


### PR DESCRIPTION
Resolves an issue where the "Send to Google Drive" button in the Image Generator would fail on the first click with a Cross-Origin-Opener-Policy error. This was caused by a redundant, local authentication process that was separate from the global `AuthContext`.

This commit refactors `ImageGeneratorFrontendOnly.jsx` to:
- Remove the local authentication state and dialog (`authConfigured`, `showAuthSetup`, `GoogleAuthSetup`).
- Use the global `isGoogleDriveConnected` state from the `useAuth` hook.
- Disable the "Send to Google Drive" button when the user is not authenticated.
- Add a `Tooltip` to the disabled button to guide the user to the main settings to connect.

This unifies the application's authentication logic and provides a more consistent and predictable user experience.