### PR TITLE
Fix: Re-enable body parser for Vercel Blob upload handler

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -1,12 +1,7 @@
 import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from './middleware/auth.js';
 
-// This config is crucial to disable the default body parser
-export const config = {
-  api: {
-    bodyParser: false,
-  },
-};
+// By removing the `config` export, we re-enable the default Next.js body parser.
 
 const handler = async (req, res) => {
   console.log('[API /upload] Received request');
@@ -17,13 +12,13 @@ const handler = async (req, res) => {
     return res.status(405).json({ error: 'Method Not Allowed' });
   }
 
-  try {
-    // No longer parsing the body here.
-    // The raw `req` object will be passed to `handleUpload`.
+  // The body is now automatically parsed by Next.js and available on `req.body`.
+  const body = req.body;
 
+  try {
     const jsonResponse = await handleUpload({
-      body: req,
-      request: req,
+      body, // Pass the parsed body object.
+      request: req, // Pass the original request for other properties.
       onBeforeGenerateToken: async (pathname, clientPayload) => {
         console.log(`[API /upload] onBeforeGenerateToken: Pathname: ${pathname}`);
 


### PR DESCRIPTION
This commit provides the definitive fix for the 500 Internal Server Error in the `/api/upload` endpoint, which was caused by an `Invalid event type` error from the Vercel Blob SDK.

The root cause was a misunderstanding of how the `@vercel/blob/client`'s `handleUpload` function expects to receive request data in a Next.js Pages Router environment. The previous implementation incorrectly disabled the default Next.js body parser (`bodyParser: false`). This resulted in the `handleUpload` function receiving a raw stream instead of the parsed JSON object it requires to identify the event type (e.g., 'blob.generate-client-token').

This commit corrects the issue by:
1.  Removing `export const config = { api: { bodyParser: false } };` from `api/upload.js`.
2.  Allowing the default Next.js body parser to run.
3.  Passing the parsed `req.body` object to the `handleUpload` function.

This ensures that the handler receives the correctly formatted JSON event from the client, allowing it to generate the client token and proceed with the upload flow as intended. This should resolve all remaining errors with file and campaign saving.