### PR TITLE
feat: Implement incremental and contextual follow-up post generation

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -602,7 +602,33 @@ function HomePage() {
   }, [aspectRatio, updateImageAndPalette]);
   const handleGenerateSummary = async (targetLength, content = campaignContent) => { if (!content?.conteudo) { alert("Por favor, gere o conteúdo principal primeiro."); return; } const setLoading = targetLength === 1800 ? setIsGeneratingSummaryMedio : setIsGeneratingSummaryPequeno; setLoading(true); if (!geminiAPI.isInitialized) { const apiKey = getGeminiApiKey(); if (!apiKey) { alert('Por favor, configure sua chave de API Gemini primeiro.'); setLoading(false); return; } geminiAPI.initialize(apiKey); } try { const summaryPrompt = `Resuma o seguinte texto para ter no máximo ${targetLength} caracteres, mantendo a essência e o tom: "${stripHtml(content.conteudo)}"`; const summary = await geminiAPI.generateContent(summaryPrompt); const fieldName = targetLength === 1800 ? 'conteudoMedio' : 'conteudoPequeno'; setCampaignContent(prev => ({ ...prev, [fieldName]: summary })); } catch (error) { alert(`Ocorreu um erro ao gerar o resumo. Verifique o console.`); } finally { setLoading(false); } };
   const handleGenerateFormattedContent = async (content = campaignContent) => { if (!content?.conteudo) { toast.error("Por favor, gere o conteúdo principal primeiro."); return; } setIsGeneratingConteudoFormatado(true); try { const finalContent = await generateFormattedContent({ content }); setCampaignContent(prev => ({ ...prev, conteudoFormatado: finalContent })); } catch (error) { toast.error(`Ocorreu um erro ao gerar o conteúdo formatado: ${error.message}`); } finally { setIsGeneratingConteudoFormatado(false); } };
-  const handleGenerateFollowupPosts = async (content = campaignContent) => { if (!content?.conteudo) { toast.error("Por favor, gere o conteúdo principal primeiro."); return; } setIsGeneratingFollowup(true); try { const plan = await generateFollowupPlan({ content, followupPostsQuantity }); const posts = await generateFollowupPosts({ content, plan }); setFollowupPosts(posts); } catch (error) { toast.error(`Ocorreu um erro ao gerar os posts de follow-up: ${error.message}`); } finally { setIsGeneratingFollowup(false); } };
+  const handleGenerateFollowupPosts = async (content = campaignContent) => {
+    if (!content?.conteudo) {
+      toast.error("Por favor, gere o conteúdo principal primeiro.");
+      return;
+    }
+
+    if (followupPosts.length >= followupPostsQuantity) {
+      toast.info('A quantidade de posts desejada já foi atingida ou superada.');
+      return;
+    }
+
+    setIsGeneratingFollowup(true);
+    try {
+      const neededQuantity = followupPostsQuantity - followupPosts.length;
+      const plan = await generateFollowupPlan({
+        content,
+        neededQuantity,
+        existingPosts: followupPosts,
+      });
+      const newPosts = await generateFollowupPosts({ content, plan });
+      setFollowupPosts(prevPosts => [...prevPosts, ...newPosts]);
+    } catch (error) {
+      toast.error(`Ocorreu um erro ao gerar os posts de follow-up: ${error.message}`);
+    } finally {
+      setIsGeneratingFollowup(false);
+    }
+  };
   const handleResetCampaign = () => {
     console.log('[HomePage] DIAGNOSTIC: handleResetCampaign called. Setting generatedImageUrl to null.');
     setCampaignContent(null);

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -160,7 +160,7 @@ export const generateFormattedContent = async ({ content }) => {
 /**
  * Generates a plan for follow-up posts for the campaign.
  */
-export const generateFollowupPlan = async ({ content, followupPostsQuantity }) => {
+export const generateFollowupPlan = async ({ content, neededQuantity, existingPosts = [] }) => {
   if (!content?.conteudo) {
     throw new Error("Conteúdo principal deve ser gerado primeiro.");
   }
@@ -173,8 +173,15 @@ export const generateFollowupPlan = async ({ content, followupPostsQuantity }) =
   const { persona } = getCampaignPrompt();
   const personaString = formatObjectForPrompt(persona, ['description']);
 
+  const existingPostsString = existingPosts.length > 0
+    ? `
+POSTS JÁ EXISTENTES (NÃO REPITA ESTES TEMAS OU ETAPAS):
+${existingPosts.map(p => `- Título: "${p.titulo}", Etapa AIDA: ${p.etapa_aida}`).join('\n')}
+`
+    : '';
+
   const prompt =
-  `Você é um estrategista de marketing de conteúdo. Sua tarefa é criar um plano para ${followupPostsQuantity} posts sequenciais no LinkedIn, baseados em um conteúdo principal, seguindo o modelo AIDA.
+  `Você é um estrategista de marketing de conteúdo. Sua tarefa é criar um plano para ${neededQuantity} novos posts sequenciais no LinkedIn, baseados em um conteúdo principal e complementando os posts já existentes.
 
 CONTEÚDO PRINCIPAL:
 Tema: "${stripHtml(content.titulo)}"
@@ -182,7 +189,7 @@ Detalhes: "${stripHtml(content.conteudo)}"
 
 PERSONA-ALVO:
 ${personaString}
-
+${existingPostsString}
 ESTRUTURA DA SEQUÊNCIA (AIDA):
 1.  **Atenção:** Gancho impactante (dado, insight contraintuitivo).
 2.  **Interesse:** Conexão com problema/oportunidade da persona.
@@ -190,10 +197,11 @@ ESTRUTURA DA SEQUÊNCIA (AIDA):
 4.  **Ação:** CTA direto para o conteúdo principal.
 
 INSTRUÇÕES:
+-   Crie um plano para exatamente ${neededQuantity} novos posts.
 -   Para cada post, defina um título curto e chamativo.
 -   Defina o "coração do prompt" que será usado para gerar o conteúdo completo em uma etapa posterior.
 -   O "coração do prompt" deve ser uma instrução clara e concisa para um redator, incluindo o tipo de gancho, o ângulo e a emoção a ser evocada.
--   Varie os formatos e gatilhos para cada etapa do funil AIDA.
+-   Varie os formatos e gatilhos para cada etapa do funil AIDA, evitando as etapas já cobertas nos posts existentes.
 
 FORMATO DE RESPOSTA:
 Retorne um array JSON com a seguinte estrutura. Não inclua markdown ou qualquer outro texto fora do JSON.


### PR DESCRIPTION
This commit enhances the 'Generate Follow-up Posts' feature based on user feedback.

1.  **Incremental Generation**: The system now checks how many follow-up posts already exist. It will only generate the number of new posts required to meet the user-defined quantity, preventing unnecessary regeneration and preserving existing content. If the desired number of posts already exists, it informs the user and takes no further action.

2.  **Contextual AI Prompt**: The prompt sent to the AI for planning new follow-up posts now includes the AIDA stage and title of any existing posts. This provides the AI with the necessary context to generate a more coherent and complementary sequence of new posts, avoiding repetition of themes or funnel stages.

These changes result in a more intelligent, efficient, and context-aware content generation experience.