### PR TITLE
feat: Implement combined scheduler with 14:00 rule

### DIFF
--- a/api/db.json
+++ b/api/db.json
@@ -1,10 +1,10 @@
 {
   "posts": [
     {
-      "id": "4e29e78b-3d78-4eff-97c6-cdb9782ccb6f",
-      "createdAt": "2025-08-16T18:03:43.721Z",
+      "id": "a21dede5-9946-45e0-9fb6-9ecc2b9e73e5",
+      "createdAt": "2025-08-16T18:18:56.473Z",
       "status": "failed",
-      "scheduledAt": "2025-08-16T18:02:43.716Z",
+      "scheduledAt": "2025-08-16T14:00:00.000Z",
       "authorUrn": "urn:li:person:xCDEUBo-Mf",
       "content": {
         "titulo": "Test Post from Scheduler",
@@ -17,6 +17,7 @@
         ]
       },
       "accessToken": "AQXrKPbg-cEl8t2-AEofaYKl2BVkeBC8iDxDINFhjVd6OX0BVaiy2YZM_dfZfJBgl0AZkP-5pXUxFyKQ2uxDfMyTTDrPYVJTvXNVTy0ultakgs7pr1A7wLZIL9udMSIraulAfHCX6nmIcUFlhBDrClkP2FFy-1VB48ipM8yfMosMe97NFAllH3wir6AFmDR1jGpydEb6xINOQefgyQfSLlgIixfBvLiyfQEAZkBdYScGo0DyRyjcu0g-8qzLwgDGwzsXXv3R1h_5n4I69j3Ybw03U84qsIU4JS1uteUjZdz29rUJ1hDTadgYtvuFRHSFA73TI2yfkCnOFSukxmYteWSSSrSGEg",
+      "userSelectedTime": "2025-08-16T18:17:56.468Z",
       "error": "Unexpected end of JSON input"
     }
   ]

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -10,11 +10,17 @@ async function handleCreateSchedule(request, response) {
             return response.status(400).json({ error: 'Missing post data payload.' });
         }
 
+        const userSelectedScheduledAt = postData.scheduledAt;
+        const executionDate = new Date(userSelectedScheduledAt);
+        executionDate.setUTCHours(14, 0, 0, 0);
+
         const newPost = {
             id: crypto.randomUUID(),
             createdAt: new Date().toISOString(),
             status: 'scheduled',
             ...postData,
+            scheduledAt: executionDate.toISOString(),
+            userSelectedTime: userSelectedScheduledAt,
         };
 
         db.data.posts.push(newPost);

--- a/test_scheduler.js
+++ b/test_scheduler.js
@@ -128,6 +128,17 @@ async function runTest() {
         }
         console.log(`Post status is 'failed' as expected. Error: ${myPost.error}`);
 
+        // Verify the new time logic
+        console.log('Verifying scheduling time logic...');
+        const executionTime = new Date(myPost.scheduledAt);
+        if (executionTime.getUTCHours() !== 14 || executionTime.getUTCMinutes() !== 0) {
+            throw new Error(`Execution time was not 14:00 UTC. It was ${executionTime.toISOString()}`);
+        }
+        if (myPost.userSelectedTime !== scheduledAt) {
+            throw new Error('The original user-selected time was not preserved correctly.');
+        }
+        console.log('Scheduling time logic verified successfully. Execution time is 14:00 UTC.');
+
     } catch (error) {
         console.error(error);
         return;


### PR DESCRIPTION
This feature enhances the LinkedIn post scheduling functionality by combining the new automated, server-side scheduling with the original manual, Google Drive-based workflow.

A new business rule is implemented in the backend to set the execution time for all scheduled posts to 14:00 UTC, regardless of the time selected by the user. The user's original selection is preserved for reference.

When a user schedules a campaign:
1. The original process of uploading media to a Google Drive folder and creating a control spreadsheet is preserved.
2. The schedule information is sent to the `/api/schedule` endpoint and stored in a local JSON database.

A Vercel cron job, configured in `vercel.json`, triggers the backend scheduler every 5 minutes to publish due posts automatically.

The test suite has been updated to assert the new 14:00 execution time logic.