### PR TITLE
Fix: Correctly display user name after LinkedIn connection

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -63,7 +63,9 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
         });
         if (!response.ok) throw new Error('Falha ao buscar detalhes do usuário.');
         const data = await response.json();
-        setConnectedUser(data);
+        const firstName = data.firstName?.localized?.pt_BR || data.firstName?.localized?.en_US;
+        const lastName = data.lastName?.localized?.pt_BR || data.lastName?.localized?.en_US;
+        setConnectedUser({ localizedFirstName: firstName, localizedLastName: lastName });
       } catch (err) {
         console.error("Erro ao buscar detalhes do usuário do LinkedIn:", err);
         setConnectedUser({ localizedFirstName: 'Usuário', localizedLastName: 'Desconhecido' });


### PR DESCRIPTION
This commit fixes a bug where the user's name was displayed as "undefined undefined" after a successful LinkedIn connection.

The `fetchUserDetails` function in `src/components/LinkedinAuthSetup.jsx` was not correctly parsing the user's name from the LinkedIn API response.

The fix involves:
- Updating the `fetchUserDetails` function to correctly extract the first and last names from the nested `localized` object in the API response.
- Setting the `connectedUser` state with the formatted name.