### PR TITLE
fix: Update deprecated LinkedIn organizationAcls endpoint

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -354,7 +354,7 @@ async function handleGetProfiles(request, response) {
   try {
     const [personalResponse, orgAclsResponse] = await Promise.all([
       fetch('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))', { headers }),
-      fetch('https://api.linkedin.com/v2/organizationAcls?q=roleAssignee', { headers })
+      fetch('https://api.linkedin.com/rest/organizationAcls?q=roleAssignee', { headers })
     ]);
 
     if (!personalResponse.ok) {


### PR DESCRIPTION
The LinkedIn API endpoint for fetching organization ACLs has been updated from the deprecated v2 endpoint to the current REST endpoint.

This change is necessary to ensure that the application can continue to fetch the list of organizations a user has access to, which is a prerequisite for listing the profiles and pages they can publish to.