### PR TITLE
Fix: Add includeFiles to vercel.json for serverless functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,13 @@
       "path": "/api/schedule",
       "schedule": "0 8-23 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "api/**/*.js": {
+      "includeFiles": [
+        "package.json",
+        "package-lock.json"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
The `/api/upload` serverless function was consistently failing with an `ERR_MODULE_NOT_FOUND` for the `@vercel/blob` package, despite the dependency being correctly listed in `package.json`.

This indicates an issue with the Vercel build process, where the necessary `node_modules` were not being included in the function's runtime environment.

To resolve this, this commit modifies `vercel.json` to add a `functions` configuration. It uses `includeFiles` to explicitly include `package.json` and `package-lock.json` in the build for all JavaScript serverless functions (`api/**/*.js`). This should ensure that Vercel's build system correctly installs all required dependencies for the functions at runtime.