### PR TITLE
fix: Stabilize FieldPositioner and improve Author UX

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -210,7 +210,7 @@ const FieldPositioner = ({
     observer.observe(container);
 
     return () => observer.disconnect();
-  }, [onImageDisplayedSizeChange]);
+  }, [onImageDisplayedSizeChange, backgroundImage]);
 
   // Effect to initialize or update field positions and styles based on csvHeaders and props.
   // This ensures that every field in csvHeaders has a corresponding position and a complete style object.


### PR DESCRIPTION
This commit resolves a series of critical regressions in the `FieldPositioner` component and improves the user experience for editing Author details in the Campaign Standards modal.

**Bug Fixes:**
- **Field Resizing**: Fixed a persistent regression where resizing fields was either erratic or impossible. The root cause was identified as the `ResizeObserver` not being re-initialized correctly when the background image was loaded. The `useEffect` hook for the observer now correctly depends on the `backgroundImage` prop.
- **Disappearing Fields**: As a consequence of the above fix, the issue where fields would not appear at all has also been resolved. Draggable elements are now conditionally rendered only after their container size is known.
- **Linter Errors**: Corrected several linter errors in `FieldPositioner` and `DraggableElement`, including a conditional hook call and a variable name typo.

**UX Improvements:**
- **Author Editing**: Clicking the "Tipo de Organização" fields now opens the Author Wizard directly to the relevant editing step, restoring the intended workflow.
- **Layout**: Replaced multi-line display fields with compact, single-line `TextField`s in `CampaignStandardsModal.jsx` for a cleaner layout.