### PR TITLE
fix: Align Author wizard description field with Persona's style

### DIFF
--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -80,6 +80,15 @@ export const AutorWizardContent = ({ open, onClose, onSave, onGenerate, isGenera
   };
 
   const getStepContent = (step) => {
+    const emptyLabelStyle = {
+        '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiFormLabel-filled)': {
+            fontFamily: 'Montserrat, sans-serif',
+            fontSize: '1.4rem',
+            // Ajustado para um campo de 6 linhas
+            transform: 'translate(14px, 60px) scale(1)',
+        },
+    };
+
     switch (step) {
       case 0:
         return (
@@ -90,7 +99,7 @@ export const AutorWizardContent = ({ open, onClose, onSave, onGenerate, isGenera
             </Alert>
             <TextField
               name="descricaoGeral"
-              label="Descrição Geral do Autor"
+              label="Descrição do Autor"
               multiline
               rows={6}
               fullWidth
@@ -98,7 +107,7 @@ export const AutorWizardContent = ({ open, onClose, onSave, onGenerate, isGenera
               onChange={handleChange}
               placeholder="Ex: 'Uma empresa de consultoria de marketing digital focada em startups de tecnologia, que busca se posicionar como líder de pensamento em SEO e marketing de conteúdo.'"
               disabled={isGeneratingAutor}
-              sx={{ mb: 2 }}
+              sx={!(autorData.descricaoGeral || '').trim() ? { ...emptyLabelStyle, mb: 2 } : { mb: 2 }}
             />
             <TextField
               name="dominioReferencia"


### PR DESCRIPTION
This commit applies the same styling and label from the Persona wizard's description field to the Author wizard's description field, as requested by the user.

- The label "Descrição Geral do Autor" is changed to "Descrição do Autor".
- A conditional style is applied to make the label act as a placeholder when the text field is empty, improving UI consistency.