### PR TITLE
feat: Add separate model selection for Gemini image generation

### DIFF
--- a/src/components/GeminiAuthSetup.jsx
+++ b/src/components/GeminiAuthSetup.jsx
@@ -15,7 +15,8 @@ const GeminiAuthSetup = () => {
   const [testResult, setTestResult] = useState(null);
 
   const apiKey = settings.gemini_api_key || '';
-  const selectedModel = settings.gemini_model || 'gemini-1.5-pro-latest';
+  const selectedModel = settings.gemini_model || 'gemini-1.5-pro';
+  const selectedImageModel = settings.gemini_image_model || 'imagen-3';
 
   const handleApiKeyChange = (e) => {
     updateSetting('gemini_api_key', e.target.value);
@@ -24,6 +25,10 @@ const GeminiAuthSetup = () => {
 
   const handleModelChange = (e) => {
     updateSetting('gemini_model', e.target.value);
+  };
+
+  const handleImageModelChange = (e) => {
+    updateSetting('gemini_image_model', e.target.value);
   };
 
   const handleRemove = () => {
@@ -106,9 +111,26 @@ const GeminiAuthSetup = () => {
                 label="Modelo Gemini"
                 onChange={handleModelChange}
             >
-                <MenuItem value="gemini-1.5-pro-latest">Gemini 1.5 Pro (latest)</MenuItem>
-                <MenuItem value="gemini-1.5-flash-latest">Gemini 1.5 Flash (latest)</MenuItem>
+                <MenuItem value="gemini-2.5-pro">Gemini 2.5 Pro</MenuItem>
+                <MenuItem value="gemini-2.5-flash">Gemini 2.5 Flash</MenuItem>
+                <MenuItem value="gemini-1.5-pro">Gemini 1.5 Pro</MenuItem>
+                <MenuItem value="gemini-1.5-flash">Gemini 1.5 Flash</MenuItem>
+                <MenuItem value="gemini-1.5-pro-preview-0514">Gemini 1.5 Pro (Preview 0514)</MenuItem>
                 <MenuItem value="gemini-1.0-pro">Gemini 1.0 Pro</MenuItem>
+            </Select>
+        </FormControl>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+            <InputLabel id="gemini-image-model-select-label">Modelo Gemini (imagem)</InputLabel>
+            <Select
+                labelId="gemini-image-model-select-label"
+                id="gemini-image-model-select"
+                value={selectedImageModel}
+                label="Modelo Gemini (imagem)"
+                onChange={handleImageModelChange}
+            >
+                <MenuItem value="imagen-3">Imagen 3</MenuItem>
+                <MenuItem value="gemini-2.0-flash-preview-image-generation">Gemini 2.0 Flash (Preview)</MenuItem>
             </Select>
         </FormControl>
 

--- a/src/utils/credentialsManager.js
+++ b/src/utils/credentialsManager.js
@@ -1,4 +1,4 @@
-import { getGeminiApiKey, saveGeminiApiKey } from './geminiCredentials';
+import { getGeminiApiKey, saveGeminiApiKey, saveGeminiModel, saveGeminiImageModel } from './geminiCredentials';
 import { getGoogleCloudTTSCredentials, saveGoogleCloudTTSCredentials } from './googleCloudTTSCredentials';
 import { getWordpressConfig, saveWordpressConfig } from './wordpressCredentials';
 import { getTimezone, saveTimezone } from './timezone';
@@ -12,6 +12,8 @@ const CREDENTIAL_KEYS = {
   // LINKEDIN: 'linkedinConfig', // This is now handled by SettingsContext
   WORDPRESS: 'wordpressConfig',
   TIMEZONE: 'user_timezone',
+  GEMINI_MODEL: 'gemini_model',
+  GEMINI_IMAGE_MODEL: 'gemini_image_model',
 };
 
 /**
@@ -82,6 +84,12 @@ export const applySettings = (settings) => {
   }
   if (settings[CREDENTIAL_KEYS.TIMEZONE]) {
     saveTimezone(settings[CREDENTIAL_KEYS.TIMEZONE]);
+  }
+  if (settings[CREDENTIAL_KEYS.GEMINI_MODEL]) {
+    saveGeminiModel(settings[CREDENTIAL_KEYS.GEMINI_MODEL]);
+  }
+  if (settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL]) {
+    saveGeminiImageModel(settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL]);
   }
 };
 

--- a/src/utils/geminiAPI.js
+++ b/src/utils/geminiAPI.js
@@ -1,4 +1,4 @@
-import { getGeminiModel } from './geminiCredentials';
+import { getGeminiModel, getGeminiImageModel } from './geminiCredentials';
 
 const GEMINI_API_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
 
@@ -36,7 +36,7 @@ class GeminiAPI {
       throw new Error('O prompt não pode ser vazio.');
     }
 
-    const model = getGeminiModel() || 'gemini-1.5-flash-latest';
+    const model = getGeminiModel() || 'gemini-1.5-pro';
     console.log(`[${purpose}] Iniciando chamada à API Gemini com o modelo ${model}.`);
     console.log(`[${purpose}] Prompt:`, promptString);
 
@@ -98,7 +98,7 @@ class GeminiAPI {
       throw new Error('O prompt não pode ser vazio.');
     }
 
-    const model = getGeminiModel() || 'gemini-1.5-flash-latest';
+    const model = getGeminiImageModel() || 'imagen-3';
     console.log(`[${purpose}] Iniciando chamada à API de Imagem Gemini com o modelo ${model}.`);
     console.log(`[${purpose}] Prompt:`, promptString);
 

--- a/src/utils/geminiCredentials.js
+++ b/src/utils/geminiCredentials.js
@@ -29,6 +29,37 @@ export const getGeminiApiKey = () => {
   }
 };
 
+const GEMINI_IMAGE_MODEL_STORAGE_KEY = 'gemini_image_model';
+
+/**
+ * Salva o modelo de imagem Gemini selecionado no localStorage.
+ * @param {string} model - O modelo a ser salvo.
+ */
+export const saveGeminiImageModel = (model) => {
+    if (typeof model !== 'string' || model.trim() === '') {
+        console.error('Modelo de imagem Gemini inválido fornecido para salvar.');
+        return;
+    }
+    try {
+        localStorage.setItem(GEMINI_IMAGE_MODEL_STORAGE_KEY, model);
+    } catch (error) {
+        console.error('Erro ao salvar o modelo de imagem Gemini no localStorage:', error);
+    }
+};
+
+/**
+ * Recupera o modelo de imagem Gemini selecionado do localStorage.
+ * @returns {string | null} O modelo ou null se não estiver definido.
+ */
+export const getGeminiImageModel = () => {
+    try {
+        return localStorage.getItem(GEMINI_IMAGE_MODEL_STORAGE_KEY);
+    } catch (error) {
+        console.error('Erro ao recuperar o modelo de imagem Gemini do localStorage:', error);
+        return null;
+    }
+};
+
 /**
  * Remove a chave da API Gemini do localStorage.
  */


### PR DESCRIPTION
This commit introduces a new feature that allows users to select a separate model for Gemini image generation, distinct from the model used for text generation.

Key changes:
- The Gemini settings UI in `GeminiAuthSetup.jsx` now includes two dropdown menus: one for text models and a new one for image models.
- The list of available models for both text and images has been updated to the latest options.
- The application's persistence logic has been updated to correctly save and load the new `gemini_image_model` setting.
- The `geminiAPI.js` utility has been modified to use the appropriate model based on whether the task is text generation or image generation.
- No database schema changes were necessary, as the existing `JSONB` column for settings is flexible enough to accommodate the new field.