### PR TITLE
fix: Update @vercel/blob import path

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,4 +1,4 @@
-import { handleUpload } from '@vercel/blob/server';
+import { handleUpload } from '@vercel/blob';
 import { withAuth } from './middleware/auth.js';
 
 const handler = async (req, res) => {


### PR DESCRIPTION
This commit corrects the import path for the `handleUpload` function from the `@vercel/blob` library.

The previous import path, `@vercel/blob/server`, is deprecated or has been removed in a recent version of the library, which caused a `Cannot find module` error on the server.

This has been updated to the correct import path, `import { handleUpload } from '@vercel/blob';`, which should resolve the 500 error on the `/api/upload` endpoint.