### PR TITLE
feat(campaign): Adjust centered labels for empty fields

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -195,9 +195,9 @@ const Campaign = ({
     const emptyLabelStyle = {
         '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiFormLabel-filled)': {
             fontFamily: 'Montserrat, sans-serif',
-            fontSize: '1.2rem',
-            // Aproxima o posicionamento ao centro para um campo de 4 linhas
-            transform: 'translate(14px, 45px) scale(1)',
+            fontSize: '1.4rem',
+            // Aproxima o posicionamento ao centro para um campo de 4 linhas, com maior recuo e tamanho
+            transform: 'translate(24px, 47px) scale(1)',
         },
     };
 


### PR DESCRIPTION
This commit fine-tunes the styling for the centered labels on the campaign creation tab based on user feedback.

The changes include:
- Increasing the font size for better readability.
- Adding more left padding to the labels for improved visual spacing.

This enhances the previously implemented feature, providing a more polished and visually appealing starting state for the user when the "Problema" and "Solução" fields are empty.