### PR TITLE
Fix: Correct field positioning in generated image editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -107,6 +107,8 @@ const FieldPositioner = ({
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+  // New state for the actual rendered image dimensions and offsets
+  const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
   const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
@@ -207,13 +209,36 @@ const FieldPositioner = ({
         if (onImageDisplayedSizeChange) {
           onImageDisplayedSizeChange({ width, height });
         }
+
+        // Calculate the actual rendered size and position of the image due to 'object-fit: contain'
+        if (originalImageSize?.width && originalImageSize?.height && width > 0 && height > 0) {
+          const containerAspectRatio = width / height;
+          const imageAspectRatio = originalImageSize.width / originalImageSize.height;
+
+          let renderedWidth, renderedHeight, x, y;
+
+          if (containerAspectRatio > imageAspectRatio) {
+            // Container is wider than the image (letterboxed on sides)
+            renderedHeight = height;
+            renderedWidth = height * imageAspectRatio;
+            x = (width - renderedWidth) / 2;
+            y = 0;
+          } else {
+            // Container is taller or equal aspect ratio (letterboxed on top/bottom)
+            renderedWidth = width;
+            renderedHeight = width / imageAspectRatio;
+            x = 0;
+            y = (height - renderedHeight) / 2;
+          }
+          setRenderedImageMetrics({ width: renderedWidth, height: renderedHeight, x, y });
+        }
       }
     });
 
     observer.observe(container);
 
     return () => observer.disconnect();
-  }, [onImageDisplayedSizeChange, backgroundImage]);
+  }, [onImageDisplayedSizeChange, backgroundImage, originalImageSize]);
 
   // Effect to initialize or update field positions and styles based on csvHeaders and props.
   // This ensures that every field in csvHeaders has a corresponding position and a complete style object.
@@ -500,16 +525,16 @@ const FieldPositioner = ({
     ? `${originalImageSize.width} / ${originalImageSize.height}`
     : '16 / 9';
 
-  // Effect to calculate font scale based on container and original image sizes
+  // Effect to calculate font scale based on the actual rendered image size
   useEffect(() => {
-    if (imageSize.width > 0 && originalImageSize?.width > 0 && imageSize.height > 0 && originalImageSize?.height > 0) {
-      const widthScale = imageSize.width / originalImageSize.width;
-      const heightScale = imageSize.height / originalImageSize.height;
-      setFontScale(Math.min(widthScale, heightScale));
+    if (renderedImageMetrics.width > 0 && originalImageSize?.width > 0) {
+      // The scale is uniform, so we can just use the width ratio.
+      const scale = renderedImageMetrics.width / originalImageSize.width;
+      setFontScale(scale);
     } else {
       setFontScale(1);
     }
-  }, [imageSize, originalImageSize]);
+  }, [renderedImageMetrics, originalImageSize]);
 
   // Efeito para gerenciar scroll durante interações
   useEffect(() => {
@@ -569,7 +594,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField, fontScale]);
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField, fontScale, renderedImageMetrics]);
 
   if (!backgroundImage) {
     return (
@@ -673,31 +698,44 @@ const FieldPositioner = ({
                 draggable={false}
               />
 
-              {imageSize.width > 0 && renderableElements.map(element => (
-                <DraggableElement
-                  key={element.id}
-                  element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}
-                  position={element.position}
-                  style={element.style}
-                  content={element.content}
-                  isSelected={selectedField === element.id}
-                  onSelect={handleFieldSelectInternal}
-                  onPositionChange={handlePositionChange}
-                  onSizeChange={handleSizeChange}
-                  containerSize={imageSize}
-                  onContentChange={element.type === 'text' ? handleContentChange : undefined}
-                  onDoubleClick={() => {
-                    if (element.type === 'text' && isHtmlField(element.id)) {
-                      onOpenHtmlEditor(element.id);
-                    }
-                  }}
-                  rotation={element.rotation}
-                  originalImageSize={originalImageSize}
-                  fontScale={element.fontScale}
-                  enableHtmlRendering={element.enableHtmlRendering}
-                  darkMode={darkMode}
-                />
-              ))}
+              {/* Wrapper for draggable elements, positioned over the actual image */}
+              <Box
+                className="elements-wrapper"
+                sx={{
+                  position: 'absolute',
+                  left: `${renderedImageMetrics.x}px`,
+                  top: `${renderedImageMetrics.y}px`,
+                  width: `${renderedImageMetrics.width}px`,
+                  height: `${renderedImageMetrics.height}px`,
+                  pointerEvents: 'none', // Allow clicks to pass through to the main container for deselection
+                }}
+              >
+                {renderedImageMetrics.width > 0 && renderableElements.map(element => (
+                  <DraggableElement
+                    key={element.id}
+                    element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}
+                    position={element.position}
+                    style={element.style}
+                    content={element.content}
+                    isSelected={selectedField === element.id}
+                    onSelect={handleFieldSelectInternal}
+                    onPositionChange={handlePositionChange}
+                    onSizeChange={handleSizeChange}
+                    containerSize={renderedImageMetrics} // Use the actual rendered image size
+                    onContentChange={element.type === 'text' ? handleContentChange : undefined}
+                    onDoubleClick={() => {
+                      if (element.type === 'text' && isHtmlField(element.id)) {
+                        onOpenHtmlEditor(element.id);
+                      }
+                    }}
+                    rotation={element.rotation}
+                    originalImageSize={originalImageSize}
+                    fontScale={element.fontScale}
+                    enableHtmlRendering={element.enableHtmlRendering}
+                    darkMode={darkMode}
+                  />
+                ))}
+              </Box>
             </Box>
 
             {csvData && csvData.length > 1 && (


### PR DESCRIPTION
The previous implementation incorrectly positioned draggable fields relative to their container's dimensions, rather than the actual dimensions of the visible image. When the container's aspect ratio did not match the image's, the `object-fit: contain` property on the image would create letterboxing (empty space), causing field positions (especially on the Y-axis) to be compressed and misaligned.

This commit resolves the issue by:
- Calculating the true rendered dimensions and offsets of the image within its container.
- Introducing a wrapper element that is dynamically sized and positioned to perfectly overlay the visible image.
- Bounding the draggable elements within this new wrapper, ensuring all percentage-based positions are relative to the correct reference frame.