### PR TITLE
fix(campaignState): Sanitize state before saving to prevent silent crash

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -3,6 +3,7 @@
 import { upload } from '@vercel/blob/client';
 import { toast } from 'sonner';
 import fetchWithAuth from './fetchWithAuth';
+import { sanitizeStateForSave } from './stateSanitizers';
 
 // Helper to upload a blob-like asset to Vercel Blob storage.
 const uploadAsset = async (asset, filename, campaignId, userId) => {
@@ -267,30 +268,10 @@ export const loadCampaign = async (id) => {
   return deserializeCampaignData(campaign.campaign_data);
 };
 
-// Helper to create a version of the state safe for the initial save,
-// without any local blobs that would cause serialization issues.
-const cleanStateForInitialSave = (state) => {
-  const cleanedState = { ...state };
-
-  // Remove properties that shouldn't be persisted or are heavy
-  delete cleanedState.isSaving;
-  delete cleanedState.isLoading;
-  delete cleanedState.user;
-
-  // Replace asset data with placeholders or remove them
-  cleanedState.generatedImagesData = (state.generatedImagesData || []).map(d => ({ ...d, blob: null, url: d.url || '' }));
-  cleanedState.generatedAudioData = (state.generatedAudioData || []).map(d => ({ ...d, blob: null, url: d.url || '' }));
-  cleanedState.generatedVideosData = (state.generatedVideosData || []).map(d => ({ ...d, blob: null, url: d.url || '' }));
-  cleanedState.brandElements = (state.brandElements || []).map(el => ({ ...el, url: el.url && el.url.startsWith('http') ? el.url : '' }));
-  cleanedState.backgroundImage = state.backgroundImage && state.backgroundImage.startsWith('http') ? state.backgroundImage : null;
-  cleanedState.generatedImageUrl = state.generatedImageUrl && state.generatedImageUrl.startsWith('http') ? state.generatedImageUrl : null;
-
-  return cleanedState;
-};
-
 export const saveCampaign = async (name, campaignState, setProgress, userId) => {
-  // 1. Create a clean state object for the initial save to get an ID.
-  const initialState = cleanStateForInitialSave(campaignState);
+  // 1. Create a clean, minimal state object for the initial save to get a campaign ID.
+  // This version has no blobs and only essential data.
+  const initialState = sanitizeStateForSave(campaignState);
 
   // 2. Make the initial request to create the campaign entry.
   const createRes = await fetchWithAuth('/api/campaigns', {
@@ -307,13 +288,16 @@ export const saveCampaign = async (name, campaignState, setProgress, userId) => 
   const campaignId = newCampaign.id;
 
   // 3. Now that we have a campaign ID, serialize the full state, which includes uploading assets.
-  const finalSerializableData = await serializeCampaignData(campaignState, campaignId, setProgress, userId);
+  const stateWithAssetUrls = await serializeCampaignData(campaignState, campaignId, setProgress, userId);
 
-  // 4. Update the campaign with the final data including asset URLs.
+  // 4. Sanitize the final state again to ensure it's clean before the final PUT.
+  const finalSanitizedData = sanitizeStateForSave(stateWithAssetUrls);
+
+  // 5. Update the campaign with the final data including asset URLs.
   const updateRes = await fetchWithAuth(`/api/campaigns/${campaignId}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, campaign_data: finalSerializableData }),
+    body: JSON.stringify({ name, campaign_data: finalSanitizedData }),
   });
 
   if (!updateRes.ok) {
@@ -322,21 +306,23 @@ export const saveCampaign = async (name, campaignState, setProgress, userId) => 
     throw new Error(err.error || 'Failed to update campaign with assets.');
   }
 
-  // 5. Return the final, updated campaign data.
+  // 6. Return the final, updated campaign data.
   return updateRes.json();
 };
 
 export const updateCampaign = async (id, name, campaignState, setProgress, userId) => {
   console.log('[updateCampaign] Starting.');
-  // For an existing campaign, we already have the ID.
-  // We can directly serialize the data, which will upload any new/changed assets.
-  const serializableData = await serializeCampaignData(campaignState, id, setProgress, userId);
+  // 1. Serialize the data, which will upload any new/changed assets and return state with URLs.
+  const stateWithAssetUrls = await serializeCampaignData(campaignState, id, setProgress, userId);
+
+  // 2. Sanitize the result to create a clean, minimal payload for the PUT request.
+  const finalSanitizedData = sanitizeStateForSave(stateWithAssetUrls);
 
   console.log(`[updateCampaign] About to PUT to /api/campaigns/${id}.`);
   const res = await fetchWithAuth(`/api/campaigns/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, campaign_data: serializableData }),
+    body: JSON.stringify({ name, campaign_data: finalSanitizedData }),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/src/utils/stateSanitizers.js
+++ b/src/utils/stateSanitizers.js
@@ -1,0 +1,63 @@
+/**
+ * This module contains functions to sanitize the application state before
+ * saving it to the database, ensuring that only necessary and serializable
+ * data is persisted.
+ */
+
+/**
+ * Creates a minimal, clean state object suitable for saving to the database.
+ * It strips out any data that is not essential for restoring a campaign,
+ * such as UI state, large datasets (like csvData), etc.
+ * @param {object} fullState - The complete state object from getAppState().
+ * @returns {object} A sanitized state object containing only campaign-essential data.
+ */
+export const sanitizeStateForSave = (fullState) => {
+  // Define the list of properties that are essential for a campaign.
+  const campaignProperties = [
+    'activeStep',
+    'problema',
+    'solucao',
+    'campaignContent',
+    'persona',
+    'autor',
+    'instrucoes',
+    'formato',
+    'aspectRatio',
+    'followupPosts',
+    'followupPostsQuantity',
+    'fieldPositions',
+    'fieldStyles',
+    'imageFilters',
+    'brandElements',
+    'backgroundImage',
+    'generatedImageUrl',
+    'generatedImagesData',
+    'generatedAudioData',
+    'generatedVideosData',
+    'standardsColors',
+    // We explicitly exclude heavy or UI-related data like:
+    // 'csvData', 'csvHeaders', 'colorPalette', 'sidebarOpen', etc.
+  ];
+
+  const sanitizedState = {};
+  for (const prop of campaignProperties) {
+    if (fullState[prop] !== undefined) {
+      sanitizedState[prop] = fullState[prop];
+    }
+  }
+
+  // Further clean the asset arrays within the sanitized state.
+  // We want to remove the local blob data before saving, as the URLs are what matter.
+  // The blob data will be handled by the upload process separately.
+  if (sanitizedState.generatedImagesData) {
+    sanitizedState.generatedImagesData = sanitizedState.generatedImagesData.map(d => ({ ...d, blob: null }));
+  }
+  if (sanitizedState.generatedAudioData) {
+    sanitizedState.generatedAudioData = sanitizedState.generatedAudioData.map(d => ({ ...d, blob: null }));
+  }
+  if (sanitizedState.generatedVideosData) {
+    sanitizedState.generatedVideosData = sanitizedState.generatedVideosData.map(d => ({ ...d, blob: null }));
+  }
+
+  return sanitizedState;
+};


### PR DESCRIPTION
The root cause of the silent save failure was identified as a browser crash due to excessive memory usage when serializing a very large state object with `JSON.stringify`. This happened because the entire application state, including large datasets like `csvData`, was being prepared for the final PUT request.

This commit introduces a robust sanitization process to prevent this:

1.  **New `stateSanitizers.js` utility:** A `sanitizeStateForSave` function has been created. It builds a new, clean state object containing only the properties essential for restoring a campaign, explicitly excluding heavy UI-related data.

2.  **Refactored `campaignState.js`:**
    - The `saveCampaign` and `updateCampaign` functions now use `sanitizeStateForSave` to clean the campaign data *after* assets have been uploaded and serialized, but *before* the final state is sent to the server in the PUT/POST request.
    - The old, less effective `cleanStateForInitialSave` function has been removed.

This ensures that the JSON payload sent to the server is always minimal and safe, preventing the browser from crashing and resolving the silent save failure.