### PR TITLE
fix: Corrigido TypeError em /api/upload

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,14 +1,34 @@
-import { handleUpload } from '@vercel/blob';
+import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from './middleware/auth.js';
+
+// Helper to parse the body for Vercel Serverless Functions
+async function parseJson(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
 
 const handler = async (req, res) => {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
 
-  const body = await req.json();
-
   try {
+    const body = await parseJson(req);
+
     const jsonResponse = await handleUpload({
       body,
       request: req,


### PR DESCRIPTION
A função de upload em `/api/upload` estava tentando usar `req.json()`, que não é uma função disponível no ambiente de serverless functions da Vercel para requisições do tipo `http.IncomingMessage`. Isso causava um `TypeError` e retornava um erro 500.

Esta correção introduz uma função auxiliar `parseJson` para ler e analisar o corpo da requisição a partir do stream, que é a maneira correta de lidar com requisições POST em um ambiente Node.js puro.

Adicionalmente, a importação de `handleUpload` foi corrigida para `@vercel/blob/client` para alinhar com a documentação de uploads do lado do cliente.