### PR TITLE
Fix: Correct asset counting and processing in serialization

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -62,7 +62,6 @@ export const uploadAsset = async (dataUrl, filename, campaignId, userId) => {
 export const serializeCampaignData = async (state, userId, campaignId = null, onProgress = () => {}) => {
   console.log('[serializeCampaignData] Starting serialization and upload...');
 
-  // Deep copy to avoid mutating the original state object directly.
   const cleanState = JSON.parse(JSON.stringify(state));
   let assetsToUploadCount = 0;
   let assetsUploadedCount = 0;
@@ -78,9 +77,14 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     assetsToUploadCount += cleanState.brandElements.filter(el => el.url && el.url.startsWith('data:')).length;
   }
   if (Array.isArray(cleanState.generatedImagesData)) {
-    assetsToUploadCount += cleanState.generatedImagesData.filter(img => img.dataUrl && img.dataUrl.startsWith('data:')).length;
+    assetsToUploadCount += cleanState.generatedImagesData.filter(img => img.url && img.url.startsWith('data:')).length;
   }
-  // Future asset types can be counted here.
+  if (Array.isArray(cleanState.generatedAudioData)) {
+    assetsToUploadCount += cleanState.generatedAudioData.filter(audio => audio.url && audio.url.startsWith('data:')).length;
+  }
+  if (Array.isArray(cleanState.generatedVideosData)) {
+    assetsToUploadCount += cleanState.generatedVideosData.filter(video => video.url && video.url.startsWith('data:')).length;
+  }
 
   console.log(`[serializeCampaignData] Found ${assetsToUploadCount} assets to upload.`);
   onProgress({ current: 0, total: assetsToUploadCount });
@@ -124,7 +128,6 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     // Generated Post Images
     if (Array.isArray(cleanState.generatedImagesData)) {
        for (const image of cleanState.generatedImagesData) {
-        // Bug fix: Was checking `image.dataUrl`, but the property is `image.url`.
         if (image.url && image.url.startsWith('data:')) {
           const filename = image.filename || `post_image_${image.index}_${Date.now()}.png`;
           console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
@@ -134,9 +137,37 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
           assetsUploadedCount++;
           onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
         }
-        // This is the crucial fix: The `backgroundImage` property is duplicated inside each
-        // generated image object and must be removed to prevent payload size errors.
         delete image.backgroundImage;
+      }
+    }
+
+    // Generated Audio
+    if (Array.isArray(cleanState.generatedAudioData)) {
+      for (const audio of cleanState.generatedAudioData) {
+        if (audio.url && audio.url.startsWith('data:')) {
+          const filename = audio.filename || `audio_${audio.index}_${Date.now()}.mp3`;
+          console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
+          const dataUrlToUpload = audio.url;
+          const permanentUrl = await uploadAsset(dataUrlToUpload, filename, campaignId, userId);
+          audio.url = permanentUrl;
+          assetsUploadedCount++;
+          onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
+        }
+      }
+    }
+
+    // Generated Videos
+    if (Array.isArray(cleanState.generatedVideosData)) {
+      for (const video of cleanState.generatedVideosData) {
+        if (video.url && video.url.startsWith('data:')) {
+          const filename = video.filename || `video_${video.index}_${Date.now()}.mp4`;
+          console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
+          const dataUrlToUpload = video.url;
+          const permanentUrl = await uploadAsset(dataUrlToUpload, filename, campaignId, userId);
+          video.url = permanentUrl;
+          assetsUploadedCount++;
+          onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
+        }
       }
     }
 
@@ -156,6 +187,8 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     }
   };
   finalCleanup(cleanState.generatedImagesData);
+  finalCleanup(cleanState.generatedAudioData);
+  finalCleanup(cleanState.generatedVideosData);
 
   console.log('[serializeCampaignData] All uploads and cleanup complete.');
   return cleanState;


### PR DESCRIPTION
This commit fixes a critical bug in the `serializeCampaignData` function within `src/utils/campaignState.js` that was preventing audio and video files from being uploaded.

The root cause was missing logic in the asset counting phase. The code was not iterating over `generatedAudioData` or `generatedVideosData` to count how many assets needed to be uploaded. This resulted in the log message "Found 0 assets to upload" and caused the upload process for those types to be skipped entirely. Additionally, the corresponding loops to process and upload these assets were also missing.

This commit resolves the issue by:
1.  Adding the necessary filter and count logic for `generatedAudioData` and `generatedVideosData`.
2.  Adding the `for...of` loops to process and upload audio and video files, replacing their `data:` URLs with permanent Vercel Blob URLs.
3.  Correcting a lingering typo in the image counting logic (`img.dataUrl` to `img.url`).

This comprehensive fix ensures all asset types are now correctly counted, processed, and uploaded, finally resolving the campaign saving feature.