### PR TITLE
Refactor campaign UI and fix state saving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -807,6 +807,7 @@ function App() {
         autor,
         instrucoes,
         formato,
+        generatedImageUrl,
         conteudoMedio,
         conteudoPequeno,
         conteudoFormatado,
@@ -1576,11 +1577,11 @@ function App() {
           editingFollowup !== null
             ? `Editar Post de Follow-up ${editingFollowup.index + 1}`
             : `Editar ${
-                editingField === 'conteudo'
-                  ? 'Conteúdo'
-                  : editingField === 'cta'
-                  ? 'CTA'
-                  : 'Conteúdo Formatado'
+                editingField === 'conteudo' ? 'Conteúdo' :
+                editingField === 'conteudoMedio' ? 'Conteúdo Médio' :
+                editingField === 'conteudoPequeno' ? 'Conteúdo Pequeno' :
+                editingField === 'cta' ? 'CTA' :
+                'Conteúdo Formatado'
               }`
         }
         content={
@@ -1588,7 +1589,11 @@ function App() {
             ? editingFollowup.content
             : editingField === 'conteudoFormatado'
             ? conteudoFormatado
-            : editingField
+            : editingField === 'conteudoMedio'
+            ? conteudoMedio
+            : editingField === 'conteudoPequeno'
+            ? conteudoPequeno
+            : editingField && campaignContent
             ? campaignContent[editingField]
             : ''
         }
@@ -1598,7 +1603,11 @@ function App() {
             : (newContent) => {
                 if (editingField === 'conteudoFormatado') {
                   setConteudoFormatado(newContent);
-                } else {
+                } else if (editingField === 'conteudoMedio') {
+                  setConteudoMedio(newContent);
+                } else if (editingField === 'conteudoPequeno') {
+                  setConteudoPequeno(newContent);
+                } else if (editingField) {
                   setCampaignContent({
                     ...campaignContent,
                     [editingField]: newContent,

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -36,6 +36,7 @@ import {
     TipsAndUpdatesOutlined as TipsAndUpdatesIcon,
     FactCheckOutlined as FactCheckIcon,
     AutoAwesomeOutlined as GeminiIcon,
+    Edit as EditIcon,
 } from '@mui/icons-material';
 
 const problemaHint = (
@@ -574,25 +575,32 @@ const Campaign = ({
                 <TabPanel value={activeTab} index={4}>
                     {campaignContent && (
                         <Grid container spacing={2} sx={{ mt: 2 }}>
-                            <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                                <TextField
-                                    label="Conteúdo Formatado (HTML)"
-                                    multiline
-                                    rows={10}
-                                    value={conteudoFormatado}
-                                    onClick={() => setEditingField('conteudoFormatado')}
-                                    readOnly
-                                    variant="outlined"
-                                    fullWidth
-                                    sx={{ cursor: 'pointer' }}
-                                />
-                                <Button onClick={() => handleGenerateFormattedContent()} disabled={isGeneratingConteudoFormatado || !campaignContent} startIcon={<GeminiIcon />}>
-                                    {isGeneratingConteudoFormatado ? 'Gerando...' : 'Gerar'}
-                                </Button>
-                            </Grid>
                              <Grid item xs={12}>
-                                <Typography variant="h6" gutterBottom>Pré-visualização</Typography>
-                                <Box border={1} borderColor="grey.300" p={2} borderRadius={1} sx={{ minHeight: 100, '& *': { all: 'revert' } }}>
+                                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                                    <Typography variant="h6" gutterBottom component="div" sx={{ mb: 0 }}>
+                                        Pré-visualização
+                                    </Typography>
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                        <Button
+                                            onClick={() => setEditingField('conteudoFormatado')}
+                                            startIcon={<EditIcon />}
+                                            variant="outlined"
+                                            size="small"
+                                        >
+                                            Editar
+                                        </Button>
+                                        <Button
+                                            onClick={() => handleGenerateFormattedContent()}
+                                            disabled={isGeneratingConteudoFormatado || !campaignContent}
+                                            startIcon={<GeminiIcon />}
+                                            variant="outlined"
+                                            size="small"
+                                        >
+                                            {isGeneratingConteudoFormatado ? 'Gerando...' : 'Gerar'}
+                                        </Button>
+                                    </Box>
+                                </Box>
+                                <Box border={1} borderColor="grey.300" p={2} borderRadius={1} sx={{ minHeight: 300, '& *': { all: 'revert' } }}>
                                     <div dangerouslySetInnerHTML={{ __html: conteudoFormatado }} />
                                 </Box>
                             </Grid>

--- a/src/theme.js
+++ b/src/theme.js
@@ -55,6 +55,19 @@ export const lightTheme = createTheme({
           }
         }
       }
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#f1f5f9', // slate-100
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#8b5cf6', // primary.main
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#8b5cf6', // primary.main
+          },
+        }
+      }
     }
   }
 });
@@ -102,6 +115,19 @@ export const darkTheme = createTheme({
           '&:hover': {
             background: 'linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%)',
           }
+        }
+      }
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: '#1e293b', // background.paper
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#a78bfa', // primary.main
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#a78bfa', // primary.main
+          },
         }
       }
     }


### PR DESCRIPTION
This commit addresses several UI/UX issues in the campaign management feature and fixes a critical bug related to state persistence.

Key changes:

- **Unified Content Editing**: The editing experience for 'Conteúdo Médio', 'Conteúdo Pequeno', and 'CTA' fields is now consistent with the main 'Conteúdo' field. All these fields now open a dialog for editing.

- **WordPress Tab Refactor**: The 'Conteúdo WordPress' tab has been streamlined. The read-only HTML text area was removed, and an 'Editar' button was added to the preview panel, improving the workflow.

- **Theming for Inputs**: The background color of text input fields is now slightly different from the main background in both light and dark modes, improving field visibility and the overall look and feel.

- **Fix AI Image Persistence**: The AI-generated image URL is now correctly included when saving the campaign state to a .midiator file, preventing the image from being lost when loading a saved campaign.