### PR TITLE
This commit renames the label of the 'Identidade do Autor' field to '…

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -924,7 +924,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
                 <TextField
                   fullWidth
-                  label="Identidade do Autor"
+                  label="Nome"
                   name="identidade"
                   value={autor?.identidade || ''}
                   onChange={handleAutorChange}


### PR DESCRIPTION
…Nome' as requested in a follow-up.