### PR TITLE
feat: Implement Vercel Blob storage to fix 'Content Too Large' error

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,0 +1,23 @@
+import { put } from '@vercel/blob';
+import { withAuth } from './middleware/auth.js';
+
+const handler = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  try {
+    const filename = req.headers['x-vercel-filename'] || 'file';
+    const blob = await put(filename, req.body, {
+      access: 'public',
+    });
+
+    return res.status(200).json(blob);
+  } catch (error) {
+    console.error('[API/UPLOAD] Error uploading file:', error);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export default withAuth(handler);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@uppy/core": "^4.4.7",
     "@uppy/react": "^4.4.0",
     "@uppy/screen-capture": "^4.3.1",
+    "@vercel/blob": "^1.1.1",
     "bcryptjs": "^3.0.2",
     "chroma-js": "^3.1.2",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@uppy/screen-capture':
         specifier: ^4.3.1
         version: 4.4.2(@uppy/core@4.5.2)
+      '@vercel/blob':
+        specifier: ^1.1.1
+        version: 1.1.1
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
@@ -495,6 +498,10 @@ packages:
   '@eslint/js@9.32.0':
     resolution: {integrity: sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@ffmpeg/core@0.12.10':
     resolution: {integrity: sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA==}
@@ -1292,6 +1299,10 @@ packages:
     peerDependencies:
       '@uppy/core': ^4.5.2
 
+  '@vercel/blob@1.1.1':
+    resolution: {integrity: sha512-heiJGj2qt5qTv6yiShH9f6KRAoZGj+lz61GQ+lBRL4lhvUmKI9A51KYlQTnsUd9ymdFlKHBlvmPeG+yGz2Qsbg==}
+    engines: {node: '>=16.14'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1365,6 +1376,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1980,6 +1994,10 @@ packages:
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -2026,6 +2044,9 @@ packages:
   is-network-error@1.1.0:
     resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
     engines: {node: '>=16'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2775,6 +2796,10 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2813,6 +2838,10 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
 
   uniq@1.0.1:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
@@ -3258,6 +3287,8 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.32.0': {}
+
+  '@fastify/busboy@2.1.1': {}
 
   '@ffmpeg/core@0.12.10': {}
 
@@ -4003,6 +4034,14 @@ snapshots:
       '@uppy/utils': 6.2.2
       preact: 10.27.0
 
+  '@vercel/blob@1.1.1':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 5.29.0
+
   '@vitejs/plugin-react@4.7.0(vite@5.4.19)':
     dependencies:
       '@babel/core': 7.28.0
@@ -4104,6 +4143,10 @@ snapshots:
       is-array-buffer: 3.0.5
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -4893,6 +4936,8 @@ snapshots:
 
   is-buffer@1.1.6: {}
 
+  is-buffer@2.0.5: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
@@ -4934,6 +4979,8 @@ snapshots:
   is-negative-zero@2.0.3: {}
 
   is-network-error@1.1.0: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -5764,6 +5811,8 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  throttleit@2.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5820,6 +5869,10 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   uniq@1.0.1: {}
 

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -1,95 +1,105 @@
 // This file now handles the logic for serializing, deserializing,
 // and communicating with the campaign API endpoints.
 
-// Helper to convert Blob to Base64
-const blobToBase64 = (blob) => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result);
-    reader.onerror = reject;
-    reader.readAsDataURL(blob);
-  });
-};
+// Helper to upload a file (Blob, Data URL, or Blob URL) to Vercel Blob
+const uploadFile = async (fileData, filenamePrefix = 'file') => {
+  // If fileData is null, or already a Vercel Blob URL, do nothing.
+  if (!fileData || (typeof fileData === 'string' && fileData.includes('.public.blob.vercel-storage.com'))) {
+    return fileData;
+  }
 
-// Helper to convert Base64 back to Blob
-const base64ToBlob = async (base64) => {
-  if (!base64) return null;
-  const fetchString = base64.startsWith('data:') ? base64 : `data:application/octet-stream;base64,${base64}`;
+  let blob;
+  // A more robust filename to avoid collisions.
+  const filename = `${filenamePrefix}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
   try {
-    const res = await fetch(fetchString);
-    return res.blob();
+    if (typeof fileData === 'string' && (fileData.startsWith('data:') || fileData.startsWith('blob:'))) {
+      const response = await fetch(fileData);
+      blob = await response.blob();
+    } else if (fileData instanceof Blob) {
+      blob = fileData;
+    } else {
+      // If the type is not supported for upload, return the original data.
+      // This might be the case for non-file string data.
+      return fileData;
+    }
+
+    const response = await fetch('/api/upload', {
+      method: 'POST',
+      headers: { 'x-vercel-filename': filename },
+      body: blob,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({ error: 'Upload failed with no error body.' }));
+      throw new Error(`Failed to upload file: ${errorBody.error}`);
+    }
+
+    const newBlob = await response.json();
+    return newBlob.url;
   } catch (error) {
-    console.error("Error converting base64 to blob:", error);
-    return null;
+    console.error(`Error uploading file with prefix ${filenamePrefix}:`, error);
+    // Return original data to not break the app state if upload fails
+    return fileData;
   }
 };
+
 
 /**
  * Gathers and serializes the current application state for saving.
- * Blobs are converted to Base64 strings.
+ * Local files (blobs, data URLs) are uploaded to Vercel Blob.
  * @param {object} state - The current application state from HomePage.
- * @returns {Promise<object>} A promise that resolves to a serializable object.
+ * @returns {Promise<object>} A promise that resolves to a serializable object with public URLs.
  */
 export const serializeCampaignData = async (state) => {
-  const serializableGeneratedImages = await Promise.all(
-    (state.generatedImagesData || []).map(async (img) => {
-      const imageBase64 = img.blob ? await blobToBase64(img.blob) : null;
-      return { ...img, blob: undefined, url: undefined, imageBase64 };
+  // Process single image URLs
+  const generatedImageUrl = await uploadFile(state.generatedImageUrl, 'campaign-image');
+  const backgroundImage = await uploadFile(state.backgroundImage, 'background-image');
+
+  // Process arrays of media data
+  const generatedImagesData = await Promise.all(
+    (state.generatedImagesData || []).map(async (img, index) => {
+      const fileToUpload = img.url || (img.blob ? URL.createObjectURL(img.blob) : null);
+      const newUrl = await uploadFile(fileToUpload, `gen-img-${index}`);
+      return { ...img, url: newUrl, blob: undefined, imageBase64: undefined };
     })
   );
-  const serializableGeneratedAudio = await Promise.all(
-    (state.generatedAudioData || []).map(async (audio) => {
-      const audioBase64 = audio.blob ? await blobToBase64(audio.blob) : null;
-      return { ...audio, blob: undefined, audioBase64 };
+
+  const generatedAudioData = await Promise.all(
+    (state.generatedAudioData || []).map(async (audio, index) => {
+        const newUrl = await uploadFile(audio.blob, `gen-audio-${index}`);
+        return { ...audio, url: newUrl, blob: undefined, audioBase64: undefined };
     })
   );
-  const serializableGeneratedVideos = await Promise.all(
-    (state.generatedVideosData || []).map(async (video) => {
-      const videoBase64 = video.blob ? await blobToBase64(video.blob) : null;
-      return { ...video, blob: undefined, url: undefined, videoBase64 };
+
+  const generatedVideosData = await Promise.all(
+    (state.generatedVideosData || []).map(async (video, index) => {
+      const fileToUpload = video.url || (video.blob ? URL.createObjectURL(video.blob) : null);
+      const newUrl = await uploadFile(fileToUpload, `gen-video-${index}`);
+      return { ...video, url: newUrl, blob: undefined, videoBase64: undefined };
     })
   );
-  const serializableBrandElements = await Promise.all(
+
+  const brandElements = await Promise.all(
     (state.brandElements || []).map(async (el) => {
-      if (el.url && el.url.startsWith('blob:')) {
-        const response = await fetch(el.url);
-        const blob = await response.blob();
-        const urlBase64 = await blobToBase64(blob);
-        return { ...el, url: undefined, urlBase64 };
-      }
-      return el;
+      const newUrl = await uploadFile(el.url, `brand-el-${el.id}`);
+      return { ...el, url: newUrl, urlBase64: undefined };
     })
   );
-  let backgroundImageBase64 = null;
-  if (state.backgroundImageUrl && state.backgroundImageUrl.startsWith('blob:')) {
-    const response = await fetch(state.backgroundImageUrl);
-    const blob = await response.blob();
-    backgroundImageBase64 = await blobToBase64(blob);
-  } else {
-    backgroundImageBase64 = state.backgroundImageUrl;
-  }
-  let generatedImageBase64 = null;
-  if (state.generatedImageUrl && state.generatedImageUrl.startsWith('blob:')) {
-    const response = await fetch(state.generatedImageUrl);
-    const blob = await response.blob();
-    generatedImageBase64 = await blobToBase64(blob);
-  } else {
-    generatedImageBase64 = state.generatedImageUrl;
-  }
 
   const stateToSave = {
     ...state,
-    generatedImagesData: serializableGeneratedImages,
-    generatedAudioData: serializableGeneratedAudio,
-    generatedVideosData: serializableGeneratedVideos,
-    brandElements: serializableBrandElements,
-    backgroundImageUrl: undefined,
-    backgroundImageBase64: backgroundImageBase64,
-    generatedImageUrl: undefined,
-    generatedImageBase64: generatedImageBase64,
+    generatedImageUrl,
+    backgroundImage,
+    generatedImagesData,
+    generatedAudioData,
+    generatedVideosData,
+    brandElements,
   };
 
-  // Remove props that shouldn't be persisted
+  // Clean up properties that are no longer needed or should not be persisted
+  delete stateToSave.backgroundImageBase64;
+  delete stateToSave.generatedImageBase64;
   delete stateToSave.isSaving;
   delete stateToSave.isLoading;
   delete stateToSave.user;
@@ -98,54 +108,15 @@ export const serializeCampaignData = async (state) => {
 };
 
 /**
- * Takes a loaded campaign state and deserializes it for the application.
+ * Takes a loaded campaign state and prepares it for the application.
+ * The new data format is much simpler, as URLs point directly to Vercel Blob.
  * @param {object} loadedState - The state object loaded from the database.
- * @returns {Promise<object>} The deserialized state ready for the application.
+ * @returns {Promise<object>} The state ready for the application.
  */
 export const deserializeCampaignData = async (loadedState) => {
-  if (loadedState.backgroundImageBase64) {
-    const blob = await base64ToBlob(loadedState.backgroundImageBase64);
-    if (blob) loadedState.backgroundImageUrl = URL.createObjectURL(blob);
-  }
-  if (loadedState.generatedImageBase64) {
-    const blob = await base64ToBlob(loadedState.generatedImageBase64);
-    if (blob) loadedState.generatedImageUrl = URL.createObjectURL(blob);
-  }
-  if (loadedState.generatedImagesData) {
-    loadedState.generatedImagesData = await Promise.all(
-      (loadedState.generatedImagesData || []).map(async (imgData) => {
-        const blob = await base64ToBlob(imgData.imageBase64);
-        return { ...imgData, blob, url: blob ? URL.createObjectURL(blob) : null, imageBase64: undefined };
-      })
-    );
-  }
-  if (loadedState.generatedAudioData) {
-    loadedState.generatedAudioData = await Promise.all(
-      (loadedState.generatedAudioData || []).map(async (audioData) => {
-        const blob = await base64ToBlob(audioData.audioBase64);
-        return { ...audioData, blob, audioBase64: undefined };
-      })
-    );
-  }
-  if (loadedState.generatedVideosData) {
-    loadedState.generatedVideosData = await Promise.all(
-      (loadedState.generatedVideosData || []).map(async (videoData) => {
-        const blob = await base64ToBlob(videoData.videoBase64);
-        return { ...videoData, blob, url: blob ? URL.createObjectURL(blob) : null, videoBase64: undefined };
-      })
-    );
-  }
-  if (loadedState.brandElements) {
-    loadedState.brandElements = await Promise.all(
-      (loadedState.brandElements || []).map(async (el) => {
-        if (el.urlBase64) {
-          const blob = await base64ToBlob(el.urlBase64);
-          if (blob) return { ...el, url: URL.createObjectURL(blob), urlBase64: undefined };
-        }
-        return el;
-      })
-    );
-  }
+  // No complex conversions are needed for the new data format.
+  // The URLs in the loaded state are the public Vercel Blob URLs.
+  // This function now mainly serves to ensure a clean state object and for any future transformations.
   return loadedState;
 };
 
@@ -192,8 +163,14 @@ export const updateCampaign = async (id, name, campaignState) => {
     body: JSON.stringify({ name, campaign_data: serializableData }),
   });
   if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(err.error || 'Failed to update campaign.');
+    const errText = await res.text();
+    console.error("Update campaign failed with status:", res.status, "and body:", errText);
+    try {
+        const err = JSON.parse(errText);
+        throw new Error(err.error || 'Failed to update campaign.');
+    } catch(e) {
+        throw new Error(`Failed to update campaign. Server responded with: ${errText}`);
+    }
   }
   return res.json();
 };


### PR DESCRIPTION
- Replaced base64 file encoding with Vercel Blob storage to prevent 'Content Too Large' errors when saving campaigns.
- Added a new `/api/upload` endpoint to handle file uploads to Vercel Blob.
- Updated campaign serialization to upload media and store URLs instead of file data.
- Simplified campaign deserialization to use direct media URLs.