### PR TITLE
feat: Enable editing for all CSV fields and add conditional editor

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -3,7 +3,7 @@
 > vite
 
 
-  VITE v5.4.19  ready in 344 ms
+  VITE v5.4.19  ready in 1040 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose

--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -20,9 +20,9 @@ const DraggableElement = ({
   originalImageSize,
   fontScale: fontScaleProp,
   enableHtmlRendering = false,
-  darkMode,
   onDoubleClick,
 }) => {
+  const [isEditing, setIsEditing] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
@@ -51,45 +51,6 @@ const DraggableElement = ({
     sanitized = sanitized.replace(/on\w+="[^"]*"/gi, ''); // Remove event handlers
     
     return sanitized;
-  };
-
-  // Função para renderizar conteúdo HTML ou texto simples
-  const renderContent = () => {
-    if (element.type === 'image') {
-      return (
-        <img
-          src={element.url}
-          alt={element.name || 'Brand Element'}
-          style={{
-            width: '100%',
-            height: '100%',
-            objectFit: 'contain', // or 'cover', depending on desired behavior
-            pointerEvents: 'none',
-          }}
-        />
-      );
-    }
-
-    // Default to text rendering
-    if (!enableHtmlRendering) {
-      return content;
-    }
-
-    const sanitizedContent = sanitizeHtml(content);
-    return (
-      <div
-        ref={htmlContentRef}
-        dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-        style={{
-          width: '100%',
-          height: '100%',
-          overflow: 'hidden',
-          wordWrap: 'break-word',
-          pointerEvents: 'none',
-          textAlign: style.textAlign || 'left',
-        }}
-      />
-    );
   };
 
   const getRotatedBoundingBox = useCallback((widthPercent, heightPercent, rotationDegrees) => {
@@ -250,12 +211,13 @@ const DraggableElement = ({
     setEditedContent(content);
   }, [content]);
 
-  const pixelPosition = {
-    x: (position.x / 100) * (containerSize.width || 1),
-    y: (position.y / 100) * (containerSize.height || 1),
-    width: (position.width / 100) * (containerSize.width || 1),
-    height: (position.height / 100) * (containerSize.height || 1)
-  };
+  // Auto-focus the textarea when entering edit mode
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select(); // Select all text for easy replacement
+    }
+  }, [isEditing]);
 
   const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || 
                    ('ontouchstart' in window) || 
@@ -548,6 +510,20 @@ const DraggableElement = ({
     pointerEvents: 'none',
   };
 
+  const handleDoubleClick = (e) => {
+    // Prevent triggering onDoubleClick on parent elements
+    e.stopPropagation();
+
+    // Logic for simple text fields
+    if (element.type === 'text' && !enableHtmlRendering) {
+      setIsEditing(true);
+    }
+    // Logic for HTML fields (and other potential double-click actions)
+    else if (onDoubleClick) {
+      onDoubleClick(e);
+    }
+  };
+
   return (
     <>
       <Box
@@ -564,7 +540,7 @@ const DraggableElement = ({
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
         onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}
         onClick={() => onSelect(element.id)}
-        onDoubleClick={onDoubleClick}
+        onDoubleClick={handleDoubleClick}
       >
         <Box
           className={`${styles.textBoxContent} ${isSelected ? styles.selected : ''} ${element.type === 'image' ? styles.imageElement : ''}`}
@@ -601,6 +577,30 @@ const DraggableElement = ({
                       wordWrap: 'break-word',
                       pointerEvents: 'none',
                       textAlign: style.textAlign || 'left',
+                    }}
+                  />
+                ) : isEditing ? (
+                  <textarea
+                    ref={textareaRef}
+                    value={editedContent}
+                    onChange={(e) => setEditedContent(e.target.value)}
+                    onBlur={() => {
+                      setIsEditing(false);
+                      onContentChange(element.id, editedContent);
+                    }}
+                    style={{
+                      ...textContentStyle,
+                      width: '100%',
+                      height: '100%',
+                      padding: 0,
+                      margin: 0,
+                      border: 'none',
+                      background: 'rgba(255, 255, 255, 0.7)',
+                      resize: 'none',
+                      outline: 'none',
+                      overflow: 'hidden',
+                      whiteSpace: 'pre-wrap',
+                      wordWrap: 'break-word',
                     }}
                   />
                 ) : (

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -99,15 +99,14 @@ const FieldPositioner = ({
   imageFilters,
   brandElements,
   setBrandElements,
-  setImageFilters,
-  onZIndexChange,
-  onOpenHtmlEditor,
+  onOpenEditor,
+  currentPreviewIndex,
+  setCurrentPreviewIndex,
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
-  const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0);
   const [composedImageUrl, setComposedImageUrl] = useState(null);
   const [isComposing, setIsComposing] = useState(false);
 
@@ -170,29 +169,6 @@ const FieldPositioner = ({
       onCsvDataUpdate(updatedCsvData);
     }
   }, [csvData, currentPreviewIndex, onCsvDataUpdate]);
-
-  const handleVisibilityChange = useCallback((fieldId, isVisible) => {
-    // Check if the selected element is a brand element
-    const isBrandElement = brandElements.some(el => el.id === fieldId);
-
-    if (isBrandElement) {
-        if (!isVisible) {
-            // It's a brand element and it's being hidden, so delete it.
-            setBrandElements(prev => prev.filter(el => el.id !== fieldId));
-            // Also deselect it
-            handleFieldSelectInternal(null);
-        }
-    } else {
-        // It's a text field from CSV. Just toggle its visibility.
-        setFieldPositions(prev => ({
-            ...prev,
-            [fieldId]: {
-                ...(prev[fieldId] || {}),
-                visible: isVisible
-            }
-        }));
-    }
-  }, [brandElements, setBrandElements, setFieldPositions, handleFieldSelectInternal]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -668,7 +644,7 @@ const FieldPositioner = ({
                   onContentChange={element.type === 'text' ? handleContentChange : undefined}
                   onDoubleClick={() => {
                     if (element.type === 'text' && isHtmlField(element.id)) {
-                      onOpenHtmlEditor(element.id);
+                      onOpenEditor(element.id);
                     }
                   }}
                   rotation={element.rotation}
@@ -719,4 +695,3 @@ const FieldPositioner = ({
 };
 
 export default FieldPositioner;
-

--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -18,7 +18,7 @@ const FormattingDrawer = ({
   setBrandElements,
   onZIndexChange,
   onDeselectField,
-  onOpenHtmlEditor,
+  onOpenEditor,
   isHtmlField,
   standardsColors,
 }) => {
@@ -44,7 +44,7 @@ const FormattingDrawer = ({
           setBrandElements={setBrandElements}
           onZIndexChange={onZIndexChange}
           onDeselectField={onDeselectField}
-          onOpenHtmlEditor={onOpenHtmlEditor}
+          onOpenEditor={onOpenEditor}
           isHtmlField={isHtmlField}
           standardsColors={standardsColors}
         />

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -61,7 +61,7 @@ const FormattingPanel = ({
   setBrandElements,
   onZIndexChange,
   onDeselectField,
-  onOpenHtmlEditor,
+  onOpenEditor,
   isHtmlField,
   standardsColors,
 }) => {
@@ -311,7 +311,7 @@ const FormattingPanel = ({
                   <Button
                     variant="contained"
                     startIcon={<Edit />}
-                    onClick={() => onOpenHtmlEditor(selectedField)}
+                    onClick={() => onOpenEditor(selectedField)}
                     fullWidth
                     sx={{ mb: 2 }}
                   >

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -48,8 +48,10 @@ const ImageStep = ({
   selectedField,
   setSelectedField,
   onDeselectField,
-  onOpenHtmlEditor,
+  onOpenEditor,
   isHtmlField,
+  currentPreviewIndex,
+  setCurrentPreviewIndex
 }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -156,7 +158,9 @@ const ImageStep = ({
             brandElements={brandElements}
             setBrandElements={setBrandElements}
             onZIndexChange={onZIndexChange}
-            onOpenHtmlEditor={onOpenHtmlEditor}
+            onOpenEditor={onOpenEditor}
+            currentPreviewIndex={currentPreviewIndex}
+            setCurrentPreviewIndex={setCurrentPreviewIndex}
           />
         </Grid>
         {!isMobile ? (
@@ -174,7 +178,7 @@ const ImageStep = ({
               setBrandElements={setBrandElements}
               onZIndexChange={onZIndexChange}
               onDeselectField={onDeselectField}
-              onOpenHtmlEditor={onOpenHtmlEditor}
+              onOpenEditor={onOpenEditor}
               isHtmlField={isHtmlField}
               standardsColors={standardsColors}
             />
@@ -197,7 +201,7 @@ const ImageStep = ({
               setBrandElements={setBrandElements}
               onZIndexChange={onZIndexChange}
               onDeselectField={onDeselectField}
-              onOpenHtmlEditor={onOpenHtmlEditor}
+              onOpenEditor={onOpenEditor}
               isHtmlField={isHtmlField}
               standardsColors={standardsColors}
             />

--- a/src/components/TextEditorDialog.jsx
+++ b/src/components/TextEditorDialog.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField } from '@mui/material';
 import RichTextEditor from './RichTextEditor'; // Import the RichTextEditor
 
-const TextEditorDialog = ({ open, title, content, onSave, onClose }) => {
+const TextEditorDialog = ({ open, title, content, onSave, onClose, isHtml }) => {
   const [editedContent, setEditedContent] = useState(content);
 
   useEffect(() => {
@@ -24,11 +24,23 @@ const TextEditorDialog = ({ open, title, content, onSave, onClose }) => {
     }}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 1 }}>
-        <RichTextEditor
-          value={editedContent}
-          onChange={setEditedContent}
-          maxHeight="100%" // Allow editor to fill the space
-        />
+        {isHtml ? (
+          <RichTextEditor
+            value={editedContent}
+            onChange={setEditedContent}
+            maxHeight="100%" // Allow editor to fill the space
+          />
+        ) : (
+          <TextField
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+            multiline
+            rows={10}
+            fullWidth
+            variant="outlined"
+            style={{ flex: 1 }}
+          />
+        )}
       </DialogContent>
       <DialogActions sx={{ pb: 2, px: 3 }}>
         <Button onClick={onClose}>Cancelar</Button>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -53,6 +53,8 @@ import { parseCsv } from '../utils/csvParser.js';
 import { lightTheme, darkTheme } from '../theme.js';
 import ColorThief from 'colorthief';
 
+const htmlFields = ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'];
+
 function HomePage() {
   const { user } = useUserAuth();
 
@@ -124,11 +126,12 @@ function HomePage() {
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showLoadModal, setShowLoadModal] = useState(false);
   const [currentCampaign, setCurrentCampaign] = useState(null);
+  const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0);
 
   const fileInputRef = useRef(null);
   const imageInputRef = useRef(null);
 
-  const getAppState = () => ({ activeStep, darkMode, sidebarOpen, csvData, csvHeaders, backgroundImage, colorPalette, standardsColors, problema, solucao, campaignContent, persona, autor, instrucoes, formato, aspectRatio, generatedImageUrl, conteudoMedio, conteudoPequeno, followupPosts, followupPostsQuantity, isScheduled, scheduleDate, weeklySchedule, selectedProfile, selectedImages, selectedVideos, inputMethod, promptNumRecords, promptText, fieldPositions, fieldStyles, displayedImageSize, originalImageSize, generatedImagesData, generatedAudioData, generatedVideosData, imageFilters, brandElements });
+  const getAppState = () => ({ activeStep, darkMode, sidebarOpen, csvData, csvHeaders, backgroundImage, colorPalette, standardsColors, problema, solucao, campaignContent, persona, autor, instrucoes, formato, aspectRatio, generatedImageUrl, conteudoMedio, conteudoPequeno, followupPosts, followupPostsQuantity, isScheduled, scheduleDate, weeklySchedule, selectedProfile, selectedImages, selectedVideos, inputMethod, promptNumRecords, promptText, fieldPositions, fieldStyles, displayedImageSize, originalImageSize, generatedImagesData, generatedAudioData, generatedVideosData, imageFilters, brandElements, currentPreviewIndex });
   const applyAppState = (state) => {
     if (!state) return;
     setActiveStep(state.activeStep ?? 0);
@@ -170,6 +173,7 @@ function HomePage() {
     setGeneratedVideosData(state.generatedVideosData ?? []);
     setImageFilters(state.imageFilters ?? { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 });
     setBrandElements(state.brandElements ?? []);
+    setCurrentPreviewIndex(state.currentPreviewIndex ?? 0);
   };
 
   const handleSaveCampaign = async (name) => {
@@ -373,14 +377,14 @@ function HomePage() {
               selectedField={selectedField}
               setSelectedField={setSelectedField}
               onDeselectField={() => setSelectedField(null)}
-              onOpenHtmlEditor={(fieldId) => {
+              currentPreviewIndex={currentPreviewIndex}
+              setCurrentPreviewIndex={setCurrentPreviewIndex}
+              onOpenEditor={(fieldId) => {
                 setEditingField(fieldId);
-                // This is a guess, I might need to create a new state for this
-                // setIsHtmlEditorOpen(true);
               }}
               isHtmlField={(fieldName) => {
                 if (!fieldName) return false;
-                return fieldName && ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'].some(field => fieldName.toLowerCase().includes(field.toLowerCase()))
+                return fieldName && htmlFields.some(field => String(fieldName).toLowerCase().includes(field.toLowerCase()))
               }}
             />
           </div>
@@ -397,7 +401,62 @@ function HomePage() {
       <MemorialDescritivoModal open={showMemorialDescritivoModal} onClose={() => setShowMemorialDescritivoModal(false)} campaignData={campaignData} />
       <CampaignStandardsModal open={showCampaignStandardsModal} onClose={() => { setShowCampaignStandardsModal(false); loadCampaignStandards(); }} onShowMemorial={() => setShowMemorialDescritivoModal(true)} onGeneratePalette={async (briefing) => { try { const palette = await generateColorPalette(briefing); return palette; } catch (error) { toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores."); throw error; } }} />
       <LoadingDialog open={isGeneratingCampaign || isSaving || isLoading} title={ isSaving ? "Salvando configuração..." : isLoading ? "Carregando configuração..." : "Gerando conteúdo..." } description={ isSaving ? "Aguarde um momento, estamos empacotando tudo para você." : isLoading ? "Estamos desempacotando sua configuração. Quase pronto!" : "A IA está pensando e escrevendo. Isso pode levar alguns segundos." } />
-      <TextEditorDialog open={editingField !== null || editingFollowup !== null} title={ editingFollowup !== null ? `Editar Post de Follow-up ${editingFollowup.index + 1}` : `Editar ${ editingField === 'conteudo' ? 'Conteúdo' : editingField === 'conteudoMedio' ? 'Conteúdo Médio' : editingField === 'conteudoPequeno' ? 'Conteúdo Pequeno' : editingField === 'cta' ? 'CTA' : 'Conteúdo Formatado' }` } content={ editingFollowup !== null ? editingFollowup.content : editingField === 'conteudoFormatado' ? conteudoFormatado : editingField === 'conteudoMedio' ? conteudoMedio : editingField === 'conteudoPequeno' ? conteudoPequeno : editingField && campaignContent ? campaignContent[editingField] : '' } onSave={ editingFollowup !== null ? handleSaveFollowup : (newContent) => { if (editingField === 'conteudoFormatado') { setConteudoFormatado(newContent); } else if (editingField === 'conteudoMedio') { setConteudoMedio(newContent); } else if (editingField === 'conteudoPequeno') { setConteudoPequeno(newContent); } else if (editingField) { setCampaignContent({ ...campaignContent, [editingField]: newContent, }); } } } onClose={() => { setEditingField(null); setEditingFollowup(null); }} />
+      <TextEditorDialog
+        open={editingField !== null || editingFollowup !== null}
+        title={
+          editingFollowup !== null
+            ? `Editar Post de Follow-up ${editingFollowup.index + 1}`
+            : `Editar Campo: "${editingField}"`
+        }
+        isHtml={
+          editingFollowup !== null ||
+          (editingField && htmlFields.some(field => String(editingField).toLowerCase().includes(field)))
+        }
+        content={
+          editingFollowup !== null
+            ? editingFollowup.content
+            : editingField && csvHeaders.includes(editingField) && csvData[currentPreviewIndex]
+              ? csvData[currentPreviewIndex][editingField] || ''
+              : editingField === 'conteudoFormatado'
+                ? conteudoFormatado
+                : editingField === 'conteudoMedio'
+                  ? conteudoMedio
+                  : editingField === 'conteudoPequeno'
+                    ? conteudoPequeno
+                    : editingField && campaignContent
+                      ? campaignContent[editingField] || ''
+                      : ''
+        }
+        onSave={
+          editingFollowup !== null
+            ? handleSaveFollowup
+            : editingField && csvHeaders.includes(editingField)
+              ? (newContent) => {
+                  const updatedCsvData = csvData.map((row, index) => {
+                    if (index === currentPreviewIndex) {
+                      return { ...row, [editingField]: newContent };
+                    }
+                    return row;
+                  });
+                  setCsvData(updatedCsvData);
+                }
+              : (newContent) => {
+                  if (editingField === 'conteudoFormatado') {
+                    setConteudoFormatado(newContent);
+                  } else if (editingField === 'conteudoMedio') {
+                    setConteudoMedio(newContent);
+                  } else if (editingField === 'conteudoPequeno') {
+                    setConteudoPequeno(newContent);
+                  } else if (editingField) {
+                    setCampaignContent({ ...campaignContent, [editingField]: newContent });
+                  }
+                }
+        }
+        onClose={() => {
+          setEditingField(null);
+          setEditingFollowup(null);
+        }}
+      />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
This commit implements the ability for users to edit any field loaded from a CSV file in the "Image and Formatting" step.

Key changes:
- All text fields are now editable on double-click.
- A rich text editor is used for fields containing HTML, and a simple in-place text editor is used for plain text fields.
- The `onOpenHtmlEditor` prop has been renamed to `onOpenEditor` for clarity.
- A bug was fixed where the editor dialog was not correctly loading or saving data for CSV fields. This was resolved by lifting the `currentPreviewIndex` state to `HomePage.jsx` and adding logic to the `TextEditorDialog` to handle CSV data sources correctly.
- Addressed a code review comment to fix a logical conflict where both the in-place editor and the dialog editor could be triggered simultaneously.
- Cleaned up linting errors in the modified files.