### PR TITLE
Fix: Add missing index and filename to generated audio data

### DIFF
--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -193,8 +193,12 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
         let audio;
         if (audioMode.startsWith('google-tts')) {
           audio = await generateAudioGoogleTTS(textToSpeak, voice, speechRate);
+          audio.index = i;
+          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.mp3`;
         } else {
           audio = await generateAudioBrowser(textToSpeak, speechRate);
+          audio.index = i;
+          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.mp3`;
         }
         generatedAudios.push(audio);
       } catch (error) {


### PR DESCRIPTION
This commit fixes a critical bug that prevented generated audio files from being saved with a campaign.

The root cause was a data mismatch. The `AudioGenerator.jsx` component was creating audio data objects that were missing the `index` and `filename` properties. The `serializeCampaignData` function relies on these properties to correctly name and process the files for upload. This mismatch caused the audio upload process to fail silently.

This commit resolves the issue by adding the `index` and `filename` properties to the audio objects at the moment they are generated in `AudioGenerator.jsx`. This ensures the data structure is consistent and provides the serialization function with all the necessary information to upload the audio assets to Vercel Blob Storage.

This change should fully resolve the issue of audio files not being saved.