### PR TITLE
fix: Prevent image generation with empty theme

### DIFF
--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -63,6 +63,13 @@ export const generateCampaignContent = async ({ problema, solucao }) => {
     }
   }
 
+  const { titulo, title, conteudo, body, cta } = parsedContent;
+
+  if (!titulo && !title) {
+    console.error("Content generation response missing title:", parsedContent);
+    throw new Error("A resposta da IA para o conteúdo da campanha não continha um campo 'titulo' ou 'title'.");
+  }
+
   let hashtags = [];
   if (Array.isArray(parsedContent.hashtags)) {
     // If it's already an array, just trim and remove the '#' if present
@@ -76,9 +83,9 @@ export const generateCampaignContent = async ({ problema, solucao }) => {
   }
 
   return {
-    titulo: parsedContent.titulo || parsedContent.title || '',
-    conteudo: parsedContent.conteudo || parsedContent.body || '',
-    cta: parsedContent.cta || '',
+    titulo: titulo || title,
+    conteudo: conteudo || body || '',
+    cta: cta || '',
     hashtags: hashtags,
   };
 };


### PR DESCRIPTION
Adds validation to the `generateCampaignContent` function to ensure that the content generated by the AI includes a title.

If the AI response is missing a 'titulo' or 'title' field, the function now throws an error. This prevents the creation of "headless" campaign content, which was causing a downstream failure in the image generation step where the empty title was used as the theme for the image prompt.