### PR TITLE
Fix(Formatting): Prevent crash when editing brand elements with no fi…

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -124,7 +124,18 @@ const FormattingPanel = ({
     if (selectedField) {
       const brandEl = brandElements?.find(el => el.id === selectedField);
       if (brandEl) {
-        setCurrentElement(brandEl);
+        // Defensively add filters if they are missing
+        const elementWithFilters = {
+          ...brandEl,
+          filters: brandEl.filters || {
+            brightness: 100,
+            contrast: 100,
+            saturate: 100,
+            blur: 0,
+            opacity: 100,
+          },
+        };
+        setCurrentElement(elementWithFilters);
         setIsTextField(false);
       } else if (fieldPositions[selectedField]) {
         setCurrentElement({


### PR DESCRIPTION
…lters

This commit fixes a TypeError that occurred when a user tried to edit a brand element (e.g., a logo) that was created before the introduction of image filter properties.

When a brand element without a `filters` object was selected for editing, the formatting panel would crash trying to access properties of `undefined`.

The fix adds a defensive check in `FormattingPanel.jsx`. If a selected brand element is missing the `.filters` property, it is now initialized with a default set of values. This ensures backward compatibility with older data formats and prevents the crash.