### PR TITLE
Fix: Implement manual body parsing for Vercel Blob handler

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,6 +1,26 @@
 import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from './middleware/auth.js';
 
+// Helper function to parse the request body in a Vercel serverless function environment
+function parseJson(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
 const handler = async (req, res) => {
   console.log('[API /upload] Received request');
 
@@ -11,7 +31,10 @@ const handler = async (req, res) => {
   }
 
   try {
+    const body = await parseJson(req);
+
     const jsonResponse = await handleUpload({
+      body,
       request: req,
       onBeforeGenerateToken: async (pathname, clientPayload) => {
         console.log(`[API /upload] onBeforeGenerateToken: Pathname: ${pathname}`);


### PR DESCRIPTION
This commit resolves the final issue in the campaign saving workflow by correctly handling the request body in the `api/upload.js` serverless function.

The root cause of the last `500 Internal Server Error` was a `TypeError` indicating that the Vercel Blob library was not receiving the request body in the expected format. The environment was not compatible with the `req.json()` method, and the library did not handle the raw request stream automatically.

This commit introduces a helper function to manually parse the JSON body from the raw request stream, which is a robust method for standard Node.js environments. This parsed body is then correctly passed to the `@vercel/blob/client`'s `handleUpload` function.

This change is combined with all previous fixes:
- Correcting the user ID property from `sub` to `uuid` on both frontend and backend.
- Updating the Vercel Blob import path.
- Fixing various state management issues in the frontend `HomePage` component.