### PR TITLE
fix(api): Add missing 'googleapis' dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@vercel/blob": "^1.1.1",
     "cookie": "^1.0.2",
+    "googleapis": "^140.0.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3"
   }


### PR DESCRIPTION
This commit resolves a server-side crash that occurred when using the 'Save to Collection' feature.

The error `Cannot find module 'googleapis'` was caused by the new `api/google-proxy.js` endpoint which uses the `googleapis` library, but the package was not declared as a dependency in the `api/package.json` file.

This fix adds `googleapis` to the dependencies, ensuring it will be installed in the server environment, thus resolving the module-not-found error.