### PR TITLE
refactor: Adjust Persona wizard UI to use InfoTooltip

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -289,10 +289,7 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     switch (step) {
       case 0:
         return (
-          <Box>
-            <Alert severity="info" sx={{ mb: 2 }}>
-              Forneça uma breve descrição do perfil. A IA irá usar essa informação para preencher os primeiros campos automaticamente. Ex: 'CTO de uma startup de tecnologia que precisa inovar rapidamente e reduzir custos com a nuvem.'
-            </Alert>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <TextField
               name="description"
               label="Descrição da Persona"
@@ -305,6 +302,7 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
               disabled={isGeneratingPersona}
               sx={!(personaData.description || '').trim() ? emptyLabelStyle : {}}
             />
+            <InfoTooltip title="Forneça uma breve descrição do perfil. A IA irá usar essa informação para preencher os primeiros campos automaticamente. Ex: 'CTO de uma startup de tecnologia que precisa inovar rapidamente e reduzir custos com a nuvem.'" />
           </Box>
         );
       case 1:


### PR DESCRIPTION
This commit refactors the UI of the Persona creation wizard to be consistent with the Author wizard.

- The `Alert` component in the first step is removed.
- The informational text is moved into an `InfoTooltip` placed next to the main description field, creating a cleaner and more consistent UI.