### PR TITLE
Fix: Correct API requests, metadata handling, and save performance

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -270,7 +270,20 @@ function HomePage() {
       csvData,
       csvHeaders,
     };
-    console.log("[HomePage] Campaign data object created:", campaignDataToSave);
+
+    const dataForSaving = {
+      ...campaignDataToSave,
+      generatedImagesData: campaignDataToSave.generatedImagesData.map(img => {
+        const { blob, ...rest } = img;
+        return rest;
+      }),
+      generatedVideosData: campaignDataToSave.generatedVideosData.map(vid => {
+        const { blob, ...rest } = vid;
+        return rest;
+      }),
+    };
+
+    console.log("[HomePage] Campaign data object created for saving:", dataForSaving);
 
 
     setIsSaving(true);
@@ -278,12 +291,12 @@ function HomePage() {
     try {
       if (currentCampaign) {
         console.log(`[HomePage] Updating existing campaign, ID: ${currentCampaign.id}`);
-        const updated = await updateCampaign(currentCampaign.id, name, campaignDataToSave, setUploadProgress, user.uuid);
+        const updated = await updateCampaign(currentCampaign.id, name, dataForSaving, setUploadProgress, user.uuid);
         toast.success(`Campaign "${name}" updated.`);
         setCurrentCampaign(updated);
       } else {
         console.log(`[HomePage] Saving new campaign.`);
-        const newCampaign = await saveCampaign(name, campaignDataToSave, setUploadProgress, user.uuid);
+        const newCampaign = await saveCampaign(name, dataForSaving, setUploadProgress, user.uuid);
         toast.success(`Campaign "${name}" saved.`);
         setCurrentCampaign(newCampaign);
       }


### PR DESCRIPTION
This commit addresses several issues:

1.  **LinkedIn API Request:** The API call to fetch organization profiles was failing due to an improperly encoded URL. The `List()` syntax in the `ids` parameter is now correctly URL-encoded.

2.  **Image Metadata Display:** The image preview metadata was showing 'N/A' because the `blob` property was missing from the image data. The image generator now converts the `dataUrl` to a `blob` and includes it in the image data object.

3.  **Image Metadata on Load:** A related issue was discovered where the `blob` data, being non-serializable, was lost when a campaign was saved and reloaded. The campaign loading logic has been updated to regenerate the image `blob` from the persisted `dataUrl`.

4.  **Campaign Save Performance:** Saving a campaign after generating an image was extremely slow or would freeze. This was caused by the presence of the non-serializable `blob` object in the campaign data being saved. The `handleSaveCampaign` function now removes the `blob` property from the data before sending it to the save/update functions, resolving the performance issue.