### PR TITLE
Fix: Correct campaign saving and serverless function dependencies

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,10 +7,7 @@
   ],
   "functions": {
     "api/**/*.js": {
-      "includeFiles": [
-        "package.json",
-        "package-lock.json"
-      ]
+      "includeFiles": "package*.json"
     }
   }
 }


### PR DESCRIPTION
This commit resolves a multi-part issue that prevented campaigns with media assets from being saved.

1.  **Frontend Fix (`src/utils/campaignState.js`):** A `ReferenceError` was occurring during campaign serialization because image data was not being processed. This has been corrected, allowing the frontend to properly initiate the blob upload process.

2.  **Backend Fix (`vercel.json`):** The `/api/upload` serverless function was failing with an `ERR_MODULE_NOT_FOUND` for the `@vercel/blob` package. This was due to the dependency not being included in the function's runtime environment. The `vercel.json` file has been updated to use the `includeFiles` property, ensuring that the project's `package.json` and `package-lock.json` are included in the build. This should allow the Vercel build system to install the necessary dependencies for the function. The `includeFiles` value was also corrected to be a glob string (`"package*.json"`) to pass schema validation.