### PR TITLE
Fix ReferenceError in campaign serialization

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -83,6 +83,7 @@ export const serializeCampaignData = async (state, setProgress) => {
   };
 
   try {
+    const serializableGeneratedImages = await serializeAssetList(state.generatedImagesData);
     const serializableGeneratedAudio = await serializeAssetList(state.generatedAudioData);
     const serializableGeneratedVideos = await serializeAssetList(state.generatedVideosData);
 


### PR DESCRIPTION
When saving a campaign, the `serializeCampaignData` function in `src/utils/campaignState.js` was responsible for uploading blob assets (images, audio, etc.) and replacing them with public URLs before saving the campaign data as JSON.

The function correctly handled audio and video data, but it failed to process image data. It attempted to use a variable `serializableGeneratedImages` that was never defined, causing a `ReferenceError`. This error halted the save process silently.

This commit adds the missing logic to serialize the `generatedImagesData` array, resolving the `ReferenceError` and allowing campaigns with blob assets to be saved correctly.