### PR TITLE
refactor(persona): Remove descriptive text from Persona Wizard

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -290,10 +290,6 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
       case 0:
         return (
           <Box>
-            <Typography variant="h6" gutterBottom>Descreva a persona para começar</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Explique o que é uma persona no contexto do marketing de conteúdo e as informações chave em um vocabulário simples.
-            </Typography>
             <Alert severity="info" sx={{ mb: 2 }}>
               Forneça uma breve descrição do perfil. A IA irá usar essa informação para preencher os primeiros campos automaticamente. Ex: 'CTO de uma startup de tecnologia que precisa inovar rapidamente e reduzir custos com a nuvem.'
             </Alert>


### PR DESCRIPTION
This commit removes the introductory title and descriptive paragraph from the first step of the Persona Creation Wizard, as requested. This change simplifies the UI by making the instructional alert and the description field the primary focus for the user.