### PR TITLE
fix: Resolve campaign saving and improve API robustness

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-D0B7VHeJ.js"></script>
+  <script type="module" crossorigin src="/assets/index-D00XeOp2.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-D4DOKQUy.css">
 </head>
 

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -41,22 +41,27 @@ const uploadAsset = async (blob, filename, campaignId, userId) => {
 export const serializeCampaignData = async (state, campaignId, setProgress, userId) => {
   console.log('[serializeCampaignData] Starting serialization...');
   try {
-    // Helper to process a list of assets, uploading their blobs
+    // Helper to process a list of assets, uploading their blobs sequentially.
     const serializeAssetList = async (assetList) => {
       if (!assetList) return [];
-      return Promise.all(
-        assetList.map(async (asset) => {
-          // Check for the blob object directly. This is the main fix.
-          if (asset && asset.blob instanceof Blob) {
-            const newUrl = await uploadAsset(asset.blob, asset.filename, campaignId, userId);
-            setProgress(prev => ({ ...prev, current: prev.current + 1 }));
-            return { ...asset, url: newUrl, blob: undefined }; // Store URL, remove blob
-          }
+      const serializedList = [];
+      for (const asset of assetList) {
+        // Use a default filename if one is not provided.
+        const filename = asset.filename || `asset_${Date.now()}`;
+        console.log(`[serializeAssetList] Processing asset: ${filename}`);
+
+        if (asset && asset.blob instanceof Blob) {
+          const newUrl = await uploadAsset(asset.blob, filename, campaignId, userId);
+          setProgress(prev => ({ ...prev, current: prev.current + 1 }));
+          serializedList.push({ ...asset, url: newUrl, blob: undefined });
+        } else {
           // If asset has no blob, it might already have a permanent URL.
           // Ensure blob property is removed.
-          return { ...asset, blob: undefined };
-        })
-      );
+          serializedList.push({ ...asset, blob: undefined });
+        }
+        console.log(`[serializeAssetList] Finished processing asset: ${filename}`);
+      }
+      return serializedList;
     };
 
     // Helper to fetch a blob/data URL and convert it to a Blob object.


### PR DESCRIPTION
This commit provides a comprehensive fix for the campaign saving workflow by addressing multiple issues identified during debugging.

1.  **Fix Asset Upload Logic:**
    - Refactored `src/utils/campaignState.js` to upload assets sequentially instead of in parallel, which resolves a silent hang in the save process.
    - Uploads now use the in-memory `Blob` objects directly, instead of re-fetching from `blob:` URLs, making the process more reliable.
    - Added a process yield (`setTimeout`) to the serialization function to prevent the UI from hanging during heavy processing.

2.  **Robust Google API Token Handling:**
    - Refactored `src/utils/googleApi.js` to manage the access token internally, preventing stale token issues.
    - Updated all components using the Google API to integrate with the new centralized token management system.

3.  **Prevent LinkedIn API Interference:**
    - Modified `Publisher.jsx` to change LinkedIn profile fetching to a manual, user-initiated action, preventing API rate-limiting errors from blocking the UI.

4.  **Add Detailed Logging:**
    - Added extensive logging to the campaign saving process and API calls to improve traceability and simplify future debugging.