### PR TITLE
feat(auth): Add global 401 handling to redirect to login

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -2,6 +2,7 @@
 // and communicating with the campaign API endpoints.
 import { upload } from '@vercel/blob/client';
 import { toast } from 'sonner';
+import fetchWithAuth from './fetchWithAuth';
 
 // Helper to upload a blob-like asset to Vercel Blob storage.
 const uploadAsset = async (asset, filename, campaignId) => {
@@ -221,7 +222,7 @@ export const deserializeCampaignData = async (loadedState) => {
 // --- API Functions ---
 
 export const getCampaigns = async () => {
-  const res = await fetch('/api/campaigns');
+  const res = await fetchWithAuth('/api/campaigns');
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || 'Failed to fetch campaigns.');
@@ -230,7 +231,7 @@ export const getCampaigns = async () => {
 };
 
 export const loadCampaign = async (id) => {
-  const res = await fetch(`/api/campaigns/${id}`);
+  const res = await fetchWithAuth(`/api/campaigns/${id}`);
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || 'Failed to load campaign.');
@@ -265,7 +266,7 @@ export const saveCampaign = async (name, campaignState, setProgress) => {
   const initialState = cleanStateForInitialSave(campaignState);
 
   // 2. Make the initial request to create the campaign entry.
-  const createRes = await fetch('/api/campaigns', {
+  const createRes = await fetchWithAuth('/api/campaigns', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, campaign_data: initialState }),
@@ -282,7 +283,7 @@ export const saveCampaign = async (name, campaignState, setProgress) => {
   const finalSerializableData = await serializeCampaignData(campaignState, campaignId, setProgress);
 
   // 4. Update the campaign with the final data including asset URLs.
-  const updateRes = await fetch(`/api/campaigns/${campaignId}`, {
+  const updateRes = await fetchWithAuth(`/api/campaigns/${campaignId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, campaign_data: finalSerializableData }),
@@ -302,7 +303,7 @@ export const updateCampaign = async (id, name, campaignState, setProgress) => {
   // For an existing campaign, we already have the ID.
   // We can directly serialize the data, which will upload any new/changed assets.
   const serializableData = await serializeCampaignData(campaignState, id, setProgress);
-  const res = await fetch(`/api/campaigns/${id}`, {
+  const res = await fetchWithAuth(`/api/campaigns/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, campaign_data: serializableData }),
@@ -315,7 +316,7 @@ export const updateCampaign = async (id, name, campaignState, setProgress) => {
 };
 
 export const deleteCampaign = async (id) => {
-  const res = await fetch(`/api/campaigns/${id}`, { method: 'DELETE' });
+  const res = await fetchWithAuth(`/api/campaigns/${id}`, { method: 'DELETE' });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || 'Failed to delete campaign.');

--- a/src/utils/fetchWithAuth.js
+++ b/src/utils/fetchWithAuth.js
@@ -1,0 +1,16 @@
+const fetchWithAuth = async (url, options = {}) => {
+  const response = await fetch(url, options);
+
+  if (response.status === 401) {
+    // Unauthorized. Redirect to login page.
+    // You might want to clear any stored user data here as well.
+    // Adding a query parameter to show a message on the login page.
+    window.location.href = '/login?session_expired=true';
+    // Throw an error to prevent further processing in the original call stack.
+    throw new Error('Session expired. Redirecting to login.');
+  }
+
+  return response;
+};
+
+export default fetchWithAuth;


### PR DESCRIPTION
When the user's session (JWT) expires, API calls fail with a 401 Unauthorized error. The application was not handling this gracefully, leading to confusing errors and a poor user experience. This was particularly noticeable during file uploads when saving a campaign.

This commit introduces a `fetchWithAuth` utility, a wrapper around the native `fetch` function. This wrapper intercepts any 401 responses from the API and automatically redirects the user to the login page. This ensures that session expirations are handled consistently across the application.

All relevant API calls in `src/utils/campaignState.js` have been refactored to use this new utility.