### PR TITLE
fix(googleApi): Prevent crash on token refresh

### DIFF
--- a/src/utils/googleApi.js
+++ b/src/utils/googleApi.js
@@ -30,6 +30,9 @@ const fetchWithRefresh = async (url, options, accessToken, setAccessToken) => {
 
             // Retry the original request with the new token
             const newOptions = { ...options };
+            if (!newOptions.headers) {
+                newOptions.headers = {};
+            }
             newOptions.headers['Authorization'] = `Bearer ${newAccessToken}`;
 
             console.log('Retrying request with new token...');


### PR DESCRIPTION
When a Google API call was made with an expired token and without any headers, the `fetchWithRefresh` function would crash when trying to set the `Authorization` header on an undefined `headers` object.

This commit adds a check to ensure that `newOptions.headers` is initialized as an object if it doesn't exist before setting the `Authorization` header, thus preventing the application from crashing and allowing the token refresh mechanism to work as expected.