### PR TITLE
Fix: Include CSV data in campaign save state

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -235,6 +235,8 @@ function HomePage() {
       generatedAudioData,
       generatedVideosData,
       standardsColors,
+      csvData,
+      csvHeaders,
     };
     console.log("[HomePage] Campaign data object created:", campaignDataToSave);
 


### PR DESCRIPTION
This commit fixes an oversight where the CSV data (`csvData` and `csvHeaders`) for short posts was not being included in the campaign state object when a campaign was saved.

The `handleSaveCampaign` function in `HomePage.jsx` has been updated to include these two state variables in the `campaignDataToSave` object. The corresponding logic to load this data from a saved campaign was already present in the `applyAppState` function.

This ensures that any user-provided or AI-generated short posts are correctly persisted and reloaded with the rest of the campaign.