### PR TITLE
Refactor: Remove media metadata display from publisher UI

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -606,14 +606,6 @@ const Publisher = ({
                             <video src={previewedMedia.url} controls style={{ maxHeight: '100%', maxWidth: '100%' }} />
                           )}
                         </Box>
-                        <Box sx={{ mt: 1, textAlign: 'center' }}>
-                          <Typography variant="caption" color="text.secondary">
-                            Tipo: {previewedMedia.fileType}
-                          </Typography>
-                          <Typography variant="caption" color="text.secondary" sx={{ ml: 2 }}>
-                            Tamanho: {previewedMedia.fileSize}
-                          </Typography>
-                        </Box>
                       </>
                     ) : (
                       <Typography>Selecione uma mídia para visualizar</Typography>


### PR DESCRIPTION
This commit removes the 'Tipo' (Type) and 'Tamanho' (Size) metadata display from below the media preview in the Publisher component.

This change is made at the user's request to simplify the UI.