### PR TITLE
fix: Ensure followup quantity field is always controlled

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -546,7 +546,7 @@ const Campaign = ({
                                 <TextField
                                     label="Quantidade de Posts de Follow-up"
                                     type="number"
-                                    value={followupPostsQuantity}
+                                    value={followupPostsQuantity || ''}
                                     onChange={(e) => setFollowupPostsQuantity(parseInt(e.target.value, 10))}
                                     fullWidth
                                     variant="outlined"


### PR DESCRIPTION
This commit fixes an issue where the "Quantidade de Posts de Follow-Up" text field could appear empty. By changing the `value` prop to `value={followupPostsQuantity || ''}`, we ensure that the `TextField` is always a controlled component, even if the state value is `null` or `undefined`. This prevents unexpected visual behavior and ensures the default value is displayed correctly.