### PR TITLE
Feat: Add image prompt column to short post generation

### DIFF
--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -500,9 +500,9 @@ INSTRUÇÕES DE FORMATAÇÃO DA SAÍDA (MUITO IMPORTANTE):
 A SUA RESPOSTA DEVE CONTER *APENAS E SOMENTE* UM BLOCO DE TEXTO FORMATADO COMO CSV, SEM NENHUM TEXTO ADICIONAL ANTES OU DEPOIS DO BLOCO CSV.
 O BLOCO CSV DEVE SER DELIMITADO EXATAMENTE POR TRÊS CRASE SEGUIDAS E A PALAVRA "csv" (\`\`\`csv) NO INÍCIO, E TRÊS CRASE SEGUIDAS (\`\`\`) NO FINAL.
 DENTRO DO BLOCO CSV:
-- A primeira linha DEVE SER o cabeçalho: Titulo;Texto Principal;Ponte para o Próximo
+- A primeira linha DEVE SER o cabeçalho: Titulo;Texto Principal;Ponte para o Próximo;prompt_imagem_carrossel
 - As linhas subsequentes DEVERÃO ser os dados de cada elemento, com os campos separados por PONTO E VÍRGULA (;).
-- NÃO inclua números de elemento ou qualquer outra coluna além de "Titulo", "Texto Principal", e "Ponte para o Próximo".
+- NÃO inclua números de elemento ou qualquer outra coluna além de "Titulo", "Texto Principal", "Ponte para o Próximo", e "prompt_imagem_carrossel".
 - NÃO inclua explicações, introduções, ou qualquer texto fora do bloco \`\`\`csv ... \`\`\`.
 
 REQUISITOS PARA O CONTEÚDO DE CADA ELEMENTO (LINHA DO CSV):
@@ -523,6 +523,12 @@ REQUISITOS PARA O CONTEÚDO DE CADA ELEMENTO (LINHA DO CSV):
    - Exemplos:
      → "Próximo: O passo que muda tudo!"
      → "Siga para o segredo nº3 👇"
+4. **prompt_imagem_carrossel** (Coluna 4):
+   - Um prompt de texto detalhado para um modelo de geração de imagem (como DALL-E ou Midjourney).
+   - O prompt deve descrever uma imagem de fundo visualmente atraente e conceitual para um post de carrossel, sobre a qual os campos de texto seriam sobrepostos.
+   - A imagem descrita NÃO DEVE CONTER TEXTO.
+   - O prompt deve ser em inglês, para compatibilidade com os modelos de imagem.
+   - Exemplo: "A vibrant, abstract background with swirling gradients of blue and gold, representing the flow of data and innovation, with a soft, clean area for text overlay."
 
 ESTRUTURA NARRATIVA SUGERIDA:
 - Elemento 1: Dado impactante ou pergunta instigante extraída do início do TEXTO BASE.

--- a/src/utils/iaResponseParser.js
+++ b/src/utils/iaResponseParser.js
@@ -7,7 +7,7 @@ import Papa from 'papaparse';
  */
 export const parseIaResponseToCsvData = (responseText) => {
   // Definição dos cabeçalhos esperados pelo GerenciadorRegistros
-  const finalHeaders = ["Título", "Texto Principal", "Ponte para o Próximo"];
+  const finalHeaders = ["Título", "Texto Principal", "Ponte para o Próximo", "prompt_imagem_carrossel"];
   const data = [];
 
   if (!responseText || typeof responseText !== 'string') {
@@ -50,6 +50,7 @@ export const parseIaResponseToCsvData = (responseText) => {
         if (iaHeaderLower.includes('titulo') || iaHeaderLower.includes('título')) headerMap[iaHeaderTrimmed] = "Título";
         else if (iaHeaderLower.includes('texto_principal') || iaHeaderLower.includes('texto principal')) headerMap[iaHeaderTrimmed] = "Texto Principal";
         else if (iaHeaderLower.includes('ponte_proximo') || iaHeaderLower.includes('ponte para o próximo')) headerMap[iaHeaderTrimmed] = "Ponte para o Próximo";
+        else if (iaHeaderLower.includes('prompt_imagem_carrossel')) headerMap[iaHeaderTrimmed] = "prompt_imagem_carrossel";
         else if (iaHeaderLower.includes('id_elemento') || iaHeaderLower.includes('id') || iaHeaderLower.includes('num_slide') || iaHeaderLower.includes('elemento')) headerMap[iaHeaderTrimmed] = "id";
       });
       console.log("[parseIaResponseToCsvData] Mapa de Cabeçalhos construído:", headerMap);


### PR DESCRIPTION
This commit implements a new feature to enhance the 'generate short posts' functionality.

When generating short posts with the AI, a new column named `prompt_imagem_carrossel` is now included in the output. This column contains a detailed text prompt suitable for an image generation model. The prompt describes a conceptual background image for a carousel post, upon which the other text fields can be overlaid.

Changes include:
- Modifying the AI prompt in `src/utils/generationHandlers.js` to instruct the AI to generate the new column.
- Updating the CSV parser in `src/utils/iaResponseParser.js` to correctly handle and map the new column.