### PR TITLE
Fix: Resolve LinkedIn profile loading and duplication issues

### DIFF
--- a/src/components/LinkedinInfobox.jsx
+++ b/src/components/LinkedinInfobox.jsx
@@ -19,7 +19,7 @@ const LinkedinInfobox = ({ settings }) => {
   const [profiles, setProfiles] = useState({
     personal: null,
     organizations: [],
-    loading: true,
+    loading: false,
     error: null
   });
 
@@ -43,13 +43,19 @@ const LinkedinInfobox = ({ settings }) => {
             error: error.message
           }));
         }
-      } else {
-        setProfiles(prev => ({ ...prev, loading: false, error: "Conecte sua conta do LinkedIn para ver seus perfis." }));
       }
     };
 
     fetchProfiles();
   }, [settings]);
+
+  if (!settings?.linkedin?.accessToken && !profiles.error) {
+    return (
+      <Alert severity="info">
+        Instruções de Configuração
+      </Alert>
+    );
+  }
 
   if (profiles.loading) {
     return (

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -224,21 +224,28 @@ const Publisher = ({
 
   const getPublishingTargets = () => {
     const targets = [];
+    const addedIds = new Set();
     if (linkedinProfiles.personal) {
-      targets.push({
-        id: linkedinProfiles.personal.id,
-        name: `${linkedinProfiles.personal.name} (Perfil Pessoal)`,
-        type: 'personal'
-      });
+        const personalTarget = {
+            id: linkedinProfiles.personal.id,
+            name: `${linkedinProfiles.personal.name} (Perfil Pessoal)`,
+            type: 'personal'
+        };
+        targets.push(personalTarget);
+        addedIds.add(personalTarget.id);
     }
+
     if (linkedinProfiles.organizations && linkedinProfiles.organizations.length > 0) {
-      linkedinProfiles.organizations.forEach(org => {
-        targets.push({
-          id: org.id,
-          name: `${org.name} (Página)`,
-          type: 'organization'
+        linkedinProfiles.organizations.forEach(org => {
+            if (!addedIds.has(org.id)) {
+                targets.push({
+                    id: org.id,
+                    name: `${org.name} (Página)`,
+                    type: 'organization'
+                });
+                addedIds.add(org.id);
+            }
         });
-      });
     }
     return targets;
   };


### PR DESCRIPTION
This commit addresses two issues related to the LinkedIn integration:

1.  **LinkedinInfobox Loading Error**: The `LinkedinInfobox` component was attempting to fetch profiles even when the user was not authenticated, causing an error message to be displayed. This has been fixed by only triggering the profile fetch when an access token is present. A helpful instructional message is now shown instead of an error when the user is not connected.

2.  **Profile Duplication on Refresh**: In the `Publisher` component, refreshing the list of LinkedIn profiles could cause duplicate entries to appear in the selection dropdown. This was resolved by modifying the `getPublishingTargets` function to use a `Set` to track profile IDs, ensuring that only unique profiles are displayed.