### PR TITLE
fix(campaignState): Lida corretamente com URLs de dados base64 no upl…

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -8,16 +8,20 @@ const uploadAsset = async (asset, filename) => {
   if (!asset) return null;
 
   let fileToUpload;
-  if (typeof asset === 'string' && asset.startsWith('blob:')) {
+  if (typeof asset === 'string' && (asset.startsWith('blob:') || asset.startsWith('data:'))) {
     const response = await fetch(asset);
     const blob = await response.blob();
     fileToUpload = new File([blob], filename, { type: blob.type });
   } else if (asset instanceof Blob) {
     fileToUpload = asset;
-  } else if (typeof asset === 'string') {
-    // It's likely already a URL, so we don't need to re-upload.
+  } else if (typeof asset === 'string' && asset.startsWith('http')) {
+    // It's likely already a public URL, so we don't need to re-upload.
     return asset;
-  } else {
+  } else if (typeof asset === 'string') {
+    // Could be an invalid string or something else, treat as non-uploadable
+    return asset;
+  }
+   else {
     // Unsupported asset type
     return null;
   }


### PR DESCRIPTION
…oad de ativos

- Modifica a função `uploadAsset` em `src/utils/campaignState.js` para identificar e processar corretamente as strings de URL de dados (por exemplo, `data:image/png;base64,...`).
- Antes, essas strings eram tratadas como URLs públicas e não eram enviadas para o Vercel Blob, fazendo com que os dados em Base64 fossem salvos no banco de dados.
- Esta correção garante que os dados em Base64 sejam convertidos em um blob e enviados, resolvendo o bug e garantindo que apenas as URLs do Vercel Blob sejam armazenadas.