### PR TITLE
fix: Corrige múltiplos bugs e refatora estado

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -406,24 +406,46 @@ function HomePage() {
                   conteudoPequeno: 'Conteúdo Pequeno',
                   conteudoFormatado: 'Conteúdo Formatado',
                   cta: 'CTA',
-                }[editingField] || 'Conteúdo'
+                }[editingField] || editingField || 'Conteúdo'
               }`
         }
         content={
-          editingFollowup !== null
-            ? editingFollowup.content
-            : editingField && campaignContent
-            ? campaignContent[editingField] || ''
-            : ''
+          (() => {
+            if (editingFollowup) return editingFollowup.content;
+            if (!editingField) return '';
+
+            // Step 0: Campaign content
+            if (activeStep === 0) {
+              return campaignContent ? campaignContent[editingField] || '' : '';
+            }
+
+            // Step 2: Image/Formatting step (from CSV)
+            if (activeStep === 2) {
+              const currentRecord = csvData[currentPreviewIndex];
+              return currentRecord ? currentRecord[editingField] || '' : '';
+            }
+
+            return '';
+          })()
         }
         onSave={
-          editingFollowup !== null
-            ? handleSaveFollowup
-            : (newContent) => {
-                if (editingField) {
-                  setCampaignContent((prev) => ({ ...prev, [editingField]: newContent }));
-                }
+          (newContent) => {
+            if (editingFollowup) {
+              handleSaveFollowup(newContent);
+            } else if (editingField) {
+              if (activeStep === 0) {
+                setCampaignContent((prev) => ({ ...prev, [editingField]: newContent }));
+              } else if (activeStep === 2) {
+                const updatedCsvData = csvData.map((row, index) => {
+                  if (index === currentPreviewIndex) {
+                    return { ...row, [editingField]: newContent };
+                  }
+                  return row;
+                });
+                handleCsvRecordContentUpdate(updatedCsvData);
               }
+            }
+          }
         }
         onClose={() => {
           setEditingField(null);


### PR DESCRIPTION
Este commit resolve uma série de problemas relatados:

1.  **Erro na Geração de Imagem com IA:**
    - Corrige um erro 404 ao chamar a API do Gemini, atualizando o modelo de imagem para `gemini-1.5-flash-latest`.
    - Ajusta a construção do prompt para serializar corretamente a paleta de cores, evitando o envio de `[object Object]`.

2.  **Bugs no Editor de Rich Text:**
    - Centraliza os estados de conteúdo (`conteudoMedio`, `conteudoPequeno`, `conteudoFormatado`) no objeto `campaignContent` para criar uma única fonte de verdade.
    - Refatora o `TextEditorDialog` na `HomePage` para ser ciente do contexto (usando `activeStep`), permitindo que ele carregue e salve conteúdo da fonte de dados correta (`campaignContent` ou `csvData`).
    - Remove props e variáveis de estado redundantes em múltiplos componentes (`HomePage`, `Campaign`, `Publisher`, etc.) para alinhar com a nova estrutura de estado.

3.  **Correção de Erros de Referência:**
    - Elimina os `ReferenceError` que surgiram da refatoração inicial, garantindo que todos os componentes acessem os dados de conteúdo através do objeto `campaignContent`.