### PR TITLE
feat(debug): Add logging and UI lock to save campaign flow

### DIFF
--- a/src/components/SaveCampaignModal.jsx
+++ b/src/components/SaveCampaignModal.jsx
@@ -9,7 +9,7 @@ import {
   Typography
 } from '@mui/material';
 
-const SaveCampaignModal = ({ open, onClose, onSave, campaignToEdit = null }) => {
+const SaveCampaignModal = ({ open, onClose, onSave, campaignToEdit = null, isSaving }) => {
   const [name, setName] = useState('');
 
   useEffect(() => {
@@ -21,7 +21,7 @@ const SaveCampaignModal = ({ open, onClose, onSave, campaignToEdit = null }) => 
   }, [campaignToEdit, open]);
 
   const handleSave = () => {
-    if (name.trim()) {
+    if (name.trim() && !isSaving) {
       onSave(name.trim());
       onClose();
     }
@@ -48,12 +48,13 @@ const SaveCampaignModal = ({ open, onClose, onSave, campaignToEdit = null }) => 
           value={name}
           onChange={(e) => setName(e.target.value)}
           onKeyPress={(e) => e.key === 'Enter' && handleSave()}
+          disabled={isSaving}
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={handleSave} disabled={!name.trim()} variant="contained">
-          {campaignToEdit ? 'Rename' : 'Save'}
+        <Button onClick={onClose} disabled={isSaving}>Cancel</Button>
+        <Button onClick={handleSave} disabled={!name.trim() || isSaving} variant="contained">
+          {isSaving ? 'Saving...' : (campaignToEdit ? 'Rename' : 'Save')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -185,29 +185,40 @@ function HomePage() {
   };
 
   const handleSaveCampaign = async (name) => {
+    console.log('[handleSaveCampaign] Starting...');
     try {
+      console.log('[handleSaveCampaign] Checking auth status...');
       await checkAuthStatus();
+      console.log('[handleSaveCampaign] Auth check successful.');
     } catch (error) {
+      console.error('[handleSaveCampaign] Auth check failed:', error.message);
       toast.error(error.message);
       return;
     }
 
+    console.log('[handleSaveCampaign] Proceeding with save...');
     const appState = getAppState();
     setIsSaving(true);
     setUploadProgress({ current: 0, total: 0 });
     try {
       if (currentCampaign) {
+        console.log(`[handleSaveCampaign] Updating campaign: ${currentCampaign.id}`);
         const updated = await updateCampaign(currentCampaign.id, name, appState, setUploadProgress);
         toast.success(`Campaign "${name}" updated.`);
         setCurrentCampaign(updated);
+        console.log(`[handleSaveCampaign] Campaign updated successfully.`);
       } else {
+        console.log(`[handleSaveCampaign] Saving new campaign: ${name}`);
         const newCampaign = await saveCampaign(name, appState, setUploadProgress);
         toast.success(`Campaign "${name}" saved.`);
         setCurrentCampaign(newCampaign);
+        console.log(`[handleSaveCampaign] New campaign saved successfully.`);
       }
     } catch (err) {
+      console.error('[handleSaveCampaign] Error during save/update:', err);
       // Errors from save/update are already toasted.
     } finally {
+      console.log('[handleSaveCampaign] Finalizing...');
       setIsSaving(false);
     }
   };
@@ -546,7 +557,7 @@ function HomePage() {
         </Box>
       </Box>
       <SetupModal open={showSetupModal} onClose={() => setShowSetupModal(false)} />
-      <SaveCampaignModal open={showSaveModal} onClose={() => setShowSaveModal(false)} onSave={handleSaveCampaign} campaignToEdit={currentCampaign} />
+      <SaveCampaignModal open={showSaveModal} onClose={() => setShowSaveModal(false)} onSave={handleSaveCampaign} campaignToEdit={currentCampaign} isSaving={isSaving} />
       <LoadCampaignModal open={showLoadModal} onClose={() => setShowLoadModal(false)} onLoad={handleLoadCampaign} onEdit={(campaign) => { setCurrentCampaign(campaign); setShowSaveModal(true); }} />
       <MemorialDescritivoModal open={showMemorialDescritivoModal} onClose={() => setShowMemorialDescritivoModal(false)} campaignData={campaignData} />
       <CampaignStandardsModal open={showCampaignStandardsModal} onClose={() => { setShowCampaignStandardsModal(false); loadCampaignStandards(); }} onShowMemorial={() => setShowMemorialDescritivoModal(true)} onGeneratePalette={async (briefing) => { try { const palette = await generateColorPalette(briefing); return palette; } catch (error) { toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores."); throw error; } }} />


### PR DESCRIPTION
This commit introduces changes to help diagnose a persistent and complex issue with the 'Save Campaign' feature where uploads fail after a session expires.

Changes:
- `SaveCampaignModal.jsx`: The modal now accepts an `isSaving` prop to disable its buttons during the save process, preventing potential race conditions from multiple clicks.
- `HomePage.jsx`: The `isSaving` state is now passed to the modal. Comprehensive logging has been added to the `handleSaveCampaign` function to trace the execution flow in the browser console.

These changes are intended to provide more data to debug the inconsistent 401/200 responses from the server and the client-side upload failures.