### PR TITLE
Fix: Add random suffix to blob uploads to prevent conflicts

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -60,6 +60,7 @@ const handler = async (req, res) => {
         console.log(`[API /upload] Path authorized: ${sanitizedPathname}`);
 
         return {
+          addRandomSuffix: true,
           allowedContentTypes: ['image/jpeg', 'image/png', 'image/gif', 'video/mp4', 'audio/mpeg', 'video/webm', 'audio/webm', 'audio/wav'],
           tokenPayload: JSON.stringify({ userId }),
           pathname: sanitizedPathname,


### PR DESCRIPTION
This commit addresses the final issue in the campaign saving workflow where uploads would fail if a file with the same name already existed in the Vercel Blob store.

The `onBeforeGenerateToken` handler in `api/upload.js` has been updated to include the `addRandomSuffix: true` option. This instructs the Vercel Blob service to automatically append a unique random identifier to each uploaded filename, guaranteeing that every upload is unique and preventing overwrite errors.

This change is the final piece of a comprehensive set of fixes, including:
- Correcting the user ID property from `sub` to `uuid`.
- Implementing a manual body parser for the serverless function environment.
- Fixing various state management issues in the frontend `HomePage` component.