### PR TITLE
Fix: Correct Vercel Blob import path in upload handler

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,4 +1,4 @@
-import { handleUpload } from '@vercel/blob/server';
+import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from './middleware/auth.js';
 
 // This config is crucial to disable the default body parser


### PR DESCRIPTION
This commit corrects a critical bug in the `/api/upload` endpoint that was introduced in a previous commit.

The import path for `handleUpload` was incorrectly changed to `@vercel/blob/server`, which caused an `ERR_PACKAGE_PATH_NOT_EXPORTED` error on the Vercel platform. This prevented the client from retrieving an upload token, causing all file uploads to fail.

This commit reverts the import path back to the correct `@vercel/blob/client`, which, although counter-intuitive for a backend handler, is the correct usage according to Vercel's package structure.

This change, combined with the previous fixes to the upload handler and frontend state management, should fully resolve the campaign saving flow issues.