### PR TITLE
fix: Prevent excessive API calls in Publisher component

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -334,34 +334,36 @@ const Publisher = ({
   // Fetch LinkedIn profiles on component mount
   useEffect(() => {
     const fetchProfiles = async () => {
-      setIsLoadingProfiles(true);
-      setProfileError('');
-      try {
-        const profiles = await getLinkedInProfiles(settings?.linkedin);
-        setLinkedinProfiles({
-            personal: profiles.personal,
-            organizations: profiles.organizations || []
-        });
+      // Only fetch if settings are available and profiles haven't been loaded yet.
+      if (settings?.linkedin && !linkedinProfiles.personal && linkedinProfiles.organizations.length === 0) {
+        setIsLoadingProfiles(true);
+        setProfileError('');
+        try {
+          const profiles = await getLinkedInProfiles(settings.linkedin);
+          setLinkedinProfiles({
+              personal: profiles.personal,
+              organizations: profiles.organizations || []
+          });
 
-        // Set a default profile only if the cleaned list is not empty and no profile is already selected.
-        if (profiles.personal && !selectedTarget) {
-            setSelectedTarget({
-                id: profiles.personal.id,
-                name: `${profiles.personal.name} (Perfil Pessoal)`,
-                type: 'personal'
-            });
+          // Set a default profile only if the cleaned list is not empty and no profile is already selected.
+          if (profiles.personal && !selectedTarget) {
+              setSelectedTarget({
+                  id: profiles.personal.id,
+                  name: `${profiles.personal.name} (Perfil Pessoal)`,
+                  type: 'personal'
+              });
+          }
+        } catch (error) {
+          console.error("Erro ao buscar perfis do LinkedIn:", error);
+          setProfileError(error.message);
+          setLinkedinProfiles({ personal: null, organizations: [] });
+        } finally {
+          setIsLoadingProfiles(false);
         }
-
-      } catch (error) {
-        console.error("Erro ao buscar perfis do LinkedIn:", error);
-        setProfileError(error.message);
-        setLinkedinProfiles({ personal: null, organizations: [] }); // Also clear profiles on error
-      } finally {
-        setIsLoadingProfiles(false);
       }
     };
     fetchProfiles();
-  }, [settings?.linkedin, selectedTarget]); // Rerun if settings change
+  }, [settings?.linkedin]); // Rerun only if settings change
 
   // Effect to clear selection if media data is removed.
   useEffect(() => {


### PR DESCRIPTION
This commit fixes a critical bug in the `Publisher.jsx` component that was causing an infinite loop of API calls to the LinkedIn `/api/linkedin-proxy` endpoint, resulting in persistent rate limiting errors.

The issue was in a `useEffect` hook responsible for fetching LinkedIn profiles. The hook had `selectedTarget` in its dependency array, but the hook itself was also responsible for setting `selectedTarget`. This created a cycle where setting the state would trigger the effect, which would then set the state again.

The fix removes `selectedTarget` from the dependency array. An additional condition has been added to the hook to ensure that profiles are only fetched if they haven't been loaded already, preventing unnecessary API calls on re-renders. This resolves the root cause of the rate limiting.