### PR TITLE
Hotfix: Invalidate old LinkedIn profile cache

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -56,7 +56,7 @@ class LinkedInAPI {
 
 // Wrapper function to handle caching, as requested.
 export const getLinkedInProfiles = async (linkedinConfig, forceRefresh = false) => {
-    const cacheKey = 'linkedin_profiles_cache';
+    const cacheKey = 'linkedin_profiles_cache_v2'; // v2 to invalidate old cache
 
     if (forceRefresh) {
         sessionStorage.removeItem(cacheKey);


### PR DESCRIPTION
Changes the cache key for LinkedIn profiles to ensure that users get the newest data structure. This prevents the application from using stale, incorrectly formatted data from a previous session.