### PR TITLE
fix: Improve rate limiting handling for LinkedIn API

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -3,13 +3,20 @@ import { query } from './db.js';
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-async function fetchWithRetry(fetch, url, options, retries = 3, backoff = 1000) {
+async function fetchWithRetry(fetch, url, options, retries = 5, initialBackoff = 1000) {
+  let backoff = initialBackoff;
   for (let i = 0; i < retries; i++) {
     const response = await fetch(url, options);
     if (response.status === 429) {
-      const retryAfter = parseInt(response.headers.get('Retry-After'), 10) * 1000 || backoff;
-      console.warn(`Rate limit hit. Retrying after ${retryAfter}ms...`);
+      // Use Retry-After header if available, otherwise use exponential backoff
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) * 1000 : backoff;
+
+      console.warn(`Rate limit hit. Retrying after ${retryAfter}ms... (Attempt ${i + 1}/${retries})`);
       await delay(retryAfter);
+
+      // Increase backoff for next potential retry
+      backoff *= 2;
       continue;
     }
     return response;
@@ -159,11 +166,13 @@ async function handleGetProfiles(fetch, request, response) {
     if (orgAclsResponse.ok) {
       const orgAclsData = await orgAclsResponse.json();
       const orgUrns = orgAclsData.elements?.map(el => el.organization) || [];
-      const orgIds = orgUrns.map(urn => urn.split(':').pop());
-      if (orgIds.length > 0) {
+      // Ensure IDs are unique to prevent asking for the same org multiple times
+      const uniqueOrgIds = [...new Set(orgUrns.map(urn => urn.split(':').pop()))];
+
+      if (uniqueOrgIds.length > 0) {
         const allOrgDetails = {};
-        for (let i = 0; i < orgIds.length; i += 50) {
-          const chunk = orgIds.slice(i, i + 50);
+        for (let i = 0; i < uniqueOrgIds.length; i += 50) {
+          const chunk = uniqueOrgIds.slice(i, i + 50);
           const batchOrgUrl = `https://api.linkedin.com/rest/organizations?ids=List(${chunk.join(',')})`;
           const batchOrgResponse = await fetchWithRetry(fetch, batchOrgUrl, { headers });
           if (batchOrgResponse.ok) Object.assign(allOrgDetails, (await batchOrgResponse.json()).results);


### PR DESCRIPTION
This commit addresses a rate limiting error that occurred when fetching organization profiles from the LinkedIn API.

The fix includes two improvements:
1.  The `handleGetProfiles` function in `api/linkedin-proxy.js` now ensures that the list of organization IDs is unique before making batch requests. This prevents asking for the same organization details multiple times in one session.
2.  The `fetchWithRetry` helper function has been made more robust. It now retries up to 5 times (previously 3) and uses an exponential backoff strategy if the `Retry-After` header is not provided by the API.

These changes make the application more resilient to transient rate limiting and more efficient in its use of the LinkedIn API.