### PR TITLE
fix: Ensure WordPress URL is saved correctly

### DIFF
--- a/src/utils/credentialsManager.js
+++ b/src/utils/credentialsManager.js
@@ -41,7 +41,7 @@ export const gatherCredentials = () => {
 
   // WordPress
   const wordpress = getWordpressConfig();
-  if (wordpress && wordpress.url) credentials[CREDENTIAL_KEYS.WORDPRESS] = wordpress;
+  if (wordpress && wordpress.wordpressUrl) credentials[CREDENTIAL_KEYS.WORDPRESS] = wordpress;
 
   return credentials;
 };


### PR DESCRIPTION
This commit fixes a bug where the WordPress URL was not being saved to the database. The `gatherCredentials` function in `credentialsManager.js` was checking for the property `wordpress.url`, but the actual property name in the configuration object is `wordpress.wordpressUrl`.

This commit corrects the property name in the check, ensuring that the WordPress configuration is included when settings are gathered and saved to the database.