### PR TITLE
Refatora o fluxo de autenticação do Google para unificar o login do u…

### DIFF
--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -32,7 +32,6 @@ import { toast } from 'sonner';
 import { IANA_TIMEZONES } from '../lib/timezones';
 import { saveTimezone, getTimezone } from '../utils/timezone';
 import GeminiAuthSetup from './GeminiAuthSetup';
-import GoogleDriveAuthModal from './GoogleDriveAuthModal';
 import GoogleCloudTTSAuth from './GoogleCloudTTSAuth';
 import WordpressAuthSetup from './WordpressAuthSetup';
 import LinkedinAuthSetup from './LinkedinAuthSetup';
@@ -150,10 +149,9 @@ const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
         >
           <Tab icon={<AccountCircle />} iconPosition="start" label="Geral" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(0)} />
           <Tab icon={<AutoAwesome />} iconPosition="start" label="Gemini" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(1)} />
-          <Tab icon={<DriveFolderUpload />} iconPosition="start" label="Google Drive" sx={{ justifyContent: 'flex-start', textAlign: 'left' }}{...a11yProps(2)} />
-          <Tab icon={<Audiotrack />} iconPosition="start" label="Cloud TTS" sx={{ justifyContent: 'flex-start', textAlign: 'left' }}{...a11yProps(3)} />
-          <Tab icon={<Language />} iconPosition="start" label="WordPress" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(4)} />
-          <Tab icon={<LinkedIn />} iconPosition="start" label="LinkedIn" sx={{ justifyContent: 'flex-start', textAlign: 'left' }}{...a11yProps(5)} />
+          <Tab icon={<Audiotrack />} iconPosition="start" label="Cloud TTS" sx={{ justifyContent: 'flex-start', textAlign: 'left' }}{...a11yProps(2)} />
+          <Tab icon={<Language />} iconPosition="start" label="WordPress" sx={{ justifyContent: 'flex-start', textAlign: 'left' }} {...a11yProps(3)} />
+          <Tab icon={<LinkedIn />} iconPosition="start" label="LinkedIn" sx={{ justifyContent: 'flex-start', textAlign: 'left' }}{...a11yProps(4)} />
         </Tabs>
         <TabPanel value={value} index={0}>
           <GeneralSettings />
@@ -162,15 +160,12 @@ const SetupModal = ({ open, onClose, onBeforeLinkedinRedirect }) => {
           <GeminiAuthSetup />
         </TabPanel>
         <TabPanel value={value} index={2}>
-          <GoogleDriveAuthModal />
-        </TabPanel>
-        <TabPanel value={value} index={3}>
           <GoogleCloudTTSAuth />
         </TabPanel>
-        <TabPanel value={value} index={4}>
+        <TabPanel value={value} index={3}>
           <WordpressAuthSetup />
         </TabPanel>
-        <TabPanel value={value} index={5}>
+        <TabPanel value={value} index={4}>
           <LinkedinAuthSetup onBeforeRedirect={onBeforeLinkedinRedirect} />
         </TabPanel>
       </DialogContent>


### PR DESCRIPTION
…suário e a autorização da API do Google Drive/Sheets em uma única etapa.

Alterações principais:

- **Backend:** O endpoint de autenticação do Google (`/api/auth/google`) foi modificado para usar o fluxo de código de autorização do OAuth2. Ele agora troca o código de autorização por um token de acesso e um token de atualização, que são armazenados de forma segura no banco de dados.
- **Novo Endpoint de Credenciais:** Foi criado um novo endpoint seguro (`/api/google/credentials`) que fornece ao frontend um token de acesso válido sob demanda, usando o token de atualização para renová-lo quando necessário.
- **Banco de Dados:** O esquema da tabela `users` foi atualizado para incluir colunas para `google_access_token` e `google_refresh_token`.
- **Frontend:** A página de login foi atualizada para usar o hook `useGoogleLogin` com os escopos do Drive e do Sheets, iniciando o fluxo de código de autorização.
- **Remoção de Componentes:** Os componentes `GoogleAuthSetup.jsx` e `GoogleDriveAuthModal.jsx`, que faziam parte do fluxo de configuração manual anterior, foram removidos. A referência a `GoogleDriveAuthModal` em `SetupModal.jsx` também foi removida para corrigir um erro de compilação.
- **API Utility:** O utilitário `googleDriveAPI.js` foi simplificado, removendo toda a lógica de gerenciamento de autenticação e, em vez disso, buscando o token de acesso do novo endpoint do backend antes de cada chamada de API.

Essa mudança simplifica significativamente a experiência do usuário, eliminando a necessidade de uma etapa de configuração manual separada após o login.