### PR TITLE
fix: Prevent state bloat when generating images

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -264,7 +264,6 @@ const ImageGeneratorFrontendOnly = ({
           record,
           index: i,
           filename: `midiator_${String(i + 1).padStart(3, '0')}.png`,
-          backgroundImage,
           customFieldPositions: existingImageDataItem?.customFieldPositions,
           customFieldStyles: existingImageDataItem?.customFieldStyles,
         };


### PR DESCRIPTION
Removes the redundant `backgroundImage` property from being stored in every individual generated image's data object.

This was causing the application state to become excessively large when many images were generated with a large background image, leading to a failure in the save/update API call due to the request body exceeding server limits. This failure prevented both the images from being uploaded and the campaign name from being updated.

This change resolves the issue by significantly reducing the size of the request payload, allowing the campaign save operation to complete successfully.