### PR TITLE
fix: Transition to wizard when clearing Author data

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -482,6 +482,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
   const handleClearAutor = () => {
     if (window.confirm('Tem certeza que deseja começar de novo? Todos os dados do autor serão apagados.')) {
       setAutor({});
+      setIsAutorWizardVisible(true);
       toast.success('Dados do autor removidos. Você pode começar a criar um novo.');
     }
   };


### PR DESCRIPTION
This commit aligns the behavior of the "Começar de Novo" (Start Over) button on the "Autor" tab with the "Persona" tab.

When a user clicks the button to clear the author's data, the UI now correctly transitions to show the embedded author creation wizard. This creates a more consistent and intuitive user experience.