### PR TITLE
fix(publisher): Corrige o cabeçalho da tabela de agendamentos

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -830,7 +830,7 @@ const Publisher = ({
                             <TableHead>
                                 <TableRow>
                                     <TableCell>Título</TableCell>
-                                    <TableCell align="right">Data Agendada (UTC)</TableCell>
+                                    <TableCell align="right">Data Agendada</TableCell>
                                     <TableCell align="right">Status</TableCell>
                                     <TableCell align="right">Link</TableCell>
                                     <TableCell align="right">Ações</TableCell>


### PR DESCRIPTION
- Altera o texto do cabeçalho da coluna de 'Data Agendada (UTC)' para 'Data Agendada'.
- A data já estava sendo exibida na timezone local do usuário, então o cabeçalho estava incorreto e causava confusão.