### PR TITLE
feat(autor): Add 'Other' org type field and fix regressions

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -652,7 +652,7 @@ const FieldPositioner = ({
                 draggable={false}
               />
 
-              {renderableElements.map(element => (
+              {imageSize.width > 0 && renderableElements.map(element => (
                 <DraggableElement
                   key={element.id}
                   element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}


### PR DESCRIPTION
This commit introduces a new conditional field for the "Other" organization type in the Author wizard and includes several important bug fixes and usability improvements identified during development.

**Features:**
- In `AutorWizard.jsx`, if the user selects "Outro" as the organization type, a new text field now appears to specify the type.
- This new `tipoOrganizacaoOutro` field is saved and included in prompts sent to the Gemini API.

**Fixes & Refinements:**
- **Resizing Regression**: Fixed a critical bug in `FieldPositioner.jsx` where resizing knobs behaved erratically. This was caused by `DraggableElement`s rendering before their container size was calculated. The elements are now conditionally rendered only when the size is known.
- **Editing Workflow**: Corrected a regression where clicking the "Tipo de Organização" fields opened the wrong editor. The click now correctly opens the `AutorWizard` on the second step for a focused editing experience.
- **Layout**: Replaced multi-line `HtmlDisplayField` components with single-line `TextField`s in `CampaignStandardsModal.jsx` for a more compact layout.
- **Linter Errors**: Resolved multiple linter errors, including a `no-undef` typo in `DraggableElement.jsx` and a conditional hook call in `FieldPositioner.jsx`.