### PR TITLE
Diag: Skip userId check to isolate environment hang

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -54,10 +54,11 @@ export const uploadAsset = async (dataUrl, filename, campaignId, userId) => {
   console.log('[uploadAsset] dataUrl check passed.'); // LOG 3
 
   console.log('[uploadAsset] About to check userId...'); // LOG 4
-  if (!userId) {
-    throw new Error("User ID is required to upload assets.");
-  }
-  console.log('[uploadAsset] userId check passed.'); // LOG 5
+  // DIAGNOSTIC: Commenting out the userId check to see if it's the source of the hang.
+  // if (!userId) {
+  //   throw new Error("User ID is required to upload assets.");
+  // }
+  console.log('[uploadAsset] userId check passed (DIAGNOSTICALLY SKIPPED).'); // LOG 5
 
   const fullPath = campaignId ? `${userId}/${campaignId}/${filename}` : `${userId}/${filename}`;
   console.log(`[uploadAsset] Starting manual upload for: ${fullPath}`);


### PR DESCRIPTION
This commit is the final diagnostic step to pinpoint a silent hang during the `uploadAsset` function.

Previous logs have isolated the hang to the `if (!userId)` check, which suggests an environment or memory issue rather than a code logic error.

This commit temporarily comments out this check. The goal is to see if the execution proceeds past this point, which would confirm the theory that the check itself, in a memory-constrained environment, is the source of the hang. This is not a fix, but a test to inform the final fix.