### PR TITLE
feat: Link follow-up posts to the main post on LinkedIn

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -160,7 +160,7 @@ async function handleRunScheduler(request, response) {
             const post = JSON.parse(postRaw);
 
             try {
-                const postText = [
+                const postParts = [
                     post.content.titulo.toUpperCase(),
                     '',
                     markdownToLinkedinText(post.content.conteudo),
@@ -168,8 +168,22 @@ async function handleRunScheduler(request, response) {
                     '----',
                     post.content.cta,
                     '----',
-                    (post.content.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' '),
-                ].join('\n');
+                ];
+
+                // If this is a follow-up post, try to append the main post's link
+                if (!post.is_main_post && post.main_post_id) {
+                    const mainPostRaw = await kv.get(`post:${post.main_post_id}`);
+                    if (mainPostRaw) {
+                        const mainPost = JSON.parse(mainPostRaw);
+                        if (mainPost.linkedin_post_url) {
+                            postParts.push(`\nLeia o post principal aqui: ${mainPost.linkedin_post_url}\n`);
+                        }
+                    }
+                }
+
+                postParts.push((post.content.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' '));
+
+                const postText = postParts.join('\n');
 
                 const shareContent = { shareCommentary: { text: postText }, shareMediaCategory: 'NONE' };
                 const payload = {
@@ -195,6 +209,12 @@ async function handleRunScheduler(request, response) {
                 post.status = 'published';
                 post.publishedAt = new Date().toISOString();
                 post.postId = result.id;
+
+                // If this is a main post, construct and save its URL
+                if (post.is_main_post && result.id) {
+                    post.linkedin_post_url = `https://www.linkedin.com/feed/update/${result.id}/`;
+                }
+
                 publishedCount++;
             } catch (error) {
                 post.status = 'failed';

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -460,9 +460,15 @@ const Publisher = ({
             accessToken: accessToken,
             imageDriveIds: uploadedImageIds,
             videoDriveId: uploadedVideoId,
+            is_main_post: true,
         };
 
-        await createSchedule(mainPostSchedule);
+        const createdMainPost = await createSchedule(mainPostSchedule);
+
+        if (!createdMainPost || !createdMainPost.id) {
+          throw new Error("Failed to create the main post schedule and retrieve its ID.");
+        }
+        const mainPostId = createdMainPost.id;
 
         if (followupPosts && followupPosts.length > 0) {
             for (const [index, post] of followupPosts.entries()) {
@@ -484,6 +490,8 @@ const Publisher = ({
                     accessToken: accessToken,
                     imageDriveIds: [], // Follow-ups are text-only
                     videoDriveId: '',
+                    is_main_post: false,
+                    main_post_id: mainPostId,
                 };
                 await createSchedule(followupSchedule);
             }


### PR DESCRIPTION
This feature enhances the scheduling functionality by creating a clear link between a main post and its follow-up posts.

- The frontend (`Publisher.jsx`) now sends `is_main_post` and `main_post_id` flags when scheduling posts.
- The backend scheduler (`api/schedule.js`) now saves the LinkedIn post URL for main posts after they are published.
- When publishing a follow-up post, the scheduler retrieves the main post's URL and appends it to the content, providing a direct link back to the original post.