### PR TITLE
fix: Ensure fresh Google Access Token is sent to client

### DIFF
--- a/api/auth/me.js
+++ b/api/auth/me.js
@@ -1,9 +1,11 @@
 import { withAuth } from '../middleware/auth.js';
+import { query } from '../db.js';
 
 /**
  * API handler to get the profile of the currently authenticated user.
- * This handler is wrapped with the `withAuth` middleware, so it will only
- * be executed if a valid JWT is provided in the 'auth_token' cookie.
+ * This handler is wrapped with the `withAuth` middleware.
+ * It now fetches the latest user data from the database to ensure all
+ * information, especially the Google Access Token, is up-to-date.
  */
 const meHandler = async (req, res) => {
   if (req.method !== 'GET') {
@@ -11,17 +13,37 @@ const meHandler = async (req, res) => {
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  // The user object (JWT payload) is attached to the request by the withAuth middleware.
-  // We can send it back to the client.
-  // It's good practice to filter out JWT-specific fields like 'iat' and 'exp'.
-  const {
-    sub, // subject (user id), we can filter this if uuid is the primary public id
-    iat, // issued at
-    exp, // expiration time
-    ...userProfile // the rest of the user data (uuid, name, email, role)
-  } = req.user;
+  try {
+    // The user's UUID is in the JWT payload attached by withAuth
+    const userUuid = req.user.uuid;
+    if (!userUuid) {
+      return res.status(400).json({ error: 'User identifier not found in token.' });
+    }
 
-  return res.status(200).json(userProfile);
+    // Fetch the latest user data from the database
+    const { rows } = await query('SELECT id, uuid, name, email, role, google_access_token FROM users WHERE uuid = $1', [userUuid]);
+    const user = rows[0];
+
+    if (!user) {
+      // This case should be rare if the JWT is valid, but it's a good safeguard
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    // Return the fresh user profile
+    const userProfile = {
+      uuid: user.uuid,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+      googleAccessToken: user.google_access_token,
+    };
+
+    return res.status(200).json(userProfile);
+
+  } catch (error) {
+    console.error('Error in /api/auth/me:', error);
+    return res.status(500).json({ error: 'An error occurred while fetching user profile.' });
+  }
 };
 
 // Wrap the handler with the withAuth middleware to protect this route


### PR DESCRIPTION
The `/api/auth/me` endpoint was previously returning user data directly from the JWT payload. This could lead to a stale `googleAccessToken` being sent to the client if the token had been refreshed since the JWT was issued.

This commit modifies the `/api/auth/me` handler to use the user's UUID from the token to fetch the latest user profile from the database. This guarantees that the client always receives the most up-to-date `googleAccessToken` on session verification, resolving issues in components that rely on this token, such as the `BackgroundImageSelector`.