### PR TITLE
fix: Corrige múltiplos erros de upload e carregamento de campanha

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -108,13 +108,13 @@ export const serializeCampaignData = async (state, setProgress) => {
 
     let newBackgroundImageUrl = state.backgroundImage;
     if (state.backgroundImage && (state.backgroundImage.startsWith('blob:') || state.backgroundImage.startsWith('data:'))) {
-      newBackgroundImageUrl = await uploadAsset(state.backgroundImage, 'background_image');
+      newBackgroundImageUrl = await uploadAsset(state.backgroundImage, 'background_image.png');
       updateProgress();
     }
 
     let newGeneratedImageUrl = state.generatedImageUrl;
     if (state.generatedImageUrl && (state.generatedImageUrl.startsWith('blob:') || state.generatedImageUrl.startsWith('data:'))) {
-      newGeneratedImageUrl = await uploadAsset(state.generatedImageUrl, 'generated_campaign_image');
+      newGeneratedImageUrl = await uploadAsset(state.generatedImageUrl, 'generated_campaign_image.png');
       updateProgress();
     }
 


### PR DESCRIPTION
Este commit aborda uma série de problemas relacionados ao upload de arquivos e ao ciclo de salvar/carregar campanhas.

As seguintes correções foram implementadas:

1.  **Erro de `TypeError` no Backend (`api/upload.js`):**
    - A chamada `req.json()`, que não é válida no ambiente de serverless functions da Vercel, foi substituída por uma função auxiliar que analisa manualmente o corpo da requisição.

2.  **Erro de `Cannot find module` no Backend (`vercel.json`):**
    - A importação de `@vercel/blob/client` não estava sendo incluída no bundle da função. O arquivo `vercel.json` foi atualizado para forçar a inclusão de todo o pacote `@vercel/blob`, resolvendo o erro de build.

3.  **Erro de `net::ERR_INVALID_URL` no Frontend (`src/utils/imageComposer.js`):**
    - Uma verificação foi adicionada para que URLs do tipo `blob:` não sejam tratadas incorretamente como strings base64, o que causava a criação de URLs inválidas.

4.  **Causa Raiz do Erro de URL Inválida (`src/utils/campaignState.js`):**
    - A lógica de serialização da campanha foi refatorada. A função `uploadAsset` agora garante que URLs temporárias (`blob:` ou `data:`) sejam sempre enviadas para o Vercel Blob Store e que apenas a URL permanente retornada seja salva no banco de dados.

5.  **Erro de `400 Bad Request` no Upload (`src/utils/campaignState.js`):**
    - A função `uploadAsset` foi ajustada para garantir que um objeto `File` (com nome e tipo) seja sempre criado a partir de um `Blob` antes do upload.
    - O nome do arquivo (`pathname`) enviado para a API de upload agora inclui uma extensão `.png`, que é provavelmente exigida pela API da Vercel.

Essas alterações, em conjunto, devem estabilizar o fluxo de upload de mídias e o salvamento e carregamento de campanhas.