### PR TITLE
fix: Remove unsupported parameter from image generation call

### DIFF
--- a/src/utils/geminiAPI.js
+++ b/src/utils/geminiAPI.js
@@ -117,7 +117,6 @@ class GeminiAPI {
             }]
           }],
           generationConfig: {
-            responseMimeType: "application/json",
             responseModalities: ["TEXT", "IMAGE"]
           },
           safetySettings: [


### PR DESCRIPTION
This commit fixes a `400 Bad Request` error that occurred during Gemini image generation.

The error was caused by including the `responseMimeType` parameter in the `generationConfig` of the API request. This parameter, while valid for some Gemini API calls, appears to be unsupported for the `gemini-2.0-flash-preview-image-generation` model endpoint, leading to a malformed request error.

This commit removes the extraneous `responseMimeType` parameter, leaving only the essential `responseModalities` field. This aligns with the specific requirements for this model and should resolve the 400 error.