### PR TITLE
Fix: Alinhar botões de ação em telas menores

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -1006,7 +1006,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                 />
               ) : (
                 <Stack spacing={2}>
-                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mb: 2, alignItems: 'flex-start' }}>
+                  <Stack direction="row" spacing={1} sx={{ mb: 2, alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
                     <Button
                       variant="outlined"
                       startIcon={<AutoAwesomeIcon />}


### PR DESCRIPTION
- Ajusta o layout dos botões de ação ('Gerar com IA', 'Editar com Assistente', 'Começar de Novo') na aba 'Autor' para que permaneçam em uma única linha em todas as larguras de tela, com quebra de linha (wrap) em telas muito estreitas.
- Isso garante uma interface mais consistente e melhora a usabilidade em dispositivos com telas menores.