### PR TITLE
feat: Display full stack trace in ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -21,6 +21,8 @@ class ErrorBoundary extends React.Component {
           <h1>Something went wrong.</h1>
           <details style={{ whiteSpace: 'pre-wrap' }}>
             {this.state.error && this.state.error.toString()}
+            <br />
+            <pre>{this.state.error && this.state.error.stack}</pre>
           </details>
         </div>
       );


### PR DESCRIPTION
The ErrorBoundary component has been updated to display not just the error message, but the full stack trace of a captured error.

This is a debugging measure to help diagnose a persistent client-side error. By rendering the `error.stack` property within a `<pre>` tag, the full trace will be available directly on the error screen, which will allow for easier and more accurate debugging.