### PR TITLE
fix: Ensure force refresh clears backend cache

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -152,7 +152,7 @@ async function handleCreatePost(fetch, request, response) {
 }
 
 async function handleGetProfiles(fetch, request, response) {
-  const { accessToken } = request.body;
+  const { accessToken, forceRefresh } = request.body;
   if (!accessToken) return response.status(400).json({ error: 'Missing accessToken for getProfiles.' });
   const headers = { 'Authorization': `Bearer ${accessToken}`, 'X-Restli-Protocol-Version': '2.0.0', 'LinkedIn-Version': '202507' };
   try {
@@ -168,10 +168,14 @@ async function handleGetProfiles(fetch, request, response) {
       const orgAclsData = await orgAclsResponse.json();
       const orgUrns = orgAclsData.elements?.map(el => el.organization) || [];
       const uniqueOrgIds = [...new Set(orgUrns.map(urn => urn.split(':').pop()))];
+      const cacheKeys = uniqueOrgIds.map(id => `linkedin:org:${id}`);
+
+      if (forceRefresh && cacheKeys.length > 0) {
+        await kv.del(cacheKeys);
+      }
 
       if (uniqueOrgIds.length > 0) {
         const allOrgDetails = {};
-        const cacheKeys = uniqueOrgIds.map(id => `linkedin:org:${id}`);
         const cachedResults = await kv.mget(cacheKeys);
 
         const orgsToFetch = [];

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -32,9 +32,9 @@ class LinkedInAPI {
     return organizations;
   }
 
-  async getAllManagedProfiles() {
+  async getAllManagedProfiles(forceRefresh = false) {
     // The proxy now handles fetching both personal and organization profiles together.
-    return this._proxyFetch('getProfiles');
+    return this._proxyFetch('getProfiles', { forceRefresh });
   }
 
   async getPersonalProfile() {
@@ -81,7 +81,7 @@ export const getLinkedInProfiles = async (linkedinConfig, forceRefresh = false) 
     }
 
     const api = new LinkedInAPI(linkedinConfig.accessToken);
-    const profiles = await api.getAllManagedProfiles();
+    const profiles = await api.getAllManagedProfiles(forceRefresh);
 
     try {
         sessionStorage.setItem(cacheKey, JSON.stringify(profiles));


### PR DESCRIPTION
This commit fixes an issue where the 'force refresh' button for LinkedIn profiles was not working as expected.

The frontend was clearing its sessionStorage, but the backend was still serving stale data from its Redis cache.

The fix involves two parts:
1. The frontend now sends a `forceRefresh: true` flag to the backend when a refresh is initiated.
2. The backend proxy now checks for this flag. If it's true, it deletes the relevant organization data from the Redis cache before proceeding to fetch fresh data from the LinkedIn API.