### PR TITLE
fix: Pass campaign content to image generation handler

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -522,7 +522,7 @@ const Campaign = ({
                                 <Box>
                                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2 }}>
                                         <Typography variant="h6" gutterBottom>Imagem Gerada</Typography>
-                                        <Button onClick={handleGenerateImage} disabled={isGeneratingImage} startIcon={<GeminiIcon />}>
+                                        <Button onClick={() => handleGenerateImage(campaignContent)} disabled={isGeneratingImage} startIcon={<GeminiIcon />}>
                                             {isGeneratingImage ? 'Gerando...' : 'Regerar Imagem'}
                                         </Button>
                                     </Box>
@@ -540,7 +540,7 @@ const Campaign = ({
                                     <Button
                                         variant="contained"
                                         color="secondary"
-                                        onClick={handleGenerateImage}
+                                        onClick={() => handleGenerateImage(campaignContent)}
                                         startIcon={<ImageIcon />}
                                         disabled={isGeneratingImage}
                                     >
@@ -557,7 +557,7 @@ const Campaign = ({
                                         variant="contained"
                                         color="secondary"
                                         size="large"
-                                        onClick={() => handleGenerateImage()}
+                                        onClick={() => handleGenerateImage(campaignContent)}
                                         disabled={isGeneratingImage}
                                         startIcon={<ImageIcon />}
                                     >


### PR DESCRIPTION
This commit fixes a bug where the image generation prompt was created with an empty theme because it was using a stale campaign title.

The root cause was a stale state issue. The `handleGenerateImage` function was being called from the UI without arguments, forcing it to rely on a `useRef` in its parent component. This ref was not always up-to-date with the latest user edits to the campaign title before the function was called.

The fix modifies the `onClick` handlers in the `Campaign.jsx` component to explicitly pass the current `campaignContent` object to the `handleGenerateImage` function. This ensures the function always receives the latest state, resolving the bug and ensuring the correct title is used in the image prompt.