### PR TITLE
fix: Use useCallback to prevent stale state in image generation

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -313,7 +313,28 @@ function HomePage() {
   const handleCSVUpload = (event) => { const file = event.target.files[0]; parseCsvFile(file); };
   const handleDrop = (event) => { event.preventDefault(); event.stopPropagation(); const file = event.dataTransfer.files[0]; parseCsvFile(file); };
   const handleDragOver = (event) => { event.preventDefault(); event.stopPropagation(); };
-  const updateImageAndPalette = (imageUrl) => { setBackgroundImage(imageUrl); const img = new Image(); img.crossOrigin = 'Anonymous'; img.onload = () => { setOriginalImageSize({ width: img.width, height: img.height }); try { const colorThief = new ColorThief(); const palette = colorThief.getPalette(img, 5); setColorPalette(palette.map(rgb => `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`)); } catch (error) { console.error("Error extracting color palette:", error); setColorPalette([]); } }; img.onerror = (err) => { console.error("Error loading image to extract colors:", err); setBackgroundImage(null); setColorPalette([]); }; img.src = imageUrl; };
+  const updateImageAndPalette = useCallback((imageUrl) => {
+    setBackgroundImage(imageUrl);
+    const img = new Image();
+    img.crossOrigin = 'Anonymous';
+    img.onload = () => {
+      setOriginalImageSize({ width: img.width, height: img.height });
+      try {
+        const colorThief = new ColorThief();
+        const palette = colorThief.getPalette(img, 5);
+        setColorPalette(palette.map(rgb => `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`));
+      } catch (error) {
+        console.error("Error extracting color palette:", error);
+        setColorPalette([]);
+      }
+    };
+    img.onerror = (err) => {
+      console.error("Error loading image to extract colors:", err);
+      setBackgroundImage(null);
+      setColorPalette([]);
+    };
+    img.src = imageUrl;
+  }, []); // State setters are stable.
   const parseImageFile = async (file) => {
     if (!file) return;
 
@@ -412,7 +433,25 @@ function HomePage() {
       setIsGeneratingCampaign(false);
     }
   };
-  const handleGenerateImage = async (content = campaignContent) => { if (!content) { toast.error("Por favor, gere o conteúdo do texto primeiro."); return false; } setIsGeneratingImage(true); try { const imageUrl = await generateCampaignImage({ content, aspectRatio }); setGeneratedImageUrl(imageUrl); updateImageAndPalette(imageUrl); return true; } catch (imageError) { toast.error(`Ocorreu um erro ao gerar a imagem da campanha: ${imageError.message}`); setGeneratedImageUrl(null); return false; } finally { setIsGeneratingImage(false); } };
+  const handleGenerateImage = useCallback(async (content = campaignContent) => {
+    if (!content) {
+      toast.error("Por favor, gere o conteúdo do texto primeiro.");
+      return false;
+    }
+    setIsGeneratingImage(true);
+    try {
+      const imageUrl = await generateCampaignImage({ content, aspectRatio });
+      setGeneratedImageUrl(imageUrl);
+      updateImageAndPalette(imageUrl);
+      return true;
+    } catch (imageError) {
+      toast.error(`Ocorreu um erro ao gerar a imagem da campanha: ${imageError.message}`);
+      setGeneratedImageUrl(null);
+      return false;
+    } finally {
+      setIsGeneratingImage(false);
+    }
+  }, [campaignContent, aspectRatio, updateImageAndPalette]);
   const handleGenerateSummary = async (targetLength, content = campaignContent) => { if (!content?.conteudo) { alert("Por favor, gere o conteúdo principal primeiro."); return; } const setLoading = targetLength === 1800 ? setIsGeneratingSummaryMedio : setIsGeneratingSummaryPequeno; setLoading(true); if (!geminiAPI.isInitialized) { const apiKey = getGeminiApiKey(); if (!apiKey) { alert('Por favor, configure sua chave de API Gemini primeiro.'); setLoading(false); return; } geminiAPI.initialize(apiKey); } try { const summaryPrompt = `Resuma o seguinte texto para ter no máximo ${targetLength} caracteres, mantendo a essência e o tom: "${stripHtml(content.conteudo)}"`; const summary = await geminiAPI.generateContent(summaryPrompt); const fieldName = targetLength === 1800 ? 'conteudoMedio' : 'conteudoPequeno'; setCampaignContent(prev => ({ ...prev, [fieldName]: summary })); } catch (error) { alert(`Ocorreu um erro ao gerar o resumo. Verifique o console.`); } finally { setLoading(false); } };
   const handleGenerateFormattedContent = async (content = campaignContent) => { if (!content?.conteudo) { toast.error("Por favor, gere o conteúdo principal primeiro."); return; } setIsGeneratingConteudoFormatado(true); try { const finalContent = await generateFormattedContent({ content }); setCampaignContent(prev => ({ ...prev, conteudoFormatado: finalContent })); } catch (error) { toast.error(`Ocorreu um erro ao gerar o conteúdo formatado: ${error.message}`); } finally { setIsGeneratingConteudoFormatado(false); } };
   const handleGenerateFollowupPosts = async (content = campaignContent) => { if (!content?.conteudo) { toast.error("Por favor, gere o conteúdo principal primeiro."); return; } setIsGeneratingFollowup(true); try { const plan = await generateFollowupPlan({ content, followupPostsQuantity }); const posts = await generateFollowupPosts({ content, plan }); setFollowupPosts(posts); } catch (error) { toast.error(`Ocorreu um erro ao gerar os posts de follow-up: ${error.message}`); } finally { setIsGeneratingFollowup(false); } };


### PR DESCRIPTION
Refactors the `handleGenerateImage` function in `HomePage.jsx` to use the `useCallback` hook.

This change addresses a bug where the image generation prompt was created with an empty theme, even when the title was present in the UI state. This was likely caused by the event handler holding a stale reference to the `campaignContent` state.

By wrapping the function in `useCallback` with the correct dependencies (`campaignContent`, `aspectRatio`), we ensure that the function always has access to the most recent state when it is invoked, thus preventing the stale state bug. The `updateImageAndPalette` helper function was also wrapped in `useCallback` for stability.