### PR TITLE
fix(HomePage): Adiciona declarações de estado ausentes

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -84,6 +84,9 @@ function HomePage() {
   const [formato, setFormato] = useState('');
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [generatedImageUrl, setGeneratedImageUrl] = useState(null);
+  const [conteudoMedio, setConteudoMedio] = useState('');
+  const [conteudoPequeno, setConteudoPequeno] = useState('');
+  const [conteudoFormatado, setConteudoFormatado] = useState('');
   const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const [isGeneratingSummaryMedio, setIsGeneratingSummaryMedio] = useState(false);
   const [isGeneratingSummaryPequeno, setIsGeneratingSummaryPequeno] = useState(false);


### PR DESCRIPTION
Adiciona as declarações de estado para `conteudoMedio`, `conteudoPequeno` e `conteudoFormatado` no componente `HomePage`.

A ausência dessas declarações estava causando um `ReferenceError` ao salvar uma campanha, pois as variáveis eram usadas na função `getAppState` sem terem sido inicializadas.