### PR TITLE
fix: Reorder hooks in Publisher to prevent ReferenceError

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -103,6 +103,16 @@ const Publisher = ({
   const [viewingSchedule, setViewingSchedule] = useState(null);
   const [editingSchedule, setEditingSchedule] = useState(null);
   const [isUpdating, setIsUpdating] = useState(false);
+  // Local states for Publisher component
+  const [linkedinProfiles, setLinkedinProfiles] = useState({ personal: null, organizations: [] });
+  const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
+  const [profileError, setProfileError] = useState('');
+  const [selectedTarget, setSelectedTarget] = useState(null);
+  const [publishResults, setPublishResults] = useState([]);
+  const [content, setContent] = useState(''); // Assuming campaignContent will be mapped to this
+  const [unifiedMedia, setUnifiedMedia] = useState([]);
+  const [previewedMedia, setPreviewedMedia] = useState(null);
+  const [schedulePreview, setSchedulePreview] = useState([]);
 
   const fetchSchedules = React.useCallback(async () => {
     if (tabValue === 2 && selectedTarget) {
@@ -192,16 +202,6 @@ const Publisher = ({
   const [publishingStatusLi, setPublishingStatusLi] = useState('');
   const [publishedPostUrlLi, setPublishedPostUrlLi] = useState(null);
 
-  // Local states for Publisher component
-  const [linkedinProfiles, setLinkedinProfiles] = useState({ personal: null, organizations: [] });
-  const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
-  const [profileError, setProfileError] = useState('');
-  const [selectedTarget, setSelectedTarget] = useState(null);
-  const [publishResults, setPublishResults] = useState([]);
-  const [content, setContent] = useState(''); // Assuming campaignContent will be mapped to this
-  const [unifiedMedia, setUnifiedMedia] = useState([]);
-  const [previewedMedia, setPreviewedMedia] = useState(null);
-  const [schedulePreview, setSchedulePreview] = useState([]);
   const { googleAccessToken } = useUserAuth();
 
     // Map campaign content to a simple text state for the publisher


### PR DESCRIPTION
This commit fixes a `ReferenceError: Cannot access 'X' before initialization` that occurred in the Publisher component.

The error was caused by a temporal dead zone issue. The `fetchSchedules` `useCallback` hook depended on the `selectedTarget` state variable, but the `useState` declaration for `selectedTarget` was located after the `useCallback` declaration in the component body.

This commit resolves the error by moving the `useState` declarations for the component's local state (including `selectedTarget`) to the top of the component, ensuring they are initialized before any other hooks attempt to access them.