### PR TITLE
fix: Correct image model to fix 404 error

### DIFF
--- a/src/components/GeminiAuthSetup.jsx
+++ b/src/components/GeminiAuthSetup.jsx
@@ -16,7 +16,7 @@ const GeminiAuthSetup = () => {
 
   const apiKey = settings.gemini_api_key || '';
   const selectedModel = settings.gemini_model || 'gemini-1.5-pro';
-  const selectedImageModel = settings.gemini_image_model || 'imagen-3';
+  const selectedImageModel = settings.gemini_image_model || 'gemini-2.0-flash-preview-image-generation';
 
   const handleApiKeyChange = (e) => {
     updateSetting('gemini_api_key', e.target.value);
@@ -129,7 +129,6 @@ const GeminiAuthSetup = () => {
                 label="Modelo Gemini (imagem)"
                 onChange={handleImageModelChange}
             >
-                <MenuItem value="imagen-3">Imagen 3</MenuItem>
                 <MenuItem value="gemini-2.0-flash-preview-image-generation">Gemini 2.0 Flash (Preview)</MenuItem>
             </Select>
         </FormControl>

--- a/src/utils/geminiAPI.js
+++ b/src/utils/geminiAPI.js
@@ -98,7 +98,7 @@ class GeminiAPI {
       throw new Error('O prompt não pode ser vazio.');
     }
 
-    const model = getGeminiImageModel() || 'imagen-3';
+    const model = getGeminiImageModel() || 'gemini-2.0-flash-preview-image-generation';
     console.log(`[${purpose}] Iniciando chamada à API de Imagem Gemini com o modelo ${model}.`);
     console.log(`[${purpose}] Prompt:`, promptString);
 


### PR DESCRIPTION
This commit resolves a bug that caused a 404 Not Found error during image generation.

The root cause was that the `imagen-3` model is not available through the Gemini API endpoint (`generativelanguage.googleapis.com`) used by this application. It is likely a Vertex AI model and requires a different integration.

This fix addresses the issue by:
1. Removing the `imagen-3` option from the image model selection UI.
2. Updating the default image model and API fallback to the correct, available model: `gemini-2.0-flash-preview-image-generation`.

This ensures that all image generation requests are sent to a valid model, resolving the 404 error.