### PR TITLE
fix: Improve error handling for file uploads

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -39,8 +39,8 @@ const uploadFile = async (fileData, filenamePrefix = 'file') => {
     return newBlob.url;
   } catch (error) {
     console.error(`Error uploading file with prefix ${filenamePrefix}:`, error);
-    // Return original data to not break the app state if upload fails
-    return fileData;
+    // Re-throw the error so the calling function can handle it and show a toast.
+    throw new Error(`Falha no upload do arquivo: ${error.message}. Verifique se um Blob Store está conectado ao projeto no Vercel.`);
   }
 };
 


### PR DESCRIPTION
- Updated the `uploadFile` helper in `src/utils/campaignState.js` to re-throw an error when the `/api/upload` endpoint fails.
- This ensures that the UI catches the error and displays a descriptive toast message to the user, rather than failing silently and causing a subsequent '413 Content Too Large' error.