### PR TITLE
fix: Use deep imports for date-fns-tz to resolve build and runtime er…

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -32,7 +32,9 @@ import { Language, Publish, LinkedIn } from '@mui/icons-material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import * as dateFnsTz from 'date-fns-tz';
+import { zonedTimeToUtc } from 'date-fns-tz/zonedTimeToUtc';
+import { utcToZonedTime } from 'date-fns-tz/utcToZonedTime';
+import { format } from 'date-fns-tz/format';
 import { ptBR } from 'date-fns/locale/pt-BR';
 import TimeHeatMap from './TimeHeatMap';
 import {
@@ -184,12 +186,12 @@ const Publisher = ({
       const postDate = new Date(scheduleDate);
       postDate.setDate(postDate.getDate() + index + 1);
 
-      const zonedDate = dateFnsTz.utcToZonedTime(postDate, userTimezone);
+      const zonedDate = utcToZonedTime(postDate, userTimezone);
 
       return {
         key: `followup-${index}`,
-        date: dateFnsTz.format(zonedDate, 'dd/MM/yyyy', { timeZone: userTimezone }),
-        day: dateFnsTz.format(zonedDate, 'EEE', { timeZone: userTimezone, locale: ptBR }),
+        date: format(zonedDate, 'dd/MM/yyyy', { timeZone: userTimezone }),
+        day: format(zonedDate, 'EEE', { timeZone: userTimezone, locale: ptBR }),
         time: getScheduledTime(postDate),
         title: post.tipo_gancho || `Follow-up ${index + 1}`
       };
@@ -369,7 +371,7 @@ const Publisher = ({
         };
 
         const formatDateInTimezone = (date, tz) => {
-            return dateFnsTz.format(dateFnsTz.utcToZonedTime(date, tz), 'dd/MM/yyyy', { timeZone: tz });
+            return format(utcToZonedTime(date, tz), 'dd/MM/yyyy', { timeZone: tz });
         }
 
         const mainPostRow = [
@@ -426,7 +428,7 @@ const Publisher = ({
         mainPostDate.setHours(parseInt(hours, 10), parseInt(minutes, 10), 0, 0);
 
         // Convert the combined date from the user's configured timezone to UTC
-        const scheduledAtUtc = dateFnsTz.zonedTimeToUtc(mainPostDate, userTimezone);
+        const scheduledAtUtc = zonedTimeToUtc(mainPostDate, userTimezone);
 
         const mainPostSchedule = {
             scheduledAt: scheduledAtUtc.toISOString(),
@@ -446,7 +448,7 @@ const Publisher = ({
                 const [fHours, fMinutes] = getScheduledTime(followupDate).split(':');
                 followupDate.setHours(parseInt(fHours, 10), parseInt(fMinutes, 10), 0, 0);
 
-                const followupScheduledAtUtc = dateFnsTz.zonedTimeToUtc(followupDate, userTimezone);
+                const followupScheduledAtUtc = zonedTimeToUtc(followupDate, userTimezone);
 
                 const followupSchedule = {
                     scheduledAt: followupScheduledAtUtc.toISOString(),
@@ -819,7 +821,7 @@ const Publisher = ({
                                             {row.content.titulo}
                                         </TableCell>
                                         <TableCell align="right">
-                                            {dateFnsTz.format(dateFnsTz.utcToZonedTime(new Date(row.scheduledAt), userTimezone), 'dd/MM/yyyy HH:mm', { timeZone: userTimezone, locale: ptBR })}
+                                            {format(utcToZonedTime(new Date(row.scheduledAt), userTimezone), 'dd/MM/yyyy HH:mm', { timeZone: userTimezone, locale: ptBR })}
                                         </TableCell>
                                         <TableCell align="right">
                                             <Chip


### PR DESCRIPTION
…rors

- Replaces the namespace import `import * as dateFnsTz` with direct, deep imports for `zonedTimeToUtc`, `utcToZonedTime`, and `format`.
- This resolves both the initial build error ('is not exported') and the subsequent runtime error ('(void 0) is not a function').
- This import style is more robust and ensures the bundler can correctly resolve the functions.