### PR TITLE
refactor: Remove target audience from image generation prompt

### DIFF
--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -103,8 +103,7 @@ export const generateCampaignImage = async ({ content, aspectRatio }) => {
   }
   geminiAPI.initialize(apiKey);
 
-  const { persona, autor, colors } = getCampaignPrompt();
-  const personaString = formatObjectForPrompt(persona, ['description']);
+  const { autor, colors } = getCampaignPrompt();
   const autorString = formatObjectForPrompt(autor);
 
   const colorPalettePrompt = colors && colors.length > 0
@@ -115,7 +114,6 @@ export const generateCampaignImage = async ({ content, aspectRatio }) => {
   const imagePrompt = `
     Crie uma imagem de fundo para um post de rede social.
     O tema é: "${stripHtml(content.titulo)}".
-    O público-alvo é: ${personaString}.
     O estilo deve ser consistente com a marca: ${autorString}.
     ${colorPalettePrompt}
     A imagem deve ser puramente visual, conceitual ou abstrata, e não deve conter nenhum texto, letras ou números.


### PR DESCRIPTION
This commit refactors the `generateCampaignImage` function to remove the target audience (`público-alvo`) information from the prompt sent to the Gemini API for image generation.

This change was requested by the user to simplify the prompt and potentially improve the quality or relevance of the generated images by focusing only on the core theme and brand style.

The `persona` and `personaString` variables, which were used to format this information, have also been removed from the function as they are no longer needed.