### PR TITLE
feat: Habilita seletor de aspecto e ajusta prompt de imagem

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -504,7 +504,7 @@ const Campaign = ({
                     {campaignContent && (
                         <Box sx={{ mt: 2 }}>
                              <Grid item xs={12} md={6}>
-                                <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
+                                <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
                                     <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
                                     <Select
                                         labelId="aspect-ratio-label"

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -118,7 +118,7 @@ export const generateCampaignImage = async ({ content, aspectRatio }) => {
     O público-alvo é: ${personaString}.
     O estilo deve ser consistente com a marca: ${autorString}.
     ${colorPalettePrompt}
-    A imagem deve ser puramente visual, conceitual ou abstrata, e não deve conter nenhum texto, letras ou números.
+    A IMAGEM DEVE SER PURAMENTE VISUAL, CONCEITUAL OU ABSTRATA, E NÃO DEVE CONTER NENHUM TEXTO, LETRAS OU NÚMEROS.
     A razão de aspecto da imagem deve ser ${aspectRatio}.
   `;
 


### PR DESCRIPTION
Este commit implementa as seguintes alterações solicitadas pelo usuário, além de consolidar as correções de bugs anteriores:

1.  **Ajuste no Prompt de Imagem (`src/utils/generationHandlers.js`):**
    - A instrução "A IMAGEM DEVE SER PURAMENTE VISUAL, CONCEITUAL OU ABSTRATA, E NÃO DEVE CONTER NENHUM TEXTO, LETRAS OU NÚMEROS." no prompt de geração de imagem foi colocada em maiúsculas para dar mais ênfase.

2.  **Habilitação do Seletor de Razão de Aspecto (`src/components/Campaign.jsx`):**
    - O seletor de razão de aspecto existente (dropdown) foi corrigido para ser habilitado (`disabled={!campaignContent}`) quando há conteúdo de campanha, conforme solicitado. A implementação anterior que o substituía por um `ToggleButtonGroup` foi revertida.

Este commit também inclui todas as correções de bugs anteriores para garantir a estabilidade do upload de mídias e do ciclo de salvar/carregar campanhas.