### PR TITLE
fix: Resolve crash and UI duplication in Image Step

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -22,9 +22,7 @@ import {
   Edit
 } from '@mui/icons-material';
 import DraggableElement from './DraggableElement';
-import FormattingPanel from './FormattingPanel';
 import TextEditorDialog from './TextEditorDialog';
-import FormattingDrawer from './FormattingDrawer'; // Import the new drawer
 
 const COMPLETE_DEFAULT_STYLE_FOR_FIELD_POSITIONER = {
   fontFamily: 'Arial',
@@ -158,6 +156,7 @@ const FieldPositioner = ({
   }, [backgroundImage, imageFilters]);
 
   const isHtmlField = useCallback((fieldName) => {
+    if (!fieldName) return false;
     return htmlFields.some(field =>
       fieldName.toLowerCase().includes(field.toLowerCase())
     );
@@ -594,7 +593,7 @@ const FieldPositioner = ({
 
   return (
     <Grid container spacing={3}>
-      <Grid item xs={12} lg={9}>
+      <Grid item xs={12}>
         <Card>
           <CardContent>
             <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2 }} justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
@@ -726,25 +725,6 @@ const FieldPositioner = ({
             )}
           </CardContent>
         </Card>
-      </Grid>
-      <Grid item xs={12} lg={3}>
-        <FormattingPanel
-          selectedField={selectedField}
-          fieldStyles={fieldStyles}
-          setFieldStyles={setFieldStyles}
-          fieldPositions={fieldPositions}
-          setFieldPositions={setFieldPositions}
-          csvHeaders={csvHeaders}
-          imageFilters={imageFilters}
-          setImageFilters={setImageFilters}
-          brandElements={brandElements}
-          setBrandElements={setBrandElements}
-          onZIndexChange={onZIndexChange}
-          onVisibilityChange={handleVisibilityChange}
-          onOpenHtmlEditor={handleOpenHtmlEditor}
-          isHtmlField={isHtmlField}
-          standardsColors={standardsColors}
-        />
       </Grid>
       {isHtmlEditorOpen && (
         <TextEditorDialog

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -378,7 +378,10 @@ function HomePage() {
                 // This is a guess, I might need to create a new state for this
                 // setIsHtmlEditorOpen(true);
               }}
-              isHtmlField={(fieldName) => fieldName && ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'].some(field => fieldName.toLowerCase().includes(field.toLowerCase()))}
+              isHtmlField={(fieldName) => {
+                if (!fieldName) return false;
+                return fieldName && ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'].some(field => fieldName.toLowerCase().includes(field.toLowerCase()))
+              }}
             />
           </div>
           <div hidden={activeStep !== 3}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} /></div>


### PR DESCRIPTION
This commit addresses two issues in the image formatting step:

1.  **Duplicate Formatting Panel:** The `FieldPositioner` component was erroneously rendering its own `FormattingPanel`, causing a duplicated UI. This has been removed. `ImageStep` is now the sole component responsible for rendering the formatting UI.

2.  **Crash on Deselect:** Clicking the background to deselect a field caused a crash (`TypeError: Cannot read properties of null (reading 'toLowerCase')`). This was due to a function being called with a null value. A null check has been added to the `isHtmlField` function in `HomePage.jsx` to prevent this crash.