### PR TITLE
fix: Resolve 'toast is not defined' ReferenceError in Campaign component

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -25,6 +25,7 @@ import {
   Tabs,
   Tab,
 } from '@mui/material';
+import { toast } from 'sonner';
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { getCampaignPrompt } from '../utils/campaignPrompt';
 import { useSettings } from '../context/SettingsContext';


### PR DESCRIPTION
This commit fixes a `ReferenceError: toast is not defined` that occurred when using the "Save to Collection" feature.

The error was caused by direct calls to `toast.error()` within the `handleSaveToDrive` function in `src/components/Campaign.jsx` without the component importing the `toast` object from the 'sonner' library.

The fix adds the required `import { toast } from 'sonner';` statement to the top of `src/components/Campaign.jsx`, making the toast notification functions available within the component's scope and resolving the error.