### PR TITLE
fix: Add validation for saved image model setting

### DIFF
--- a/src/utils/credentialsManager.js
+++ b/src/utils/credentialsManager.js
@@ -89,7 +89,13 @@ export const applySettings = (settings) => {
     saveGeminiModel(settings[CREDENTIAL_KEYS.GEMINI_MODEL]);
   }
   if (settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL]) {
-    saveGeminiImageModel(settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL]);
+    const validImageModels = ['gemini-2.0-flash-preview-image-generation'];
+    if (validImageModels.includes(settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL])) {
+      saveGeminiImageModel(settings[CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL]);
+    } else {
+      // If the saved model is invalid (e.g., old 'imagen-3'), save the default valid one.
+      saveGeminiImageModel('gemini-2.0-flash-preview-image-generation');
+    }
   }
 };
 


### PR DESCRIPTION
This commit makes the application more robust by adding a validation step when loading user settings from the database.

Previously, if a user had an old, invalid image model name (e.g., 'imagen-3') saved in their settings, the application would still try to use it, causing a 404 error, even after the UI was updated.

This fix addresses the issue by:
1.  In `credentialsManager.js`, when applying settings, the code now checks if the `gemini_image_model` is a valid, available model.
2.  If the saved model is invalid, it is automatically corrected to the current valid default model (`gemini-2.0-flash-preview-image-generation`).

This ensures that the application can gracefully handle and self-correct stale or invalid data, preventing the image generation error from recurring.