### PR TITLE
Fix: Alinhar botões de ação na aba Persona

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -669,11 +669,7 @@ Retorne apenas um único objeto JSON com estas chaves, sem texto adicional, mark
                 />
               ) : (
                 <>
-                  <Stack
-                    direction={{ xs: 'column', sm: 'row' }}
-                    spacing={2}
-                    sx={{ mb: 2, alignItems: 'flex-start' }}
-                  >
+                  <Stack direction="row" spacing={1} sx={{ mb: 2, alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
                     <Button
                       variant="outlined"
                       startIcon={<AutoAwesomeIcon />}


### PR DESCRIPTION
- Ajusta o layout dos botões de ação na aba 'Persona' para que se alinhem em uma única linha, com quebra de linha (wrap) em telas menores.
- Esta alteração torna a interface consistente com a da aba 'Autor' e melhora a usabilidade em dispositivos móveis.