### PR TITLE
feat: Implement Google OAuth2 token refresh mechanism

### DIFF
--- a/api/auth/refresh-google-token.js
+++ b/api/auth/refresh-google-token.js
@@ -1,0 +1,52 @@
+import { withAuth } from '../middleware/auth.js';
+import { query } from '../db.js';
+import { OAuth2Client } from 'google-auth-library';
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+
+const client = new OAuth2Client(GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET);
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  try {
+    const userId = req.user.sub;
+    if (!userId) {
+      return res.status(400).json({ error: 'User ID not found in token.' });
+    }
+
+    const { rows } = await query('SELECT google_refresh_token FROM users WHERE id = $1', [userId]);
+    const user = rows[0];
+
+    if (!user || !user.google_refresh_token) {
+      return res.status(403).json({ error: 'No refresh token found for this user. Please re-authenticate with Google.' });
+    }
+
+    client.setCredentials({
+      refresh_token: user.google_refresh_token,
+    });
+
+    const { credentials } = await client.refreshAccessToken();
+    const { access_token } = credentials;
+
+    if (!access_token) {
+      return res.status(500).json({ error: 'Failed to refresh access token.' });
+    }
+
+    // Update the new access token in the database
+    await query('UPDATE users SET google_access_token = $1 WHERE id = $2', [access_token, userId]);
+
+    // Return the new access token
+    res.status(200).json({ googleAccessToken: access_token });
+
+  } catch (error) {
+    console.error('Google Token Refresh Error:', error.response ? error.response.data : error.message);
+    res.status(500).json({ error: 'An error occurred while refreshing the Google token.' });
+  }
+}
+
+export default withAuth(handler);

--- a/src/components/GoogleDriveFolderPicker.jsx
+++ b/src/components/GoogleDriveFolderPicker.jsx
@@ -18,7 +18,7 @@ import {
 import { Folder, Close } from '@mui/icons-material';
 import { listFolders, createFolder } from '../utils/googleApi';
 
-const GoogleDriveFolderPicker = ({ open, onClose, onSelectFolder, googleAccessToken }) => {
+const GoogleDriveFolderPicker = ({ open, onClose, onSelectFolder, googleAccessToken, setGoogleAccessToken }) => {
   const [folders, setFolders] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -33,7 +33,7 @@ const GoogleDriveFolderPicker = ({ open, onClose, onSelectFolder, googleAccessTo
     setLoading(true);
     setError('');
     try {
-      const folderList = await listFolders(googleAccessToken);
+      const folderList = await listFolders(googleAccessToken, setGoogleAccessToken);
       setFolders(folderList);
     } catch (err) {
       setError(`Falha ao buscar pastas: ${err.message}`);
@@ -63,7 +63,7 @@ const GoogleDriveFolderPicker = ({ open, onClose, onSelectFolder, googleAccessTo
     setLoading(true);
     setError('');
     try {
-      const newFolder = await createFolder(newFolderName.trim(), null, googleAccessToken);
+      const newFolder = await createFolder(newFolderName.trim(), null, googleAccessToken, setGoogleAccessToken);
       onSelectFolder(newFolder);
       onClose();
     } catch (err) {

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -26,7 +26,7 @@ import { useUserAuth } from '../context/UserAuthContext';
 import LinkedinInfobox from './LinkedinInfobox';
 
 const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
-  const { googleAccessToken } = useUserAuth();
+  const { googleAccessToken, setGoogleAccessToken } = useUserAuth();
   const [config, setConfig] = useState({ clientId: '', clientSecret: '', folderId: '' });
   const [currentConfig, setCurrentConfig] = useState(null);
   const [isPickerOpen, setPickerOpen] = useState(false);
@@ -312,6 +312,7 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
         onClose={() => setPickerOpen(false)}
         onSelectFolder={handleSelectFolder}
         googleAccessToken={googleAccessToken}
+        setGoogleAccessToken={setGoogleAccessToken}
       />
 
       <Dialog open={showInfobox} onClose={() => setShowInfobox(false)} fullWidth maxWidth="lg">

--- a/src/context/UserAuthContext.jsx
+++ b/src/context/UserAuthContext.jsx
@@ -13,6 +13,7 @@ export const useUserAuth = () => {
 
 export const UserAuthContextProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [googleAccessToken, setGoogleAccessToken] = useState(null);
   const [loading, setLoading] = useState(true); // True initially to check for session
 
   const fetchUser = useCallback(async () => {
@@ -21,13 +22,16 @@ export const UserAuthContextProvider = ({ children }) => {
       if (res.ok) {
         const userData = await res.json();
         setUser(userData);
+        setGoogleAccessToken(userData.googleAccessToken);
       } else {
         // This is an expected case if the user is not logged in
         setUser(null);
+        setGoogleAccessToken(null);
       }
     } catch (error) {
       console.error('Could not fetch user session:', error);
       setUser(null);
+      setGoogleAccessToken(null);
       toast.error('Could not connect to the server to verify your session.');
     } finally {
       setLoading(false);
@@ -50,6 +54,7 @@ export const UserAuthContextProvider = ({ children }) => {
       const data = await res.json();
       if (res.ok) {
         setUser(data.user);
+        setGoogleAccessToken(data.user.googleAccessToken);
         toast.success('Login successful!');
         return true;
       } else {
@@ -99,6 +104,7 @@ export const UserAuthContextProvider = ({ children }) => {
       const data = await res.json();
       if (res.ok) {
         setUser(data.user);
+        setGoogleAccessToken(data.user.googleAccessToken);
         toast.success('Successfully signed in with Google!');
         return true;
       } else {
@@ -119,6 +125,7 @@ export const UserAuthContextProvider = ({ children }) => {
       const res = await fetch('/api/auth/logout', { method: 'POST' });
       if (res.ok) {
         setUser(null);
+        setGoogleAccessToken(null);
         toast.info('You have been logged out.');
       } else {
         toast.error('Logout request failed.');
@@ -133,7 +140,8 @@ export const UserAuthContextProvider = ({ children }) => {
   const value = {
     user,
     loading,
-    googleAccessToken: user?.googleAccessToken,
+    googleAccessToken,
+    setGoogleAccessToken,
     login,
     signup,
     logout,

--- a/src/utils/googleApi.js
+++ b/src/utils/googleApi.js
@@ -3,11 +3,53 @@
  * usando um token de acesso fornecido.
  */
 
+const fetchWithRefresh = async (url, options, accessToken, setAccessToken) => {
+    let response = await fetch(url, {
+        ...options,
+        headers: {
+            ...options.headers,
+            'Authorization': `Bearer ${accessToken}`,
+        },
+    });
+
+    if (response.status === 401) {
+        console.log('Access token expired, attempting to refresh...');
+        try {
+            const refreshResponse = await fetch('/api/auth/refresh-google-token', { method: 'POST' });
+            if (!refreshResponse.ok) {
+                const errorBody = await refreshResponse.json();
+                throw new Error(errorBody.error || 'Failed to refresh token');
+            }
+            const { googleAccessToken: newAccessToken } = await refreshResponse.json();
+
+            // Here you should update the token in your auth context
+            // This is a simplified example; you'll need to pass a setter function or use a state management library
+            if (setAccessToken) {
+                setAccessToken(newAccessToken);
+            }
+
+            // Retry the original request with the new token
+            const newOptions = { ...options };
+            newOptions.headers['Authorization'] = `Bearer ${newAccessToken}`;
+
+            console.log('Retrying request with new token...');
+            response = await fetch(url, newOptions);
+        } catch (error) {
+            console.error('Token refresh failed:', error);
+            // Optionally, force the user to log out or re-authenticate
+            window.location.href = '/login'; // Or show a modal
+            throw error;
+        }
+    }
+
+    return response;
+};
+
 /**
  * Procura por uma pasta com um nome específico dentro de uma pasta pai (opcional).
  * Retorna a primeira pasta encontrada ou null.
  */
-export const findFolderByName = async (name, parentId, accessToken) => {
+export const findFolderByName = async (name, parentId, accessToken, setAccessToken) => {
   if (!accessToken) throw new Error('Access token não fornecido.');
 
   let query = `mimeType='application/vnd.google-apps.folder' and name='${name.replace(/'/g, "\\'")}' and trashed=false`;
@@ -17,9 +59,12 @@ export const findFolderByName = async (name, parentId, accessToken) => {
     query += ` and 'root' in parents`;
   }
 
-  const response = await fetch(`https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name,parents)&orderBy=createdTime desc`, {
-    headers: { 'Authorization': `Bearer ${accessToken}` }
-  });
+  const response = await fetchWithRefresh(
+    `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&fields=files(id,name,parents)&orderBy=createdTime desc`,
+    {},
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.json();
@@ -33,13 +78,16 @@ export const findFolderByName = async (name, parentId, accessToken) => {
 /**
  * Lista arquivos em uma pasta específica.
  */
-export const listFiles = async (folderId, accessToken, pageSize = 100) => {
+export const listFiles = async (folderId, accessToken, setAccessToken, pageSize = 100) => {
   if (!accessToken) throw new Error('Access token não fornecido.');
 
   const query = `'${folderId}' in parents and trashed=false`;
-  const response = await fetch(`https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&pageSize=${pageSize}&fields=files(id,name,mimeType,thumbnailLink)`, {
-    headers: { 'Authorization': `Bearer ${accessToken}` }
-  });
+  const response = await fetchWithRefresh(
+    `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&pageSize=${pageSize}&fields=files(id,name,mimeType,thumbnailLink)`,
+    {},
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.json();
@@ -52,12 +100,15 @@ export const listFiles = async (folderId, accessToken, pageSize = 100) => {
 /**
  * Obtém o conteúdo de um arquivo como um Blob.
  */
-export const getFileAsBlob = async (fileId, accessToken) => {
+export const getFileAsBlob = async (fileId, accessToken, setAccessToken) => {
   if (!accessToken) throw new Error('Access token não fornecido.');
 
-  const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`, {
-    headers: { 'Authorization': `Bearer ${accessToken}` }
-  });
+  const response = await fetchWithRefresh(
+    `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
+    {},
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.text();
@@ -70,7 +121,7 @@ export const getFileAsBlob = async (fileId, accessToken) => {
 /**
  * Cria uma nova planilha Google Sheets com os dados fornecidos
  */
-export const createSpreadsheet = async (title, data, accessToken, folderId = null) => {
+export const createSpreadsheet = async (title, data, accessToken, setAccessToken, folderId = null) => {
   if (!accessToken) throw new Error('Access token não fornecido.');
 
   const sheetsData = [
@@ -111,14 +162,18 @@ export const createSpreadsheet = async (title, data, accessToken, folderId = nul
     sheets: sheetsData
   };
 
-  const response = await fetch('https://sheets.googleapis.com/v4/spreadsheets', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json'
+  const response = await fetchWithRefresh(
+    'https://sheets.googleapis.com/v4/spreadsheets',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(spreadsheetRequestBody)
     },
-    body: JSON.stringify(spreadsheetRequestBody)
-  });
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.json();
@@ -138,29 +193,36 @@ export const createSpreadsheet = async (title, data, accessToken, folderId = nul
 /**
  * Move um arquivo para uma pasta específica no Google Drive.
  */
-export const moveFileToFolder = async (fileId, folderId, accessToken) => {
+export const moveFileToFolder = async (fileId, folderId, accessToken, setAccessToken) => {
     if (!accessToken) throw new Error('Access token não fornecido.');
 
-    const file = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?fields=parents`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` }
-    }).then(res => res.json());
+    const fileResponse = await fetchWithRefresh(
+        `https://www.googleapis.com/drive/v3/files/${fileId}?fields=parents`,
+        {},
+        accessToken,
+        setAccessToken
+    );
+    const file = await fileResponse.json();
+
 
     const previousParents = file.parents ? file.parents.join(',') : '';
 
-    await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?addParents=${folderId}&removeParents=${previousParents}`, {
-        method: 'PATCH',
-        headers: { 'Authorization': `Bearer ${accessToken}` }
-    });
+    await fetchWithRefresh(
+        `https://www.googleapis.com/drive/v3/files/${fileId}?addParents=${folderId}&removeParents=${previousParents}`,
+        { method: 'PATCH' },
+        accessToken,
+        setAccessToken
+    );
 };
 
 /**
  * Cria uma pasta no Google Drive. Verifica se já existe antes de criar.
  */
-export const createFolder = async (name, parentId, accessToken) => {
+export const createFolder = async (name, parentId, accessToken, setAccessToken) => {
   if (!accessToken) throw new Error('Access token não fornecido para criar pasta.');
 
   // Primeiro, verifica se a pasta já existe para evitar duplicatas.
-  const existingFolder = await findFolderByName(name, parentId, accessToken);
+  const existingFolder = await findFolderByName(name, parentId, accessToken, setAccessToken);
   if (existingFolder) {
     console.warn(`Pasta '${name}' já existe com ID: ${existingFolder.id}. Usando a existente.`);
     return existingFolder;
@@ -175,14 +237,18 @@ export const createFolder = async (name, parentId, accessToken) => {
     metadata.parents = [parentId];
   }
 
-  const response = await fetch('https://www.googleapis.com/drive/v3/files', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
+  const response = await fetchWithRefresh(
+    'https://www.googleapis.com/drive/v3/files',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(metadata),
     },
-    body: JSON.stringify(metadata),
-  });
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.json();
@@ -196,7 +262,7 @@ export const createFolder = async (name, parentId, accessToken) => {
  * Faz upload de um arquivo (Blob) para o Google Drive.
  * Esta versão usa 'uploadType=resumable' que é mais robusto e preferível para blobs.
  */
-export const uploadFile = async (fileBlob, fileName, folderId, accessToken) => {
+export const uploadFile = async (fileBlob, fileName, folderId, accessToken, setAccessToken) => {
   if (!accessToken) throw new Error('Access token não fornecido para upload.');
 
   const metadata = {
@@ -207,14 +273,18 @@ export const uploadFile = async (fileBlob, fileName, folderId, accessToken) => {
   }
 
   // 1. Iniciar uma sessão de upload resumível
-  const initResponse = await fetch('https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json; charset=UTF-8',
+  const initResponse = await fetchWithRefresh(
+    'https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: JSON.stringify(metadata),
     },
-    body: JSON.stringify(metadata),
-  });
+    accessToken,
+    setAccessToken
+  );
 
   if (!initResponse.ok) {
     const errorBody = await initResponse.json();
@@ -246,16 +316,17 @@ export const uploadFile = async (fileBlob, fileName, folderId, accessToken) => {
 /**
  * Lista as pastas do Google Drive do usuário.
  */
-export const listFolders = async (accessToken, pageSize = 100) => {
+export const listFolders = async (accessToken, setAccessToken, pageSize = 100) => {
   if (!accessToken) throw new Error('Access token não fornecido para listar pastas.');
 
   const query = "mimeType='application/vnd.google-apps.folder' and 'me' in owners and trashed=false";
 
-  const response = await fetch(`https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&pageSize=${pageSize}&fields=files(id,name)&orderBy=name`, {
-    headers: {
-      'Authorization': `Bearer ${accessToken}`
-    }
-  });
+  const response = await fetchWithRefresh(
+    `https://www.googleapis.com/drive/v3/files?q=${encodeURIComponent(query)}&pageSize=${pageSize}&fields=files(id,name)&orderBy=name`,
+    {},
+    accessToken,
+    setAccessToken
+  );
 
   if (!response.ok) {
     const errorBody = await response.json();


### PR DESCRIPTION
This commit introduces a mechanism to automatically refresh expired Google OAuth2 access tokens, preventing authentication errors when using Google Drive features.

A new API endpoint, `/api/auth/refresh-google-token`, is added to handle the token refresh logic on the backend.

The frontend is updated with a `fetchWithRefresh` helper function that intercepts 401 Unauthorized responses from the Google API, calls the new refresh endpoint, and retries the request with the new token.

The `UserAuthContext` is refactored to manage the `googleAccessToken` state, and all Google API calls in `src/utils/googleApi.js` are updated to use the new refresh logic.