### PR TITLE
fix: Use post title in scheduling spreadsheet

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -322,7 +322,7 @@ const Publisher = ({
                     formatDate(followupDate),
                     getScheduledTime(followupDate),
                     selectedProfile,
-                    post.tipo_gancho || '', // Usando tipo_gancho como título
+                    post.titulo || '', // Usando o título do post
                     post.conteudo || '',
                     post.cta || '',
                     post.hashtags_sugeridas?.map(h => h.startsWith('#') ? h : `#${h}`).join(' ') || '',


### PR DESCRIPTION
Updates the `handleScheduleLinkedIn` function in the `Publisher` component to use the `titulo` field of the follow-up post for the 'Título' column in the generated scheduling spreadsheet.

Previously, the `tipo_gancho` field was used by mistake. This change ensures the correct title is used in the exported CSV file for scheduling.