### PR TITLE
refactor: Embed Author wizard and align behavior with Persona wizard

### DIFF
--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -26,26 +26,25 @@ const steps = [
 
 const TIPO_ORGANIZACAO_OPTIONS = ['Braço de tecnologia', 'Agência de marketing', 'Consultoria', 'Startup', 'Empresa de Software (SaaS)', 'E-commerce', 'Outro'];
 
-const AutorWizard = ({ open, onClose, onSave, onGenerate, isGeneratingAutor, autor }) => {
-  const isMobile = useIsMobile();
+export const AutorWizardContent = ({ open, onClose, onSave, onGenerate, isGeneratingAutor, autor }) => {
   const [activeStep, setActiveStep] = useState(0);
   const [autorData, setAutorData] = useState(autor || {});
 
   useEffect(() => {
-    if (open) {
-      setAutorData(autor || {
-        descricaoGeral: '',
-        dominioReferencia: '',
-        siteExclusao: '',
-        identidade: '',
-        descricao: '',
-        tipo: '',
-        objetivoEstrategico: '',
-        objetivoEngajamento: '',
-      });
-      setActiveStep(0); // Reset to first step when modal opens
-    }
-  }, [open, autor]);
+    // Unlike the modal version, we don't reset the step when 'open' changes here.
+    // The parent component will control the mounting/unmounting.
+    // We do want to initialize the data when the component mounts or the initial 'autor' prop changes.
+    setAutorData(autor || {
+      descricaoGeral: '',
+      dominioReferencia: '',
+      siteExclusao: '',
+      identidade: '',
+      descricao: '',
+      tipo: '',
+      objetivoEstrategico: '',
+      objetivoEngajamento: '',
+    });
+  }, [autor]);
 
   const handleNext = () => {
     if (activeStep === 0) { // Step "Início Rápido com IA"
@@ -197,37 +196,58 @@ const AutorWizard = ({ open, onClose, onSave, onGenerate, isGeneratingAutor, aut
   };
 
   return (
+    <Box>
+      <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      {getStepContent(activeStep)}
+      <DialogActions sx={{ p: 3, justifyContent: 'space-between', mt: 2, flexWrap: 'wrap' }}>
+        <Box>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button onClick={handleSave} color="secondary">Salvar</Button>
+        </Box>
+        <Box sx={{ display: 'flex', mt: { xs: 2, sm: 0 } }}>
+          <Button onClick={handleBack} disabled={activeStep === 0}>
+            Voltar
+          </Button>
+          <Button
+              onClick={handleNext}
+              variant="contained"
+              disabled={isNextDisabled()}
+              sx={{ ml: 1 }}
+          >
+            {isGeneratingAutor && activeStep === 0 && <CircularProgress size={24} />}
+            {!isGeneratingAutor && (activeStep === 0 ? 'Gerar com IA' : 'Finalizar e Salvar')}
+          </Button>
+        </Box>
+      </DialogActions>
+    </Box>
+  );
+};
+
+
+const AutorWizard = ({ open, onClose, onSave, ...props }) => {
+  const isMobile = useIsMobile();
+
+  return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
       <DialogTitle>
         Assistente de Criação de Autor
-        <Typography variant="body2">Passo {activeStep + 1} de {steps.length}</Typography>
       </DialogTitle>
       <DialogContent sx={{ minHeight: '50vh' }}>
-        <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>
-          {steps.map((label) => (
-            <Step key={label}>
-              <StepLabel>{label}</StepLabel>
-            </Step>
-          ))}
-        </Stepper>
-        {getStepContent(activeStep)}
+        <AutorWizardContent
+            onClose={onClose}
+            onSave={(data) => {
+                onSave(data);
+                onClose(); // In modal context, save also closes.
+            }}
+            {...props}
+        />
       </DialogContent>
-      <DialogActions sx={{ p: 3 }}>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={handleSave} color="secondary">Salvar e Sair</Button>
-        <Box sx={{ flex: '1 1 auto' }} />
-        <Button onClick={handleBack} disabled={activeStep === 0}>
-          Voltar
-        </Button>
-        <Button
-            onClick={handleNext}
-            variant="contained"
-            disabled={isNextDisabled()}
-        >
-          {isGeneratingAutor && activeStep === 0 && <CircularProgress size={24} />}
-          {!isGeneratingAutor && (activeStep === 0 ? 'Gerar com IA' : 'Finalizar e Salvar')}
-        </Button>
-      </DialogActions>
     </Dialog>
   );
 };

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -54,7 +54,7 @@ import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
 import PersonaGenerationModal from './PersonaGenerationModal';
 import PersonaWizard, { PersonaWizardContent } from './PersonaWizard';
-import AutorWizard from './AutorWizard';
+import AutorWizard, { AutorWizardContent } from './AutorWizard';
 import PaletteWizard from './PaletteWizard';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
@@ -107,6 +107,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemori
   // State for AI Autor Generation
   const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
   const [showAutorWizard, setShowAutorWizard] = useState(false);
+  const [isAutorWizardVisible, setIsAutorWizardVisible] = useState(false);
 
   // State for AI Palette Wizard
   const [showPaletteWizard, setShowPaletteWizard] = useState(false);
@@ -236,14 +237,13 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
         setIsPersonaWizardVisible(true);
       } else {
         setIsPersonaWizardVisible(false);
-        // Se a persona existe, verifica o autor.
-        // A ausência de 'identidade' é um bom indicador de que o autor não foi preenchido.
-        if (!autor || !autor.identidade) {
-            // Muda para a aba "Autor" para dar contexto ao usuário
-            setValue(1);
-            // Mostra o assistente de criação do autor
-            setShowAutorWizard(true);
-        }
+      }
+
+      // Se o autor não existir ou não tiver identidade, mostra o assistente do autor
+      if (!autor || !autor.identidade) {
+        setIsAutorWizardVisible(true);
+      } else {
+        setIsAutorWizardVisible(false);
       }
     }
   }, [open]);
@@ -968,64 +968,78 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
           )}
         </TabPanel>
             <TabPanel value={value} index={1}>
-              <Stack spacing={2}>
-                <Stack direction="row" spacing={2} sx={{ alignItems: 'flex-start' }}>
-                    <Button
-                      variant="contained"
-                      startIcon={<Add />}
-                      onClick={() => setShowAutorWizard(true)}
-                    >
-                      Assistente de Criação de Autor
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      color="error"
-                      startIcon={<DeleteForeverIcon />}
-                      onClick={handleClearAutor}
-                      disabled={!autor || Object.keys(autor).length === 0}
-                    >
-                      Começar de Novo
-                    </Button>
-                </Stack>
+              {isAutorWizardVisible ? (
+                <AutorWizardContent
+                  autor={autor}
+                  onGenerate={handleGenerateAutorWithAI}
+                  isGeneratingAutor={isGeneratingAutor}
+                  onClose={() => setIsAutorWizardVisible(false)}
+                  onSave={(newAutor) => {
+                    setAutor(newAutor);
+                    setIsAutorWizardVisible(false);
+                    toast.success('Autor salvo com o assistente!');
+                  }}
+                />
+              ) : (
+                <Stack spacing={2}>
+                  <Stack direction="row" spacing={2} sx={{ alignItems: 'flex-start' }}>
+                      <Button
+                        variant="contained"
+                        startIcon={<Add />}
+                        onClick={() => setShowAutorWizard(true)}
+                      >
+                        Editar com Assistente
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        startIcon={<DeleteForeverIcon />}
+                        onClick={handleClearAutor}
+                        disabled={!autor || Object.keys(autor).length === 0}
+                      >
+                        Começar de Novo
+                      </Button>
+                  </Stack>
 
-                <TextField
-                  fullWidth
-                  label="Nome"
-                  name="identidade"
-                  value={autor?.identidade || ''}
-                  onChange={handleAutorChange}
-                  inputProps={{ maxLength: 120 }}
-                  helperText={`${(autor?.identidade || '').length}/120 O nome da empresa ou marca que está publicando o conteúdo. Ex: ACME Corporation.`}
-                />
-                <HtmlDisplayField
-                  title="Descrição da Empresa"
-                  tooltip="Uma breve descrição que detalha a área de atuação, as especializações e o foco do negócio."
-                  htmlContent={autor?.descricao}
-                  onClick={() => handleOpenEditor('autor.descricao')}
-                  placeholder="Clique para editar a descrição..."
-                />
-                <HtmlDisplayField
-                  title="Tipo de Organização"
-                  tooltip="Uma classificação que define a natureza da empresa (ex: 'braço de tecnologia', 'agência de marketing')."
-                  htmlContent={autor?.tipo}
-                  onClick={() => handleOpenEditor('autor.tipo')}
-                  placeholder="Clique para editar o tipo..."
-                />
-                <HtmlDisplayField
-                  title="Objetivo Estratégico"
-                  tooltip="A meta de longo prazo da mensagem (posicionamento da marca, construção de autoridade, etc.)."
-                  htmlContent={autor?.objetivoEstrategico}
-                  onClick={() => handleOpenEditor('autor.objetivoEstrategico')}
-                  placeholder="Clique para editar o objetivo estratégico..."
-                />
-                <HtmlDisplayField
-                  title="Objetivo de Engajamento"
-                  tooltip="O tipo de interação que a mensagem deve estimular no público."
-                  htmlContent={autor?.objetivoEngajamento}
-                  onClick={() => handleOpenEditor('autor.objetivoEngajamento')}
-                  placeholder="Clique para editar o objetivo de engajamento..."
-                />
-              </Stack>
+                  <TextField
+                    fullWidth
+                    label="Nome"
+                    name="identidade"
+                    value={autor?.identidade || ''}
+                    onChange={handleAutorChange}
+                    inputProps={{ maxLength: 120 }}
+                    helperText={`${(autor?.identidade || '').length}/120 O nome da empresa ou marca que está publicando o conteúdo. Ex: ACME Corporation.`}
+                  />
+                  <HtmlDisplayField
+                    title="Descrição da Empresa"
+                    tooltip="Uma breve descrição que detalha a área de atuação, as especializações e o foco do negócio."
+                    htmlContent={autor?.descricao}
+                    onClick={() => handleOpenEditor('autor.descricao')}
+                    placeholder="Clique para editar a descrição..."
+                  />
+                  <HtmlDisplayField
+                    title="Tipo de Organização"
+                    tooltip="Uma classificação que define a natureza da empresa (ex: 'braço de tecnologia', 'agência de marketing')."
+                    htmlContent={autor?.tipo}
+                    onClick={() => handleOpenEditor('autor.tipo')}
+                    placeholder="Clique para editar o tipo..."
+                  />
+                  <HtmlDisplayField
+                    title="Objetivo Estratégico"
+                    tooltip="A meta de longo prazo da mensagem (posicionamento da marca, construção de autoridade, etc.)."
+                    htmlContent={autor?.objetivoEstrategico}
+                    onClick={() => handleOpenEditor('autor.objetivoEstrategico')}
+                    placeholder="Clique para editar o objetivo estratégico..."
+                  />
+                  <HtmlDisplayField
+                    title="Objetivo de Engajamento"
+                    tooltip="O tipo de interação que a mensagem deve estimular no público."
+                    htmlContent={autor?.objetivoEngajamento}
+                    onClick={() => handleOpenEditor('autor.objetivoEngajamento')}
+                    placeholder="Clique para editar o objetivo de engajamento..."
+                  />
+                </Stack>
+              )}
             </TabPanel>
             <TabPanel value={value} index={2}>
               <HtmlDisplayField


### PR DESCRIPTION
This commit refactors the Author wizard to match the behavior of the Persona wizard, based on user feedback.

- The `AutorWizard` component has been refactored to separate its content (`AutorWizardContent`) from the modal, allowing it to be embedded.
- If no author data exists, the `AutorWizardContent` is now displayed directly within the "Autor" tab instead of opening a modal.
- If author data exists, the "Editar com Assistente" button will open the wizard in a modal for editing, preserving the editing workflow.
- This creates a consistent user experience between the Persona and Autor definition flows.