### PR TITLE
fix: adjust cron schedule for Vercel Hobby plan

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/schedule",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 14 * * *"
     }
   ]
 }


### PR DESCRIPTION
Changes the cron job schedule in `vercel.json` from every 5 minutes to once daily at 14:00 UTC. This makes the configuration compliant with the Vercel Hobby plan, which limits cron jobs to one run per day.

The new schedule still meets the feature's requirements, as the backend logic is already set to schedule all posts for 14:00 UTC.