### PR TITLE
fix: Correct Gemini image generation API call

### DIFF
--- a/src/utils/geminiAPI.js
+++ b/src/utils/geminiAPI.js
@@ -116,6 +116,10 @@ class GeminiAPI {
               text: promptString
             }]
           }],
+          generationConfig: {
+            responseMimeType: "application/json",
+            responseModalities: ["TEXT", "IMAGE"]
+          },
           safetySettings: [
             {
               category: 'HARM_CATEGORY_HARASSMENT',


### PR DESCRIPTION
This commit fixes a bug where image generation was failing after the recent update to use dedicated image models.

The root cause was that the API call to the new image models was missing the required `generationConfig` object in the request body. The Gemini API for these models requires a `responseModalities` field to be specified.

This fix adds the `generationConfig` to the `generateImage` function in `geminiAPI.js`, ensuring that the API call is now compliant with the documentation and that image generation works as expected.