### PR TITLE
fix: Prevent toLowerCase error on null fieldName

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -332,7 +332,7 @@ function HomePage() {
                 // This is a guess, I might need to create a new state for this
                 // setIsHtmlEditorOpen(true);
               }}
-              isHtmlField={(fieldName) => ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'].some(field => fieldName.toLowerCase().includes(field.toLowerCase()))}
+              isHtmlField={(fieldName) => fieldName && ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'].some(field => fieldName.toLowerCase().includes(field.toLowerCase()))}
             />
           </div>
           <div hidden={activeStep !== 3}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} /></div>


### PR DESCRIPTION
Adds a null check to the `isHtmlField` function in `HomePage.jsx`.

This prevents the "TypeError: Cannot read properties of null (reading 'toLowerCase')" error that occurs during the field positioning step if the list of CSV headers contains a null or undefined value.