### PR TITLE
feat(debug): Add file size logging to uploadAsset

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -32,8 +32,11 @@ const uploadAsset = async (asset, filename, campaignId) => {
   }
 
   if (!fileToUpload) {
+    console.error('[uploadAsset] fileToUpload is null or undefined for filename:', filename);
     return null;
   }
+
+  console.log(`[uploadAsset] Attempting to upload ${filename}. Size: ${fileToUpload.size} bytes.`);
 
   try {
     const newBlob = await upload(filename, fileToUpload, {


### PR DESCRIPTION
This commit adds further diagnostic logging to the campaign saving process. Based on the latest logs, the issue appears to be related to the file upload to Vercel Blob storage, which is failing with a 400 Bad Request.

A common cause for this error is an empty file payload. This commit adds a `console.log` statement to the `uploadAsset` function in `src/utils/campaignState.js` to record the name and size of each file just before it is passed to the Vercel Blob client's `upload` function.

This will help confirm or deny the 'empty file' hypothesis and provide the final piece of information needed to resolve the issue.