### PR TITLE
Fix: Correct LinkedIn API request and media metadata handling

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -190,7 +190,7 @@ async function handleGetProfiles(fetch, request, response) {
         if (orgsToFetch.length > 0) {
           for (let i = 0; i < orgsToFetch.length; i += 50) {
             const chunk = orgsToFetch.slice(i, i + 50);
-            const batchOrgUrl = `https://api.linkedin.com/rest/organizations?ids=List(${chunk.join(',')})`;
+            const batchOrgUrl = `https://api.linkedin.com/rest/organizations?ids=${encodeURIComponent(`List(${chunk.join(',')})`)}`;
             const batchOrgResponse = await fetchWithRetry(fetch, batchOrgUrl, { headers });
             if (batchOrgResponse.ok) {
               const fetchedData = await batchOrgResponse.json();

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -40,6 +40,22 @@ import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi'
 import { composeImage } from '../utils/imageComposer';
 import { useUserAuth } from '../context/UserAuthContext';
 
+const dataURLtoBlob = (dataurl) => {
+    if (!dataurl) return null;
+    const arr = dataurl.split(',');
+    if (arr.length < 2) return null;
+    const mimeMatch = arr[0].match(/:(.*?);/);
+    if (!mimeMatch) return null;
+    const mime = mimeMatch[1];
+    const bstr = atob(arr[1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+    while(n--){
+        u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new Blob([u8arr], {type:mime});
+};
+
 const ImageGeneratorFrontendOnly = ({
   csvData,
   backgroundImage,
@@ -257,10 +273,12 @@ const ImageGeneratorFrontendOnly = ({
           ctx.restore();
         }
         const dataUrl = canvas.toDataURL('image/png', 1.0);
+        const blob = dataURLtoBlob(dataUrl);
         const existingImageDataItem = generatedImages.find(img => img.index === i);
         const imageData = {
           url: dataUrl, // The dataUrl is used for display
           dataUrl: dataUrl, // And also stored explicitly for upload
+          blob,
           record,
           index: i,
           filename: `midiator_${String(i + 1).padStart(3, '0')}.png`,
@@ -435,9 +453,11 @@ const ImageGeneratorFrontendOnly = ({
         ctx.restore();
       }
       const dataUrl = canvas.toDataURL('image/png', 1.0);
+      const blob = dataURLtoBlob(dataUrl);
       const newImageData = {
         url: dataUrl,
         dataUrl: dataUrl,
+        blob,
         record,
         index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -58,6 +58,22 @@ import ColorThief from 'colorthief';
 
 import { setGoogleApiToken, setGoogleApiTokenSetter, findFolderByName, createFolder, uploadFile } from '../utils/googleApi';
 
+const dataURLtoBlob = (dataurl) => {
+    if (!dataurl) return null;
+    const arr = dataurl.split(',');
+    if (arr.length < 2) return null;
+    const mimeMatch = arr[0].match(/:(.*?);/);
+    if (!mimeMatch) return null;
+    const mime = mimeMatch[1];
+    const bstr = atob(arr[1]);
+    let n = bstr.length;
+    const u8arr = new Uint8Array(n);
+    while(n--){
+        u8arr[n] = bstr.charCodeAt(n);
+    }
+    return new Blob([u8arr], {type:mime});
+};
+
 function HomePage() {
   const { user, googleAccessToken, setGoogleAccessToken, fetchUser } = useUserAuth();
   const { settings, updateSetting, saveSettings } = useSettings();
@@ -156,13 +172,28 @@ function HomePage() {
     setColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
     setStandardsColors(Array.isArray(state.standardsColors) ? state.standardsColors : []);
     setFollowupPosts(Array.isArray(state.followupPosts) ? state.followupPosts : []);
-    setGeneratedImagesData(Array.isArray(state.generatedImagesData) ? state.generatedImagesData : []);
+    const loadedGeneratedImagesData = Array.isArray(state.generatedImagesData) ? state.generatedImagesData : [];
+    const regeneratedImagesData = loadedGeneratedImagesData.map(img => {
+        if (img.dataUrl && (!img.blob || (typeof img.blob === 'object' && Object.keys(img.blob).length === 0))) {
+            const blob = dataURLtoBlob(img.dataUrl);
+            if (blob) {
+                return { ...img, blob };
+            }
+        }
+        return img;
+    });
+    setGeneratedImagesData(regeneratedImagesData);
+
     // FIX: Filter out invalid audio data on load to prevent crashes
     setGeneratedAudioData(
       Array.isArray(state.generatedAudioData)
         ? state.generatedAudioData.filter(a => a && typeof a.duration === 'number')
         : []
     );
+
+    // TODO: Videos are likely not being persisted correctly on save/load.
+    // The generated URL is a temporary object URL, and the blob is lost on serialization.
+    // This needs a more involved fix in how videos are saved.
     setGeneratedVideosData(Array.isArray(state.generatedVideosData) ? state.generatedVideosData : []);
     setBrandElements(Array.isArray(state.brandElements) ? state.brandElements : []);
 


### PR DESCRIPTION
This commit addresses two main issues and a related data persistence problem:

1.  **LinkedIn API Request:** The API call to fetch organization profiles was failing due to an improperly encoded URL. The `List()` syntax in the `ids` parameter is now correctly URL-encoded.

2.  **Image Metadata Display:** The image preview metadata was showing 'N/A' because the `blob` property was missing from the image data. The image generator now converts the `dataUrl` to a `blob` and includes it in the image data object.

3.  **Image Metadata on Load:** A related issue was discovered where the `blob` data, being non-serializable, was lost when a campaign was saved and reloaded. The campaign loading logic has been updated to regenerate the image `blob` from the persisted `dataUrl`, ensuring metadata is displayed correctly for loaded campaigns.