### PR TITLE
fix: Display scheduled time in user's local timezone

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -800,7 +800,7 @@ const Publisher = ({
                                         <TableCell component="th" scope="row">
                                             {row.content.titulo}
                                         </TableCell>
-                                        <TableCell align="right">{new Date(row.scheduledAt).toLocaleString('pt-BR', { timeZone: 'UTC' })}</TableCell>
+                                        <TableCell align="right">{new Date(row.scheduledAt).toLocaleString('pt-BR')}</TableCell>
                                         <TableCell align="right">
                                             <Chip
                                                 label={row.status}


### PR DESCRIPTION
This commit fixes a bug where the scheduled time for a post was always displayed in UTC, causing confusion for users in different timezones. The `{ timeZone: 'UTC' }` option has been removed from the `toLocaleString()` call in the "Meus Agendamentos" table. This allows the browser to format the date and time using the user's local timezone, which is the expected behavior.