### PR TITLE
feat(debug): Add final diagnostic log to serializeCampaignData

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -68,6 +68,7 @@ const uploadAsset = async (asset, filename, campaignId, userId) => {
  * @returns {Promise<object>} A promise that resolves to a serializable object.
  */
 export const serializeCampaignData = async (state, campaignId, setProgress, userId) => {
+  console.log('[serializeCampaignData] Starting.');
   const assetsToUpload = [
     ...(state.generatedImagesData || []).filter(a => a.blob),
     ...(state.generatedAudioData || []).filter(a => a.blob),


### PR DESCRIPTION
This is a final attempt to remotely diagnose a silent crash in the campaign save process. The previous logs have narrowed down the point of failure to the beginning of the `serializeCampaignData` function.

This commit adds a single `console.log` statement at the very beginning of this function. If this log appears in the user's console, it confirms the function is being entered and the problem lies within. If it does not appear, it points to a fundamental issue with the JavaScript event loop or promise handling in the Vercel environment for this specific user action, which is beyond the scope of remote debugging.