### PR TITLE
Refactor: Use environment variables for LinkedIn credentials

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -12,21 +12,11 @@ async function handleTokenExchange(request, response) {
     return response.status(400).json({ error: 'Missing code or redirectUri for token exchange.' });
   }
 
-  let clientId, clientSecret;
-  try {
-    const { rows } = await query('SELECT settings_data FROM settings WHERE user_id = $1', [userId]);
-    if (rows.length === 0 || !rows[0].settings_data.linkedin) {
-      return response.status(400).json({ error: 'LinkedIn credentials not configured for this user.' });
-    }
-    clientId = rows[0].settings_data.linkedin.clientId;
-    clientSecret = rows[0].settings_data.linkedin.clientSecret;
+  const clientId = process.env.LINKEDIN_CLIENT_ID;
+  const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
 
-    if (!clientId || !clientSecret) {
-      return response.status(400).json({ error: 'Incomplete LinkedIn credentials configured for this user.' });
-    }
-  } catch (dbError) {
-    console.error('Database error fetching LinkedIn credentials:', dbError);
-    return response.status(500).json({ error: 'Failed to retrieve user settings.' });
+  if (!clientId || !clientSecret) {
+    return response.status(400).json({ error: 'LinkedIn credentials not configured in environment variables.' });
   }
 
 
@@ -432,11 +422,12 @@ async function handleRefreshToken(request, response) {
         }
         const refreshToken = rows[0].linkedin_refresh_token;
 
-        const { rows: settingsRows } = await query('SELECT settings_data FROM settings WHERE user_id = $1', [userId]);
-        if (settingsRows.length === 0 || !settingsRows[0].settings_data.linkedin) {
-            return response.status(400).json({ error: 'LinkedIn credentials not configured for this user.' });
+        const clientId = process.env.LINKEDIN_CLIENT_ID;
+        const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
+
+        if (!clientId || !clientSecret) {
+            return response.status(400).json({ error: 'LinkedIn credentials not configured in environment variables.' });
         }
-        const { clientId, clientSecret } = settingsRows[0].settings_data.linkedin;
 
         const tokenUrl = 'https://www.linkedin.com/oauth/v2/accessToken';
         const params = new URLSearchParams({
@@ -520,6 +511,8 @@ const mainHandler = async (request, response) => {
         return handleFinalizeVideoUpload(request, response);
     case 'checkVideoStatus':
         return handleCheckVideoStatus(request, response);
+    case 'getClientId':
+        return response.status(200).json({ clientId: process.env.LINKEDIN_CLIENT_ID });
     default:
       return response.status(400).json({ error: `Invalid action specified: ${action}` });
   }

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -30,8 +30,28 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
   const [isDriveLoading, setIsDriveLoading] = useState(false);
   const [showInfobox, setShowInfobox] = useState(false);
   const [error, setError] = useState('');
+  const [clientId, setClientId] = useState('');
 
   const linkedinConfig = settings.linkedin || {};
+
+  useEffect(() => {
+    const fetchClientId = async () => {
+      try {
+        const response = await fetch('/api/linkedin-proxy', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'getClientId' }),
+        });
+        if (!response.ok) throw new Error('Falha ao buscar o Client ID do LinkedIn.');
+        const data = await response.json();
+        setClientId(data.clientId);
+      } catch (err) {
+        console.error("Erro ao buscar o Client ID do LinkedIn:", err);
+        setError('Não foi possível obter a configuração para a conexão com o LinkedIn.');
+      }
+    };
+    fetchClientId();
+  }, []);
 
   useEffect(() => {
     const fetchUserDetails = async (accessToken) => {
@@ -57,11 +77,10 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
     }
   }, [linkedinConfig.accessToken]);
 
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    const newLinkedinConfig = { ...linkedinConfig, [name]: value };
+  const handleFolderIdChange = (e) => {
+    const { value } = e.target;
+    const newLinkedinConfig = { ...linkedinConfig, folderId: value };
     updateSetting('linkedin', newLinkedinConfig);
-    if (error) setError('');
   };
 
   const handleSelectFolder = (folder) => {
@@ -79,15 +98,15 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
   };
 
   const handleConnect = async () => {
-    if (linkedinConfig.clientId?.trim()) {
+    if (clientId) {
       if (onBeforeRedirect) await onBeforeRedirect();
 
       const redirectUri = window.location.origin;
       const scope = encodeURIComponent('r_basicprofile w_member_social w_organization_social rw_organization_admin');
-      const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${linkedinConfig.clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
+      const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}`;
       window.location.href = authUrl;
     } else {
-      setError('Por favor, preencha o Client ID.');
+      setError('O Client ID do LinkedIn não está configurado no servidor.');
     }
   };
 
@@ -122,10 +141,11 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
   };
 
   const handleRemove = () => {
-    updateSetting('linkedin', { clientId: '', clientSecret: '', accessToken: null, expiry: null, folderId: '' });
+    const { folderId } = settings.linkedin || {};
+    updateSetting('linkedin', { accessToken: null, expiry: null, folderId: folderId || '' });
     sessionStorage.removeItem('linkedin_profiles_cache');
     setConnectedUser(null);
-    toast.info('Configuração do LinkedIn e conexão removidas.');
+    toast.info('Conexão com o LinkedIn removida.');
   };
 
   return (
@@ -152,7 +172,7 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
               name="folderId"
               label="ID da Pasta no Google Drive (Opcional)"
               value={linkedinConfig.folderId || ''}
-              onChange={handleChange}
+              onChange={handleFolderIdChange}
               fullWidth
               variant="outlined"
               placeholder="ID da pasta para a fila de publicação"
@@ -179,33 +199,8 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
           <Grid container spacing={2} sx={{ mt: 1 }}>
             <Grid item xs={12}>
               <Typography variant="body2" gutterBottom>
-                Insira suas credenciais do LinkedIn para conectar sua conta.
+                Clique no botão "Salvar e Conectar" para autorizar a aplicação a postar em seu nome.
               </Typography>
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                name="clientId"
-                label="Client ID"
-                value={linkedinConfig.clientId || ''}
-                onChange={handleChange}
-                fullWidth
-                required
-                variant="outlined"
-                placeholder="Seu Client ID do LinkedIn"
-              />
-            </Grid>
-            <Grid item xs={12}>
-              <TextField
-                name="clientSecret"
-                label="Client Secret"
-                type="password"
-                value={linkedinConfig.clientSecret || ''}
-                onChange={handleChange}
-                fullWidth
-                required
-                variant="outlined"
-                placeholder="Seu Client Secret do LinkedIn"
-              />
             </Grid>
           </Grid>
         )}


### PR DESCRIPTION
This commit refactors the LinkedIn integration to use environment variables for the `clientId` and `clientSecret`, instead of storing them in the user's settings.

Changes:
- The backend (`api/linkedin-proxy.js`) now reads `LINKEDIN_CLIENT_ID` and `LINKEDIN_CLIENT_SECRET` from `process.env`.
- A new API action `getClientId` has been added to provide the `clientId` to the frontend.
- The frontend (`src/components/LinkedinAuthSetup.jsx`) has been updated to remove the input fields for `clientId` and `clientSecret`. It now fetches the `clientId` from the backend.
- The logic for handling the connection and disconnection has been updated to reflect these changes.