### PR TITLE
feat: Implement 'My Schedules' tab for viewing scheduled posts

### DIFF
--- a/api/db.json
+++ b/api/db.json
@@ -1,8 +1,8 @@
 {
   "posts": [
     {
-      "id": "a21dede5-9946-45e0-9fb6-9ecc2b9e73e5",
-      "createdAt": "2025-08-16T18:18:56.473Z",
+      "id": "1b2d32f8-aa89-424f-97e0-99dee6b7b6cf",
+      "createdAt": "2025-08-16T18:54:29.585Z",
       "status": "failed",
       "scheduledAt": "2025-08-16T14:00:00.000Z",
       "authorUrn": "urn:li:person:xCDEUBo-Mf",
@@ -17,8 +17,27 @@
         ]
       },
       "accessToken": "AQXrKPbg-cEl8t2-AEofaYKl2BVkeBC8iDxDINFhjVd6OX0BVaiy2YZM_dfZfJBgl0AZkP-5pXUxFyKQ2uxDfMyTTDrPYVJTvXNVTy0ultakgs7pr1A7wLZIL9udMSIraulAfHCX6nmIcUFlhBDrClkP2FFy-1VB48ipM8yfMosMe97NFAllH3wir6AFmDR1jGpydEb6xINOQefgyQfSLlgIixfBvLiyfQEAZkBdYScGo0DyRyjcu0g-8qzLwgDGwzsXXv3R1h_5n4I69j3Ybw03U84qsIU4JS1uteUjZdz29rUJ1hDTadgYtvuFRHSFA73TI2yfkCnOFSukxmYteWSSSrSGEg",
-      "userSelectedTime": "2025-08-16T18:17:56.468Z",
+      "userSelectedTime": "2025-08-16T18:53:29.583Z",
       "error": "Unexpected end of JSON input"
+    },
+    {
+      "id": "dd4c30f0-c730-43f9-9cfb-75832e6bdee7",
+      "createdAt": "2025-08-16T18:54:29.637Z",
+      "status": "scheduled",
+      "scheduledAt": "2025-08-16T14:00:00.000Z",
+      "authorUrn": "urn:li:person:anotherUser",
+      "content": {
+        "titulo": "Test Post from Scheduler",
+        "conteudo": "This is a test post generated automatically by the test script.",
+        "cta": "Check out the code!",
+        "hashtags": [
+          "#testing",
+          "#automation",
+          "#nodejs"
+        ]
+      },
+      "accessToken": "AQXrKPbg-cEl8t2-AEofaYKl2BVkeBC8iDxDINFhjVd6OX0BVaiy2YZM_dfZfJBgl0AZkP-5pXUxFyKQ2uxDfMyTTDrPYVJTvXNVTy0ultakgs7pr1A7wLZIL9udMSIraulAfHCX6nmIcUFlhBDrClkP2FFy-1VB48ipM8yfMosMe97NFAllH3wir6AFmDR1jGpydEb6xINOQefgyQfSLlgIixfBvLiyfQEAZkBdYScGo0DyRyjcu0g-8qzLwgDGwzsXXv3R1h_5n4I69j3Ybw03U84qsIU4JS1uteUjZdz29rUJ1hDTadgYtvuFRHSFA73TI2yfkCnOFSukxmYteWSSSrSGEg",
+      "userSelectedTime": "2025-08-16T18:53:29.583Z"
     }
   ]
 }

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -35,8 +35,16 @@ async function handleCreateSchedule(request, response) {
 
 async function handleGetSchedules(request, response) {
     try {
-        const posts = db.data.posts;
-        return response.status(200).json(posts);
+        const { authorUrn } = request.body.payload || {};
+
+        if (!authorUrn) {
+            // Return empty array if no user is specified, for security.
+            return response.status(200).json([]);
+        }
+
+        const userPosts = db.data.posts.filter(post => post.authorUrn === authorUrn);
+        return response.status(200).json(userPosts);
+
     } catch (error) {
         console.error('Error getting schedules:', error);
         return response.status(500).json({ error: 'Internal Server Error' });

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -34,11 +34,23 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { ptBR } from 'date-fns/locale/pt-BR';
 import TimeHeatMap from './TimeHeatMap';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  Tooltip,
+} from '@mui/material';
+import { Info } from '@mui/icons-material';
 import { publishToWordPress } from '../utils/wordpressAPI';
 import { publishToLinkedIn, getLinkedInProfiles } from '../utils/linkedinAPI';
 import { getLinkedinConfig } from '../utils/linkedinCredentials';
 import googleDriveAPI from '../utils/googleDriveAPI';
-import { createSchedule } from '../utils/scheduleAPI';
+import { createSchedule, getSchedulesForUser } from '../utils/scheduleAPI';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -80,10 +92,34 @@ const Publisher = ({
   setSelectedVideos
 }) => {
   const [tabValue, setTabValue] = React.useState(0);
+  const [mySchedules, setMySchedules] = useState([]);
+  const [isLoadingSchedules, setIsLoadingSchedules] = useState(false);
 
   const handleTabChange = (event, newValue) => {
     setTabValue(newValue);
   };
+
+  // Fetch schedules when the tab is opened or the selected profile changes
+  useEffect(() => {
+    const fetchSchedules = async () => {
+        if (tabValue === 2 && selectedProfile) { // Tab 2 is "My Schedules"
+            setIsLoadingSchedules(true);
+            try {
+                const schedules = await getSchedulesForUser(selectedProfile);
+                // Sort by most recent schedule first
+                schedules.sort((a, b) => new Date(b.scheduledAt) - new Date(a.scheduledAt));
+                setMySchedules(schedules);
+            } catch (error) {
+                console.error("Failed to fetch user schedules:", error);
+                // Optionally set an error state to show in the UI
+            } finally {
+                setIsLoadingSchedules(false);
+            }
+        }
+    };
+
+    fetchSchedules();
+  }, [tabValue, selectedProfile]);
 
   // State for WordPress
   const [isPublishingWp, setIsPublishingWp] = useState(false);
@@ -454,9 +490,10 @@ const Publisher = ({
         </Typography>
         <Box sx={{ width: '100%' }}>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs value={tabValue} onChange={handleTabChange} aria-label="basic tabs example">
+            <Tabs value={tabValue} onChange={handleTabChange} aria-label="publishing tabs">
               <Tab label="LinkedIn" />
               <Tab label="WordPress" />
+              <Tab label="Meus Agendamentos" />
             </Tabs>
           </Box>
           <TabPanel value={tabValue} index={0}>
@@ -708,6 +745,59 @@ const Publisher = ({
                   )}
                 </Alert>
               )}
+            </Box>
+          </TabPanel>
+          <TabPanel value={tabValue} index={2}>
+            <Box>
+                <Typography variant="h6" gutterBottom>Meus Agendamentos</Typography>
+                {!selectedProfile && <Alert severity="warning">Selecione um perfil na aba "LinkedIn" para ver seus agendamentos.</Alert>}
+                {isLoadingSchedules && <LinearProgress />}
+                {!isLoadingSchedules && mySchedules.length === 0 && selectedProfile && (
+                    <Typography sx={{mt: 2, textAlign: 'center'}}>Nenhum agendamento encontrado para este perfil.</Typography>
+                )}
+                {mySchedules.length > 0 && (
+                    <TableContainer component={Paper} sx={{mt: 2}}>
+                        <Table sx={{ minWidth: 650 }} aria-label="simple table">
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>Título</TableCell>
+                                    <TableCell align="right">Data Agendada (UTC)</TableCell>
+                                    <TableCell align="right">Status</TableCell>
+                                    <TableCell align="right">Link</TableCell>
+                                </TableRow>
+                            </TableHead>
+                            <TableBody>
+                                {mySchedules.map((row) => (
+                                    <TableRow key={row.id}>
+                                        <TableCell component="th" scope="row">
+                                            {row.content.titulo}
+                                        </TableCell>
+                                        <TableCell align="right">{new Date(row.scheduledAt).toLocaleString('pt-BR', { timeZone: 'UTC' })}</TableCell>
+                                        <TableCell align="right">
+                                            <Chip
+                                                label={row.status}
+                                                color={row.status === 'published' ? 'success' : (row.status === 'failed' ? 'error' : 'primary')}
+                                                size="small"
+                                            />
+                                            {row.status === 'failed' && row.error && (
+                                                <Tooltip title={row.error}>
+                                                    <Info fontSize="small" sx={{verticalAlign: 'middle', ml: 0.5, color: 'error.main'}}/>
+                                                </Tooltip>
+                                            )}
+                                        </TableCell>
+                                        <TableCell align="right">
+                                            {row.status === 'published' && row.postId ? (
+                                                <MuiLink href={`https://www.linkedin.com/feed/update/${row.postId}/`} target="_blank" rel="noopener">
+                                                    Ver Post
+                                                </MuiLink>
+                                            ) : '-'}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                )}
             </Box>
           </TabPanel>
         </Box>

--- a/src/utils/scheduleAPI.js
+++ b/src/utils/scheduleAPI.js
@@ -15,3 +15,23 @@ export const createSchedule = async (scheduleData) => {
 
     return await response.json();
 };
+
+export const getSchedulesForUser = async (authorUrn) => {
+    if (!authorUrn) return []; // Don't bother making a request if there's no user.
+
+    const response = await fetch('/api/schedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            action: 'getSchedules',
+            payload: { authorUrn },
+        }),
+    });
+
+    if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: 'Proxy response was not valid JSON.' }));
+        throw new Error(`Failed to get schedules via proxy: ${errorData.message || 'Unknown error'}`);
+    }
+
+    return await response.json();
+};

--- a/test_scheduler.js
+++ b/test_scheduler.js
@@ -110,7 +110,7 @@ async function runTest() {
     // 4. Verify post status
     try {
         console.log('\nStep 3: Verifying post status...');
-        const req = createMockRequest({ action: 'getSchedules' });
+        const req = createMockRequest({ action: 'getSchedules', payload: { authorUrn } });
         const res = createMockResponse();
 
         await handleGetSchedulesForTest(req, res);
@@ -146,6 +146,49 @@ async function runTest() {
 
     console.log('\n--- Test Completed Successfully (with expected failure) ---');
     console.log('The test successfully verified the scheduling and scheduler run logic. The final "failed" status is expected because the test sandbox prevents the scheduler from calling the live LinkedIn proxy.');
+
+    console.log('\nStep 4: Verifying user filtering...');
+    try {
+        // Schedule a post for another user
+        const anotherAuthorUrn = 'urn:li:person:anotherUser';
+        const anotherSchedulePayload = { ...schedulePayload, authorUrn: anotherAuthorUrn };
+        const req1 = createMockRequest({ action: 'createSchedule', payload: anotherSchedulePayload });
+        const res1 = createMockResponse();
+        await handleCreateScheduleForTest(req1, res1);
+
+        // Get schedules for the first user
+        const req2 = createMockRequest({ action: 'getSchedules', payload: { authorUrn } });
+        const res2 = createMockResponse();
+        await handleGetSchedulesForTest(req2, res2);
+        if (res2.body.length !== 1 || res2.body[0].id !== postId) {
+            throw new Error(`Filtering failed for the first user. Expected 1 post, got ${res2.body.length}`);
+        }
+        console.log('Successfully fetched schedules for the first user.');
+
+        // Get schedules for the second user
+        const req3 = createMockRequest({ action: 'getSchedules', payload: { authorUrn: anotherAuthorUrn } });
+        const res3 = createMockResponse();
+        await handleGetSchedulesForTest(req3, res3);
+        if (res3.body.length !== 1) {
+            throw new Error(`Filtering failed for the second user. Expected 1 post, got ${res3.body.length}`);
+        }
+        console.log('Successfully fetched schedules for the second user.');
+
+        // Get schedules with no user
+        const req4 = createMockRequest({ action: 'getSchedules', payload: {} });
+        const res4 = createMockResponse();
+        await handleGetSchedulesForTest(req4, res4);
+        if (res4.body.length !== 0) {
+            throw new Error(`Security check failed. Expected 0 posts for empty user, got ${res4.body.length}`);
+        }
+        console.log('Security check passed: empty user returns empty array.');
+
+        console.log('User filtering verified successfully.');
+
+    } catch (error) {
+        console.error('Error during user filtering verification:', error);
+        return;
+    }
 }
 
 runTest();


### PR DESCRIPTION
This feature introduces a new UI component that allows users to view the status of their scheduled posts directly within the application.

A new "Meus Agendamentos" tab has been added to the Publish screen. This tab contains a table that lists all posts scheduled by the currently selected LinkedIn profile. The table displays the post title, scheduled time, and status (scheduled, published, or failed).

To support this, the `getSchedules` action in the `/api/schedule` endpoint has been modified to securely filter posts by the user's `authorUrn`. The test suite has been updated to validate this new filtering logic.