### PR TITLE
fix: Resolve TypeError when selecting a field for editing

### DIFF
--- a/jules-scratch/verification/verify_field_selection_fix.py
+++ b/jules-scratch/verification/verify_field_selection_fix.py
@@ -1,0 +1,43 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch()
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        page.goto("http://localhost:5173/")
+        page.wait_for_timeout(5000)
+
+        # Step 1: Fill campaign details and generate
+        page.fill("text=Problema ou Necessidade", "My problem")
+        page.fill("text=Solução ou Proposta", "My solution")
+        page.click("text=Elaborar Postagens")
+        page.wait_for_selector("text=Conteúdo Principal")
+
+        # Go to the next step (Posts Curtos)
+        page.click("text=Próximo")
+
+        # Go to the next step (Imagem e Formatação)
+        page.click("text=Próximo")
+
+        # Upload an image
+        with page.expect_file_chooser() as fc_info:
+            page.click("text=Selecionar Imagem")
+        file_chooser = fc_info.value
+        file_chooser.set_files("assets/dummy_image.png")
+
+        # Wait for the image to be loaded and the FieldPositioner to be visible
+        page.wait_for_selector("text=Posicionar e Formatar")
+
+        # Click on a field to select it
+        page.click(".text-box") # This is a guess, I may need to adjust the selector
+
+        # Take a screenshot to verify that the formatting panel appears correctly
+        page.screenshot(path="jules-scratch/verification/01_field_selected.png")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Card,
   CardContent,
@@ -42,9 +42,9 @@ const ImageStep = ({
   setBrandElements,
   onZIndexChange,
   isMobile,
+  selectedField,
+  setSelectedField,
 }) => {
-  const [selectedField, setSelectedField] = useState(null);
-
   if (!backgroundImage) {
     return (
       <Card>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -324,6 +324,8 @@ function HomePage() {
               setBrandElements={setBrandElements}
               onZIndexChange={handleZIndexChange}
               isMobile={isMobile}
+              selectedField={selectedField}
+              setSelectedField={setSelectedField}
             />
           </div>
           <div hidden={activeStep !== 3}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} /></div>


### PR DESCRIPTION
This commit fixes a `TypeError: m is not a function` error that occurred when a user selected a text field for editing after uploading a background image.

The root cause was a state management conflict. The `ImageStep` component had its own local `selectedField` state, which was not synchronized with the parent `HomePage` component. This was especially problematic on mobile, where the `FormattingDrawer` relied on the state from `HomePage`.

The fix involves lifting the `selectedField` state up from `ImageStep` to `HomePage`, establishing a single source of truth. The state and its updater function are now passed down through props, ensuring all components are synchronized.