### PR TITLE
fix: Resolve infinite loop in AI suggestion modals

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Card,
   CardContent,
@@ -213,7 +213,7 @@ const Campaign = ({
       setActiveTab(newValue);
     };
 
-    const handleGenerateProblems = async () => {
+    const handleGenerateProblems = useCallback(async () => {
         if (commonProblems.length > 0) return;
         setIsLoadingProblems(true);
         setProblemsError(null);
@@ -230,7 +230,7 @@ const Campaign = ({
         } finally {
             setIsLoadingProblems(false);
         }
-    };
+    }, [commonProblems.length]);
 
     useEffect(() => {
         if (isHintModalOpen) {
@@ -238,7 +238,7 @@ const Campaign = ({
         }
     }, [isHintModalOpen, handleGenerateProblems]);
 
-    const handleGenerateSolutions = async () => {
+    const handleGenerateSolutions = useCallback(async () => {
         if (commonSolutions.length > 0) return;
         setIsLoadingSolutions(true);
         setSolutionsError(null);
@@ -255,7 +255,7 @@ const Campaign = ({
         } finally {
             setIsLoadingSolutions(false);
         }
-    };
+    }, [commonSolutions.length, problema]);
 
     useEffect(() => {
         if (isSolucaoHintModalOpen) {


### PR DESCRIPTION
This commit fixes a bug that caused an infinite loop when opening the AI suggestion modals for "Problema" and "Solução". The `handleGenerateProblems` and `handleGenerateSolutions` functions were being recreated on every render, causing the `useEffect` hooks to re-trigger API calls indefinitely.

The fix involves wrapping these two functions in `useCallback` to memoize them. This prevents them from being recreated on every render, thus breaking the loop.