### PR TITLE
feat(autor): Add specification field and fix React hook error

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -297,6 +297,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
     if (editingField === 'persona') return 'Editar Persona';
     if (editingField === 'autor.descricao') return 'Editar Descrição da Empresa';
     if (editingField === 'autor.tipo') return 'Editar Tipo de Organização';
+    if (editingField === 'autor.tipoOrganizacaoOutro') return 'Editar Tipo de Organização (Outro)';
     if (editingField === 'autor.objetivoEstrategico') return 'Editar Objetivo Estratégico';
     if (editingField === 'autor.objetivoEngajamento') return 'Editar Objetivo de Engajamento';
     if (editingField === 'instrucoes') return 'Editar Instruções';
@@ -1025,6 +1026,15 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                     onClick={() => handleOpenEditor('autor.tipo')}
                     placeholder="Clique para editar o tipo..."
                   />
+                  {autor?.tipo === 'Outro' && (
+                    <HtmlDisplayField
+                      title="Tipo de Organização (Outro)"
+                      tooltip="Descrição específica do tipo de organização."
+                      htmlContent={autor?.tipoOrganizacaoOutro}
+                      onClick={() => handleOpenEditor('autor.tipoOrganizacaoOutro')}
+                      placeholder="Clique para editar a especificação do tipo..."
+                    />
+                  )}
                   <HtmlDisplayField
                     title="Objetivo Estratégico"
                     tooltip="A meta de longo prazo da mensagem (posicionamento da marca, construção de autoridade, etc.)."

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -79,6 +79,9 @@ const findBestFitFontSize = (text, fontFamily, fontWeight, boxWidth, boxHeight) 
 };
 
 
+// Campos que devem usar renderização HTML
+const htmlFields = ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'];
+
 const FieldPositioner = ({
   backgroundImage,
   csvHeaders,
@@ -135,14 +138,11 @@ const FieldPositioner = ({
     generateComposedImage();
   }, [backgroundImage, imageFilters]);
 
-  // Campos que devem usar renderização HTML
-  const htmlFields = ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'];
-
-  const isHtmlField = (fieldName) => {
-    return htmlFields.some(field => 
+  const isHtmlField = useCallback((fieldName) => {
+    return htmlFields.some(field =>
       fieldName.toLowerCase().includes(field.toLowerCase())
     );
-  };
+  }, []);
 
   const handleFieldSelectInternal = useCallback((fieldToSelect) => {
     setSelectedField(fieldToSelect);
@@ -507,26 +507,6 @@ const FieldPositioner = ({
     }
   }, [isInteracting]);
 
-  if (!backgroundImage) {
-    return (
-      <Box
-        sx={{
-          height: 400,
-          border: '2px dashed #ccc',
-          borderRadius: 2,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: '#f5f5f5'
-        }}
-      >
-        <Typography color="textSecondary" variant="h6">
-          Carregue uma imagem de fundo para posicionar os campos
-        </Typography>
-      </Box>
-    );
-  }
-
   const renderableElements = React.useMemo(() => {
     const elements = [
       ...(csvHeaders || [])
@@ -574,6 +554,25 @@ const FieldPositioner = ({
   }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField]);
 
 
+  if (!backgroundImage) {
+    return (
+      <Box
+        sx={{
+          height: 400,
+          border: '2px dashed #ccc',
+          borderRadius: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#f5f5f5'
+        }}
+      >
+        <Typography color="textSecondary" variant="h6">
+          Carregue uma imagem de fundo para posicionar os campos
+        </Typography>
+      </Box>
+    );
+  }
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} lg={9}>


### PR DESCRIPTION
This commit introduces a new text field in the Author Definition Assistant for the "Other" organization type and fixes a React Hook error in the `FieldPositioner` component.

- In `src/utils/campaignPrompt.js`, the `tipoOrganizacaoOutro` field was added to the `autor` object.
- In `src/components/AutorWizard.jsx`, a new conditional text field was added.
- In `src/components/CampaignStandardsModal.jsx`, the "Autor" tab was updated to display the new field.
- In `src/components/FieldPositioner.jsx`, the conditional hook error was fixed by moving the conditional rendering logic.