### PR TITLE
fix(api): Corrige a sintaxe do comando kv.zadd na atualização de agen…

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -126,8 +126,8 @@ async function handleUpdateSchedule(request, response) {
         // Update the post in KV
         await kv.set(`post:${id}`, JSON.stringify(post));
 
-        // zadd with the same member updates the score, so this is correct.
-        await kv.zadd('schedules_by_time', { score: newExecutionTimestamp, member: id });
+        // zadd with the same member updates the score. The correct syntax is (key, score, member).
+        await kv.zadd('schedules_by_time', newExecutionTimestamp, id);
 
         return response.status(200).json(post);
     } catch (error) {


### PR DESCRIPTION
…damento

- Altera a chamada `kv.zadd` na função `handleUpdateSchedule` em `api/schedule.js` para usar a sintaxe de argumento correta (`key, score, member`).
- A sintaxe incorreta anterior, que usava um objeto `{ score, member }`, estava causando um erro 500 no servidor ao tentar atualizar um agendamento.
- Esta correção resolve o erro e permite que a edição de agendamentos funcione como esperado.