### PR TITLE
feat: Add 'Minhas Campanhas' step and conditional start

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -40,7 +40,6 @@ const MainAppBar = ({
   const { user, logout } = useUserAuth();
   const navigate = useNavigate();
   const [userMenuAnchorEl, setUserMenuAnchorEl] = React.useState(null);
-  const [campaignMenuAnchorEl, setCampaignMenuAnchorEl] = React.useState(null);
 
   const handleUserMenu = (event) => {
     setUserMenuAnchorEl(event.currentTarget);
@@ -48,14 +47,6 @@ const MainAppBar = ({
 
   const handleUserMenuClose = () => {
     setUserMenuAnchorEl(null);
-  };
-
-  const handleCampaignMenu = (event) => {
-    setCampaignMenuAnchorEl(event.currentTarget);
-  };
-
-  const handleCampaignMenuClose = () => {
-    setCampaignMenuAnchorEl(null);
   };
 
   const handleLogout = async () => {
@@ -88,31 +79,15 @@ const MainAppBar = ({
         </Box>
 
         <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 0, sm: 1 } }}>
-          <Tooltip title="Campanhas">
+          <Tooltip title="Salvar Campanha">
             <IconButton
-              onClick={handleCampaignMenu}
+              onClick={onSaveCampaign}
               sx={{ color: 'white' }}
-              aria-label="Campanhas"
+              aria-label="Salvar Campanha"
             >
-              <FolderIcon />
+              <SaveIcon />
             </IconButton>
           </Tooltip>
-          <Menu
-            id="campaign-menu-appbar"
-            anchorEl={campaignMenuAnchorEl}
-            open={Boolean(campaignMenuAnchorEl)}
-            onClose={handleCampaignMenuClose}
-          >
-            <MenuItem onClick={() => { onSaveCampaign(); handleCampaignMenuClose(); }}>
-              <SaveIcon sx={{ mr: 1 }} />
-              Salvar Campanha
-            </MenuItem>
-            <MenuItem onClick={() => { onLoadCampaign(); handleCampaignMenuClose(); }}>
-              <FolderOpenIcon sx={{ mr: 1 }} />
-              Carregar Campanha
-            </MenuItem>
-          </Menu>
-
           <Tooltip title="Configurações">
             <IconButton
               onClick={() => setShowSetupModal(true)}

--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect } from 'react';
+import {
+  List,
+  ListItem,
+  ListItemText,
+  ListItemButton,
+  IconButton,
+  CircularProgress,
+  Alert,
+  Box,
+  Button,
+  Typography,
+  Divider,
+  Container,
+  Paper,
+} from '@mui/material';
+import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon } from '@mui/icons-material';
+import { getCampaigns, deleteCampaign } from '../utils/campaignState';
+import { toast } from 'sonner';
+
+const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
+  const [campaigns, setCampaigns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchCampaigns = () => {
+    setLoading(true);
+    setError('');
+    getCampaigns()
+      .then(data => {
+        setCampaigns(data);
+      })
+      .catch(err => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    fetchCampaigns();
+  }, []);
+
+  const handleDelete = async (id, name) => {
+    if (window.confirm(`Are you sure you want to delete the campaign "${name}"?`)) {
+      try {
+        await deleteCampaign(id);
+        toast.success(`Campaign "${name}" deleted.`);
+        fetchCampaigns(); // Refresh the list
+      } catch (err) {
+        toast.error(err.message);
+      }
+    }
+  };
+
+  return (
+    <Container maxWidth="md">
+      <Paper sx={{ p: { xs: 2, md: 4 }, mt: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+          <Typography variant="h4" component="h1">
+            Minhas Campanhas
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={onCreateNew}
+          >
+            Nova Campanha
+          </Button>
+        </Box>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          Selecione uma campanha existente para carregar e continuar editando, ou crie uma nova.
+        </Typography>
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}><CircularProgress /></Box>
+        ) : error ? (
+          <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>
+        ) : (
+          <List>
+            {campaigns.length === 0 ? (
+              <Typography sx={{ p: 2, textAlign: 'center' }}>
+                Nenhuma campanha salva encontrada. Crie uma nova para começar.
+              </Typography>
+            ) : (
+              campaigns.map((campaign) => (
+                <React.Fragment key={campaign.id}>
+                  <ListItem
+                    secondaryAction={
+                      <Box>
+                        <IconButton edge="end" aria-label="edit" onClick={() => onEditCampaign(campaign)}>
+                          <EditIcon />
+                        </IconButton>
+                        <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(campaign.id, campaign.name)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Box>
+                    }
+                    disablePadding
+                  >
+                    <ListItemButton onClick={() => onLoadCampaign(campaign.id)}>
+                      <ListItemText
+                        primary={campaign.name}
+                        secondary={`Atualizada em: ${new Date(campaign.updated_at).toLocaleString()}`}
+                      />
+                    </ListItemButton>
+                  </ListItem>
+                  <Divider />
+                </React.Fragment>
+              ))
+            )}
+          </List>
+        )}
+      </Paper>
+    </Container>
+  );
+};
+
+export default MyCampaignsStep;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -15,9 +15,10 @@ import { Toaster, toast } from 'sonner';
 import { useUserAuth } from '../context/UserAuthContext';
 import { useSettings } from '../context/SettingsContext';
 import { loadSettingsFromDb } from '../utils/credentialsManager';
-import { saveCampaign, loadCampaign, updateCampaign } from '../utils/campaignState';
+import { getCampaigns, saveCampaign, loadCampaign, updateCampaign } from '../utils/campaignState';
 import { checkAuthStatus } from '../utils/auth';
 
+import MyCampaignsStep from '../components/MyCampaignsStep';
 import MainAppBar from '../components/MainAppBar';
 import Sidebar from '../components/Sidebar';
 import FieldPositioner from '../components/FieldPositioner';
@@ -62,7 +63,7 @@ function HomePage() {
   const { settings, updateSetting, saveSettings } = useSettings();
 
   // Component State
-  const [activeStep, setActiveStep] = useState(0);
+  const [activeStep, setActiveStep] = useState(null);
   const [darkMode, setDarkMode] = useState(() => {
     const savedMode = localStorage.getItem('darkMode');
     return savedMode ? JSON.parse(savedMode) : window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -301,6 +302,33 @@ function HomePage() {
     if (apiKey) geminiAPI.initialize(apiKey);
   }, [loadCampaignStandards]);
 
+  useEffect(() => {
+    const checkCampaignsAndSetInitialStep = async () => {
+      try {
+        const existingCampaigns = await getCampaigns();
+        if (existingCampaigns && existingCampaigns.length > 0) {
+          setActiveStep(0);
+        } else {
+          setActiveStep(1);
+        }
+      } catch (error) {
+        toast.error("Could not check for existing campaigns. Starting fresh.");
+        console.error("Failed to fetch initial campaigns:", error);
+        setActiveStep(1); // Default to campaign creation on error
+      }
+    };
+
+    if (user) { // Only run if user is logged in
+      checkCampaignsAndSetInitialStep();
+    } else {
+      // If there's no user, we can't fetch campaigns, so go to the first public step.
+      // This might need adjustment depending on which steps are public.
+      // For now, let's assume the flow starts after login.
+      setActiveStep(null); // Or some other default state for logged-out users
+    }
+  }, [user]);
+
+
   // Configure googleApi module with the token and setter from context
   useEffect(() => {
     if (googleAccessToken) {
@@ -389,7 +417,17 @@ function HomePage() {
     handleLinkedInRedirect();
   }, []); // Should only run once on page load
 
-  const steps = [ { label: 'Campanha', description: 'Criar o material de referência para a campanha.', icon: CampaignIcon }, { label: 'Posts Curtos', description: 'Gere, carregue ou edite os posts para redes sociais.', icon: InsertDriveFileOutlined }, { label: 'Imagem e Formatação', description: 'Carregue a imagem de fundo, posicione os campos e configure a formatação.', icon: ImageIcon }, { label: 'Gerar Imagens', description: 'Gere as imagens finais.', icon: FormatBold }, { label: 'Gerar Áudio', description: 'Crie a narração para os slides.', icon: Audiotrack }, { label: 'Gerar Vídeo', description: 'Crie um vídeo a partir das imagens geradas.', icon: Movie }, { label: 'Publicar', description: 'Publique o conteúdo no WordPress.', icon: Publish } ];
+  const steps = [ { label: 'Minhas Campanhas', description: 'Gerencie suas campanhas existentes ou crie uma nova.', icon: FolderOpenIcon }, { label: 'Campanha', description: 'Criar o material de referência para a campanha.', icon: CampaignIcon }, { label: 'Posts Curtos', description: 'Gere, carregue ou edite os posts para redes sociais.', icon: InsertDriveFileOutlined }, { label: 'Imagem e Formatação', description: 'Carregue a imagem de fundo, posicione os campos e configure a formatação.', icon: ImageIcon }, { label: 'Gerar Imagens', description: 'Gere as imagens finais.', icon: FormatBold }, { label: 'Gerar Áudio', description: 'Crie a narração para os slides.', icon: Audiotrack }, { label: 'Gerar Vídeo', description: 'Crie um vídeo a partir das imagens geradas.', icon: Movie }, { label: 'Publicar', description: 'Publique o conteúdo no WordPress.', icon: Publish } ];
+  const handleCreateNewCampaign = () => {
+    // Reset all campaign-specific state to their defaults
+    applyAppState({}); // Clears most of the state
+    setCurrentCampaign(null); // Ensure we're not editing an existing campaign
+    setActiveStep(1); // Move to the 'Campanha' step
+  };
+  const handleEditCampaign = (campaign) => {
+    setCurrentCampaign(campaign);
+    setShowSaveModal(true);
+  };
   const parseCsvFile = async (file) => { if (!file) return; try { const { data: newCsvData, headers: newHeaders } = await parseCsv(file); if (newCsvData && newCsvData.length > 0) { setCsvData(newCsvData); setCsvHeaders(newHeaders); const updatedFieldPositions = {}; const updatedFieldStyles = {}; const defaultStylesBase = { fontFamily: 'Inter', fontSize: 24, fontWeight: 'normal', fontStyle: 'normal', textDecoration: 'none', color: '#000000', textStroke: false, strokeColor: '#ffffff', strokeWidth: 2, textShadow: false, shadowColor: '#000000', shadowBlur: 4, shadowOffsetX: 2, shadowOffsetY: 2, textAlign: 'left', verticalAlign: 'top' }; newHeaders.forEach((header, index) => { updatedFieldPositions[header] = fieldPositions[header] || { x: 10 + (index % 5) * 18, y: 10 + Math.floor(index / 5) * 12, width: 15, height: 10, visible: true }; if (fieldStyles[header]) { updatedFieldStyles[header] = fieldStyles[header]; } else { if (index === 0) { updatedFieldStyles[header] = { ...defaultStylesBase, fontFamily: 'Anton', fontSize: 72 }; } else { updatedFieldStyles[header] = { ...defaultStylesBase }; } } }); setFieldPositions(updatedFieldPositions); setFieldStyles(updatedFieldStyles); setInputMethod('manual'); } } catch (error) { toast.error(error.message || 'Ocorreu um erro desconhecido ao processar o arquivo CSV.'); } };
   const handleCSVUpload = (event) => { const file = event.target.files[0]; parseCsvFile(file); };
   const handleDrop = (event) => { event.preventDefault(); event.stopPropagation(); const file = event.dataTransfer.files[0]; parseCsvFile(file); };
@@ -479,7 +517,20 @@ function HomePage() {
   const handleImageDragLeave = (event) => { event.preventDefault(); event.stopPropagation(); setIsDraggingOverImage(false); };
   const handleNext = () => { setActiveStep((prevActiveStep) => prevActiveStep + 1); };
   const handleBack = () => { setActiveStep((prevActiveStep) => prevActiveStep - 1); };
-  const canProceedToStep = () => { switch (activeStep) { case 0: return campaignContent !== null; case 1: return csvData.length > 0; case 2: return backgroundImage !== null; default: return true; } };
+  const canProceedToStep = (step) => {
+    switch (step) {
+      case 1: // -> Campanha
+        return true; // Always allowed to go from My Campaigns to new Campaign
+      case 2: // -> Posts Curtos
+        return campaignContent !== null;
+      case 3: // -> Imagem e Formatação
+        return csvData.length > 0;
+      case 4: // -> Gerar Imagens
+        return backgroundImage !== null;
+      default:
+        return true;
+    }
+  };
   const getFieldStats = () => { const visibleFields = Object.values(fieldPositions).filter(pos => pos.visible).length; const totalFields = csvHeaders.length; const styledFields = Object.keys(fieldStyles).length; return { visibleFields, totalFields, styledFields }; };
   const { visibleFields, totalFields, styledFields } = getFieldStats();
   const handleZIndexChange = (elementId, action) => { if (!elementId) return; let allElements = [ ...Object.entries(fieldPositions).map(([id, pos]) => ({ id, zIndex: pos.zIndex, isBrand: false })), ...brandElements.map(el => ({ id: el.id, zIndex: el.zIndex, isBrand: true })), ]; allElements.sort((a, b) => (a.zIndex || 0) - (b.zIndex || 0)); const currentIndex = allElements.findIndex(el => el.id === elementId); if (currentIndex === -1) return; const [currentElement] = allElements.splice(currentIndex, 1); switch (action) { case 'front': allElements.push(currentElement); break; case 'back': allElements.unshift(currentElement); break; case 'forward': allElements.splice(Math.min(currentIndex + 1, allElements.length), 0, currentElement); break; case 'backward': allElements.splice(Math.max(currentIndex - 1, 0), 0, currentElement); break; default: allElements.splice(currentIndex, 0, currentElement); return; } const newPositions = { ...fieldPositions }; const newBrandElements = [...brandElements]; allElements.forEach((el, index) => { el.zIndex = index; if (el.isBrand) { const brandEl = newBrandElements.find(b => b.id === el.id); if (brandEl) brandEl.zIndex = index; } else { if (newPositions[el.id]) { newPositions[el.id].zIndex = index; } } }); setFieldPositions(newPositions); setBrandElements(newBrandElements); };
@@ -626,9 +677,16 @@ function HomePage() {
         {!isMobile && <Fab size="small" onClick={() => setSidebarOpen(!sidebarOpen)} aria-label={sidebarOpen ? 'Fechar barra lateral' : 'Abrir barra lateral'} sx={{ position: 'fixed', top: '50%', left: sidebarOpen ? 320 - 20 : 0, transform: 'translateY(-50%)', zIndex: (theme) => theme.zIndex.drawer + 1, transition: 'left 0.2s ease-in-out', backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', '&:hover': { backgroundColor: 'background.default' } }} >{sidebarOpen ? <ChevronLeft /> : <ChevronRight />}</Fab>}
         <Box component="main" sx={{ flexGrow: 1, p: { xs: 1, sm: 2, md: 3 }, transition: theme.transitions.create('margin', { easing: theme.transitions.easing.sharp, duration: theme.transitions.duration.leavingScreen }) }} >
           <Toolbar />
-          <div hidden={activeStep !== 0}><Container maxWidth="lg"><Campaign steps={steps} {...campaignData} setProblema={setProblema} setSolucao={setSolucao} isGeneratingCampaign={isGeneratingCampaign} handleGenerateCampaignContent={handleGenerateCampaignContent} handleResetCampaign={handleResetCampaign} handleExportHtml={() => exportHtml(campaignData)} editingField={editingField} setEditingField={setEditingField} isGeneratingSummaryMedio={isGeneratingSummaryMedio} handleGenerateSummary={handleGenerateSummary} isGeneratingSummaryPequeno={isGeneratingSummaryPequeno} isGeneratingConteudoFormatado={isGeneratingConteudoFormatado} handleGenerateFormattedContent={handleGenerateFormattedContent} isGeneratingFollowup={isGeneratingFollowup} handleGenerateFollowupPosts={handleGenerateFollowupPosts} generatedImageUrl={generatedImageUrl} isGeneratingImage={isGeneratingImage} handleGenerateImage={handleGenerateImage} setCampaignContent={setCampaignContent} onEditFollowup={handleEditFollowup} followupPostsQuantity={followupPostsQuantity} setFollowupPostsQuantity={setFollowupPostsQuantity} setAspectRatio={setAspectRatio} /></Container></div>
-          <div hidden={activeStep !== 1}><PostsCurtosStep steps={steps} inputMethod={inputMethod} setInputMethod={setInputMethod} handleDrop={handleDrop} handleDragOver={handleDragOver} fileInputRef={fileInputRef} handleCSVUpload={handleCSVUpload} downloadExampleCsv={downloadExampleCsv} setShowSetupModal={setShowSetupModal} promptNumRecords={promptNumRecords} setPromptNumRecords={setPromptNumRecords} promptText={promptText} setPromptText={setPromptText} handleGenerateIAContent={handleGenerateIAContent} isGenerating={isGenerating} csvData={csvData} csvHeaders={csvHeaders} onDadosAlterados={handleDadosAlterados} darkMode={darkMode} exportCsv={exportCsv} /></div>
-          <div hidden={activeStep !== 2}>
+          <div hidden={activeStep !== 0}>
+            <MyCampaignsStep
+              onLoadCampaign={handleLoadCampaign}
+              onEditCampaign={handleEditCampaign}
+              onCreateNew={handleCreateNewCampaign}
+            />
+          </div>
+          <div hidden={activeStep !== 1}><Container maxWidth="lg"><Campaign steps={steps} {...campaignData} setProblema={setProblema} setSolucao={setSolucao} isGeneratingCampaign={isGeneratingCampaign} handleGenerateCampaignContent={handleGenerateCampaignContent} handleResetCampaign={handleResetCampaign} handleExportHtml={() => exportHtml(campaignData)} editingField={editingField} setEditingField={setEditingField} isGeneratingSummaryMedio={isGeneratingSummaryMedio} handleGenerateSummary={handleGenerateSummary} isGeneratingSummaryPequeno={isGeneratingSummaryPequeno} isGeneratingConteudoFormatado={isGeneratingConteudoFormatado} handleGenerateFormattedContent={handleGenerateFormattedContent} isGeneratingFollowup={isGeneratingFollowup} handleGenerateFollowupPosts={handleGenerateFollowupPosts} generatedImageUrl={generatedImageUrl} isGeneratingImage={isGeneratingImage} handleGenerateImage={handleGenerateImage} setCampaignContent={setCampaignContent} onEditFollowup={handleEditFollowup} followupPostsQuantity={followupPostsQuantity} setFollowupPostsQuantity={setFollowupPostsQuantity} setAspectRatio={setAspectRatio} /></Container></div>
+          <div hidden={activeStep !== 2}><PostsCurtosStep steps={steps} inputMethod={inputMethod} setInputMethod={setInputMethod} handleDrop={handleDrop} handleDragOver={handleDragOver} fileInputRef={fileInputRef} handleCSVUpload={handleCSVUpload} downloadExampleCsv={downloadExampleCsv} setShowSetupModal={setShowSetupModal} promptNumRecords={promptNumRecords} setPromptNumRecords={setPromptNumRecords} promptText={promptText} setPromptText={setPromptText} handleGenerateIAContent={handleGenerateIAContent} isGenerating={isGenerating} csvData={csvData} csvHeaders={csvHeaders} onDadosAlterados={handleDadosAlterados} darkMode={darkMode} exportCsv={exportCsv} /></div>
+          <div hidden={activeStep !== 3}>
             <ImageStep
               steps={steps}
               isDraggingOverImage={isDraggingOverImage}
@@ -669,10 +727,10 @@ function HomePage() {
               setCurrentPreviewIndex={setCurrentPreviewIndex}
             />
           </div>
-          <div hidden={activeStep !== 3}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} /></div>
-          <div hidden={activeStep !== 4}><AudioGenerator csvData={csvData} fieldPositions={fieldPositions} onAudiosGenerated={setGeneratedAudioData} initialAudioData={generatedAudioData} /></div>
-          <div hidden={activeStep !== 5}><VideoGenerator2 generatedImages={generatedImagesData} generatedAudioData={generatedAudioData} onVideoGenerated={(videoData) => setGeneratedVideosData(videoData)} /></div>
-          <div hidden={activeStep !== 6}><Publisher settings={settings} campaignContent={campaignContent} generatedImagesData={generatedImagesData} generatedVideosData={generatedVideosData} followupPosts={followupPosts} isScheduled={isScheduled} setIsScheduled={setIsScheduled} scheduleDate={scheduleDate} setScheduleDate={setScheduleDate} weeklySchedule={weeklySchedule} setWeeklySchedule={setWeeklySchedule} selectedProfile={selectedProfile} setSelectedProfile={setSelectedProfile} selectedImages={selectedImages} setSelectedImages={setSelectedImages} selectedVideos={selectedVideos} setSelectedVideos={setSelectedVideos} /></div>
+          <div hidden={activeStep !== 4}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} /></div>
+          <div hidden={activeStep !== 5}><AudioGenerator csvData={csvData} fieldPositions={fieldPositions} onAudiosGenerated={setGeneratedAudioData} initialAudioData={generatedAudioData} /></div>
+          <div hidden={activeStep !== 6}><VideoGenerator2 generatedImages={generatedImagesData} generatedAudioData={generatedAudioData} onVideoGenerated={(videoData) => setGeneratedVideosData(videoData)} /></div>
+          <div hidden={activeStep !== 7}><Publisher settings={settings} campaignContent={campaignContent} generatedImagesData={generatedImagesData} generatedVideosData={generatedVideosData} followupPosts={followupPosts} isScheduled={isScheduled} setIsScheduled={setIsScheduled} scheduleDate={scheduleDate} setScheduleDate={setScheduleDate} weeklySchedule={weeklySchedule} setWeeklySchedule={setWeeklySchedule} selectedProfile={selectedProfile} setSelectedProfile={setSelectedProfile} selectedImages={selectedImages} setSelectedImages={setSelectedImages} selectedVideos={selectedVideos} setSelectedVideos={setSelectedVideos} /></div>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} ><Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button><Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box><Button onClick={handleNext} disabled={activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1)} variant="contained" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Próximo</Button></Box>
         </Box>
       </Box>


### PR DESCRIPTION
This commit introduces a new initial step to the campaign creation workflow called "Minhas Campanhas".

Key changes:
- A new `MyCampaignsStep` component is created to display a list of existing campaigns, allowing users to load, edit, or delete them.
- The main `HomePage` now checks if the user has existing campaigns. If so, the application starts at the "Minhas Campanhas" step. If not, it starts directly at the "Campanha" step as before.
- The `MainAppBar` has been simplified. The "Load Campaign" option, previously in a folder menu, has been removed. This functionality is now handled by the new "Minhas Campanhas" step. The app bar now features a direct "Save Campaign" icon.

Note: Due to environmental constraints that prevented the execution of an automated frontend verification script (the agent's `kill` command was blocked, preventing a necessary server restart), this change has not been fully verified through automated end-to-end testing. The implementation has been done according to the plan, but manual verification is recommended.