### PR TITLE
feat(campaign): Center-align labels for empty fields

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -192,6 +192,15 @@ const Campaign = ({
     const [isLoadingSolutions, setIsLoadingSolutions] = React.useState(false);
     const [solutionsError, setSolutionsError] = React.useState(null);
 
+    const emptyLabelStyle = {
+        '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiFormLabel-filled)': {
+            fontFamily: 'Montserrat, sans-serif',
+            fontSize: '1.2rem',
+            // Aproxima o posicionamento ao centro para um campo de 4 linhas
+            transform: 'translate(14px, 45px) scale(1)',
+        },
+    };
+
     useEffect(() => {
         // Quando o conteúdo da campanha é gerado com sucesso e o processo de geração termina,
         // muda para a segunda aba.
@@ -273,6 +282,7 @@ const Campaign = ({
                                     fullWidth
                                     placeholder="Descreva o problema que sua campanha busca resolver."
                                     disabled={campaignContent !== null}
+                                    sx={(problema.trim() === '' && solucao.trim() === '') ? emptyLabelStyle : {}}
                                 />
                                 <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setHintModalOpen(true)}>
                                     <GeminiIcon />
@@ -292,6 +302,7 @@ const Campaign = ({
                                     fullWidth
                                     placeholder="Descreva a solução que sua campanha oferece."
                                     disabled={campaignContent !== null}
+                                    sx={(problema.trim() === '' && solucao.trim() === '') ? emptyLabelStyle : {}}
                                 />
                                 <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setSolucaoHintModalOpen(true)}>
                                     <GeminiIcon />


### PR DESCRIPTION
This commit implements a user-requested style change on the campaign creation tab.

When both the "Problema" and "Solução" text fields are empty, their respective labels are now styled to be:
- Vertically centered within the text area.
- Left-aligned.
- Rendered in a larger Montserrat font.

This provides a more visually appealing and intuitive starting state for the user when creating a new campaign. The styling dynamically reverts to the default Material-UI appearance as soon as the user starts typing in either field.