### PR TITLE
fix: Reverte modelo de geração de imagem para o valor original

### DIFF
--- a/src/utils/geminiAPI.js
+++ b/src/utils/geminiAPI.js
@@ -98,7 +98,7 @@ class GeminiAPI {
       throw new Error('O prompt não pode ser vazio.');
     }
 
-    const model = getGeminiImageModel() || 'gemini-pro-vision';
+    const model = getGeminiImageModel() || 'gemini-2.0-flash-preview-image-generation';
     console.log(`[${purpose}] Iniciando chamada à API de Imagem Gemini com o modelo ${model}.`);
     console.log(`[${purpose}] Prompt:`, promptString);
 


### PR DESCRIPTION
Reverte a alteração do modelo de geração de imagem da API Gemini de volta para `gemini-2.0-flash-preview-image-generation`, conforme solicitado pelo usuário.

Esta alteração desfaz a modificação anterior que havia introduzido o `gemini-pro-vision` como uma correção para um erro `400 Bad Request`. A reversão foi solicitada pelo usuário, que confirmou que o modelo original é o correto para a aplicação.