### PR TITLE
feat: Add detailed logging to campaign save process

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-DmjvbGBv.js"></script>
+  <script type="module" crossorigin src="/assets/index-DXQnJNHN.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-D4DOKQUy.css">
 </head>
 

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -252,70 +252,112 @@ export const deserializeCampaignData = async (loadedState) => {
 // --- API Functions ---
 
 export const getCampaigns = async () => {
+  console.log('[campaignState] Fetching all campaigns...');
   const res = await fetchWithAuth('/api/campaigns');
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    console.error('[campaignState] Failed to fetch campaigns:', err);
     throw new Error(err.error || 'Failed to fetch campaigns.');
   }
+  console.log('[campaignState] Successfully fetched campaigns.');
   return res.json();
 };
 
 export const loadCampaign = async (id) => {
+  console.log(`[campaignState] Loading campaign with ID: ${id}`);
   const res = await fetchWithAuth(`/api/campaigns/${id}`);
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    console.error(`[campaignState] Failed to load campaign ${id}:`, err);
     throw new Error(err.error || 'Failed to load campaign.');
   }
   const campaign = await res.json();
-  // Deserialize the campaign_data part, but return the whole campaign object
-  // so we have access to top-level properties like `name` and `id`.
+  console.log(`[campaignState] Successfully loaded campaign ${id}, now deserializing...`);
   campaign.campaign_data = await deserializeCampaignData(campaign.campaign_data);
+  console.log(`[campaignState] Deserialization complete for campaign ${id}.`);
   return campaign;
 };
 
 export const saveCampaign = async (name, campaignData, setProgress, userId) => {
-  // The campaignData from HomePage is already a minimal, clean object.
-  // First, serialize it to upload any new assets.
-  const stateWithAssetUrls = await serializeCampaignData(campaignData, null, setProgress, userId);
+  console.log('[campaignState] Starting saveCampaign process...');
+  try {
+    console.log('[campaignState] Step 1: Serializing campaign data and uploading assets...');
+    const stateWithAssetUrls = await serializeCampaignData(campaignData, null, setProgress, userId);
+    console.log('[campaignState] Step 1 COMPLETE. Assets uploaded and URLs replaced.');
 
-  // We do an initial POST with this data to get a campaign ID.
-  const createRes = await fetchWithAuth('/api/campaigns', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, campaign_data: stateWithAssetUrls }),
-  });
+    console.log('[campaignState] Step 2: Sending campaign data to server...');
+    const requestBody = JSON.stringify({ name, campaign_data: stateWithAssetUrls });
+    console.log('[campaignState] Request body to be sent:', requestBody);
 
-  if (!createRes.ok) {
-    const err = await createRes.json().catch(() => ({}));
-    throw new Error(err.error || 'Failed to create campaign entry.');
+    const createRes = await fetchWithAuth('/api/campaigns', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: requestBody,
+    });
+
+    console.log(`[campaignState] Server responded with status: ${createRes.status}`);
+
+    if (!createRes.ok) {
+      const errorBody = await createRes.text();
+      console.error('[campaignState] Server returned an error on create:', errorBody);
+      throw new Error(`Failed to create campaign entry. Server says: ${errorBody}`);
+    }
+
+    console.log('[campaignState] Step 2 COMPLETE. Campaign created successfully.');
+    const result = await createRes.json();
+    console.log('[campaignState] Final result:', result);
+    return result;
+  } catch (error) {
+      console.error('[campaignState] An error occurred during the save process:', error);
+      toast.error(`Save failed: ${error.message}`);
+      throw error; // Re-throw to be caught by the UI component
   }
-
-  return createRes.json();
 };
 
 export const updateCampaign = async (id, name, campaignData, setProgress, userId) => {
-  // The campaignData is already pre-sanitized by the caller.
-  // First, serialize it, which uploads assets and returns a state with public URLs.
-  const stateWithAssetUrls = await serializeCampaignData(campaignData, id, setProgress, userId);
+    console.log(`[campaignState] Starting updateCampaign process for ID: ${id}...`);
+    try {
+        console.log('[campaignState] Step 1: Serializing campaign data and uploading assets...');
+        const stateWithAssetUrls = await serializeCampaignData(campaignData, id, setProgress, userId);
+        console.log('[campaignState] Step 1 COMPLETE. Assets uploaded and URLs replaced.');
 
-  // Now, send the final, clean data to the server.
-  const res = await fetchWithAuth(`/api/campaigns/${id}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, campaign_data: stateWithAssetUrls }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(err.error || 'Failed to update campaign.');
-  }
-  return res.json();
+        console.log('[campaignState] Step 2: Sending updated campaign data to server...');
+        const requestBody = JSON.stringify({ name, campaign_data: stateWithAssetUrls });
+        console.log('[campaignState] Request body to be sent:', requestBody);
+
+        const res = await fetchWithAuth(`/api/campaigns/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: requestBody,
+        });
+
+        console.log(`[campaignState] Server responded with status: ${res.status}`);
+
+        if (!res.ok) {
+            const errorBody = await res.text();
+            console.error(`[campaignState] Server returned an error on update for campaign ${id}:`, errorBody);
+            throw new Error(`Failed to update campaign. Server says: ${errorBody}`);
+        }
+
+        console.log(`[campaignState] Step 2 COMPLETE. Campaign ${id} updated successfully.`);
+        const result = await res.json();
+        console.log('[campaignState] Final result:', result);
+        return result;
+    } catch (error) {
+        console.error(`[campaignState] An error occurred during the update process for campaign ${id}:`, error);
+        toast.error(`Update failed: ${error.message}`);
+        throw error; // Re-throw to be caught by the UI component
+    }
 };
 
 export const deleteCampaign = async (id) => {
+  console.log(`[campaignState] Deleting campaign with ID: ${id}`);
   const res = await fetchWithAuth(`/api/campaigns/${id}`, { method: 'DELETE' });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    console.error(`[campaignState] Failed to delete campaign ${id}:`, err);
     throw new Error(err.error || 'Failed to delete campaign.');
   }
+  console.log(`[campaignState] Successfully deleted campaign ${id}.`);
   return res.json();
 };


### PR DESCRIPTION
To diagnose the final issue preventing campaigns from being saved, this commit adds extensive, step-by-step logging to the `saveCampaign` and `updateCampaign` functions in `src/utils/campaignState.js`.

- Logs the request body before it's sent to the server.
- Logs the server's HTTP status response.
- Logs the full error response if the request is not successful.
- Adds logging to other campaign-related API functions for better visibility.

This change is intended to provide the necessary information to debug the final step of the campaign saving workflow.