### PR TITLE
fix(autor): Improve author field editing experience

### DIFF
--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -37,8 +37,8 @@ const InfoTooltip = ({ title }) => (
     </Tooltip>
 );
 
-export const AutorWizardContent = ({ onClose, onSave, onGenerate, isGeneratingAutor, autor }) => {
-  const [activeStep, setActiveStep] = useState(0);
+export const AutorWizardContent = ({ onClose, onSave, onGenerate, isGeneratingAutor, autor, initialStep = 0 }) => {
+  const [activeStep, setActiveStep] = useState(initialStep);
   const [autorData, setAutorData] = useState(autor || {});
 
   useEffect(() => {
@@ -276,7 +276,7 @@ export const AutorWizardContent = ({ onClose, onSave, onGenerate, isGeneratingAu
 };
 
 
-const AutorWizard = ({ open, onClose, onSave, ...props }) => {
+const AutorWizard = ({ open, onClose, onSave, initialStep, ...props }) => {
   const isMobile = useIsMobile();
 
   return (
@@ -291,6 +291,7 @@ const AutorWizard = ({ open, onClose, onSave, ...props }) => {
                 onSave(data);
                 onClose(); // In modal context, save also closes.
             }}
+            initialStep={initialStep}
             {...props}
         />
       </DialogContent>

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -108,6 +108,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemori
   const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
   const [showAutorWizard, setShowAutorWizard] = useState(false);
   const [isAutorWizardVisible, setIsAutorWizardVisible] = useState(false);
+  const [initialAutorStep, setInitialAutorStep] = useState(0);
 
   // State for AI Palette Wizard
   const [showPaletteWizard, setShowPaletteWizard] = useState(false);
@@ -486,6 +487,11 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
       setIsAutorWizardVisible(true);
       toast.success('Dados do autor removidos. Você pode começar a criar um novo.');
     }
+  };
+
+  const handleEditAutorField = () => {
+    setInitialAutorStep(1);
+    setShowAutorWizard(true);
   };
 
 
@@ -1023,7 +1029,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                     fullWidth
                     label="Tipo de Organização"
                     value={autor?.tipo || ''}
-                    onClick={() => setShowAutorWizard(true)}
+                    onClick={handleEditAutorField}
                     InputProps={{
                       readOnly: true,
                       style: { cursor: 'pointer' },
@@ -1040,7 +1046,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                       fullWidth
                       label="Tipo de Organização (Outro)"
                       value={autor?.tipoOrganizacaoOutro || ''}
-                      onClick={() => setShowAutorWizard(true)}
+                      onClick={handleEditAutorField}
                       InputProps={{
                         readOnly: true,
                         style: { cursor: 'pointer' },
@@ -1187,11 +1193,16 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
 
       <AutorWizard
         open={showAutorWizard}
-        onClose={() => setShowAutorWizard(false)}
+        onClose={() => {
+          setShowAutorWizard(false);
+          setInitialAutorStep(0); // Reset for next time
+        }}
         autor={autor}
+        initialStep={initialAutorStep}
         onSave={(newAutor) => {
           setAutor(newAutor);
           setShowAutorWizard(false);
+          setInitialAutorStep(0); // Reset for next time
           toast.success('Autor salvo com sucesso!');
         }}
         onGenerate={handleGenerateAutorWithAI}


### PR DESCRIPTION
This commit addresses a regression in the author editing workflow and improves the user experience.

- The "Tipo de Organização" and "Tipo de Organização (Outro)" fields now open the Author Wizard directly on the second step, allowing for focused editing with the correct UI components (dropdown and text field).
- Modified `AutorWizard.jsx` to accept an `initialStep` prop.
- Updated `CampaignStandardsModal.jsx` to manage the wizard's starting step and reset it on close.