### PR TITLE
fix: Corrige múltiplos erros de upload e carregamento de campanha

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -5,24 +5,32 @@ import { toast } from 'sonner';
 
 // Helper to upload a blob-like asset to Vercel Blob storage.
 const uploadAsset = async (asset, filename) => {
-  if (!asset) return null;
+  if (!asset) {
+    return null;
+  }
+
+  // If it's already a permanent http(s) URL, do nothing.
+  if (typeof asset === 'string' && asset.startsWith('http')) {
+    return asset;
+  }
 
   let fileToUpload;
-  if (typeof asset === 'string' && (asset.startsWith('blob:') || asset.startsWith('data:'))) {
+  if (asset instanceof Blob) {
+    // Asset is already a blob (e.g. from an input field).
+    fileToUpload = asset;
+  } else if (typeof asset === 'string' && (asset.startsWith('blob:') || asset.startsWith('data:'))) {
+    // Asset is a temporary client-side URL. Fetch it and convert to a File.
     const response = await fetch(asset);
     const blob = await response.blob();
     fileToUpload = new File([blob], filename, { type: blob.type });
-  } else if (asset instanceof Blob) {
-    fileToUpload = asset;
-  } else if (typeof asset === 'string' && asset.startsWith('http')) {
-    // It's likely already a public URL, so we don't need to re-upload.
-    return asset;
-  } else if (typeof asset === 'string') {
-    // Could be an invalid string or something else, treat as non-uploadable
-    return asset;
+  } else {
+    // If it's any other type of string or an unsupported type, we don't upload.
+    // This prevents saving invalid data.
+    console.warn(`Unsupported asset type for upload: ${typeof asset}`, asset);
+    return asset; // Return the original asset to avoid breaking the state shape.
   }
-   else {
-    // Unsupported asset type
+
+  if (!fileToUpload) {
     return null;
   }
 

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -44,7 +44,8 @@ export const composeImage = async (
   });
   try {
     let backgroundSrc = backgroundImageUrl;
-    if (!backgroundImageUrl.startsWith('data:') && !backgroundImageUrl.startsWith('http')) {
+    // A blob: URL is a valid source, so we should not treat it as a base64 string.
+    if (!backgroundImageUrl.startsWith('data:') && !backgroundImageUrl.startsWith('http') && !backgroundImageUrl.startsWith('blob:')) {
       backgroundSrc = `data:image/png;base64,${backgroundImageUrl}`;
     }
 


### PR DESCRIPTION
Este commit aborda uma série de problemas relacionados ao upload de arquivos e ao ciclo de salvar/carregar campanhas.

As seguintes correções foram implementadas:

1.  **Erro de `TypeError` no Backend (`api/upload.js`):**
    - A chamada `req.json()`, que não é válida no ambiente de serverless functions da Vercel, foi substituída por uma função auxiliar que analisa manualmente o corpo da requisição.

2.  **Erro de `Cannot find module` no Backend (`vercel.json`):**
    - A importação de `@vercel/blob/client` não estava sendo incluída no bundle da função. O arquivo `vercel.json` foi atualizado para forçar a inclusão de todo o pacote `@vercel/blob`, resolvendo o erro de build.

3.  **Erro de `net::ERR_INVALID_URL` no Frontend (`src/utils/imageComposer.js`):**
    - Uma verificação foi adicionada para que URLs do tipo `blob:` não sejam tratadas incorretamente como strings base64, o que causava a criação de URLs inválidas.

4.  **Causa Raiz do Erro de URL Inválida (`src/utils/campaignState.js`):**
    - A lógica de serialização da campanha foi refatorada. A função `uploadAsset` agora garante que URLs temporárias (`blob:` ou `data:`) sejam sempre enviadas para o Vercel Blob Store e que apenas a URL permanente retornada seja salva no banco de dados. Isso impede que URLs inválidas sejam persistidas.

Essas alterações, em conjunto, devem estabilizar o fluxo de upload de mídias e o salvamento e carregamento de campanhas.