### PR TITLE
fix: Corrigidos erros de TypeError e Módulo não encontrado na API de …

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
       "path": "/api/schedule",
       "schedule": "0 8-23 * * *"
     }
-  ]
+  ],
+  "functions": {
+    "api/upload.js": {
+      "includeFiles": "api/node_modules/@vercel/blob/**"
+    }
+  }
 }


### PR DESCRIPTION
…upload

Este commit corrige dois problemas na função de upload em `/api/upload`:

1.  Um `TypeError: req.json is not a function` foi resolvido substituindo a chamada `req.json()` por uma função auxiliar que analisa o corpo da requisição a partir do stream do Node.js.

2.  Um erro subsequente `Cannot find module '@vercel/blob/dist/client.cjs'` foi resolvido atualizando o arquivo `vercel.json` para incluir explicitamente os arquivos do pacote `@vercel/blob` no bundle da função serverless. A importação em `api/upload.js` também foi ajustada para usar `@vercel/blob/client`, conforme a documentação.

Essas duas alterações juntas devem resolver completamente os problemas de upload de arquivos.