### PR TITLE
fix: remove duplicate import in Publisher component

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -41,7 +41,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Paper,
   Chip,
   Tooltip,
 } from '@mui/material';


### PR DESCRIPTION
Resolves a build failure caused by the `Paper` component being imported twice from `@mui/material` in `Publisher.jsx`.