### PR TITLE
feat: Atualiza a frequência do cron job do agendador

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/schedule",
-      "schedule": "0 14 * * *"
+      "schedule": "0 8-23 * * *"
     }
   ]
 }


### PR DESCRIPTION
- Modifica a expressão cron em `vercel.json` de `0 14 * * *` para `0 8-23 * * *`.
- Isso altera o agendador para rodar de hora em hora, todos os dias, entre 8:00 e 23:00 UTC, em vez de apenas uma vez por dia às 14:00 UTC.