### PR TITLE
Fix: Corrige a geração de imagens, regressão e renderização no editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -123,13 +123,13 @@ const FieldPositioner = ({
     const generateComposedImage = async () => {
       setIsComposing(true);
       try {
-        const composedUrl = await composeImage(
+        const composedCanvas = await composeImage(
           backgroundImage,
           imageFilters
           // Do not pass brandElements here to prevent ghosting.
           // They are rendered as interactive DraggableElement components on top.
         );
-        setComposedImageUrl(composedUrl);
+        setComposedImageUrl(composedCanvas.toDataURL());
       } catch (error) {
         console.error("Error composing image in FieldPositioner:", error);
         setComposedImageUrl(backgroundImage); // Fallback to original image


### PR DESCRIPTION
Esta correção aborda uma série de questões relacionadas à geração e manuseio de imagens para posts curtos:

1.  **Imagens Quebradas na Geração Automática:** As imagens geradas automaticamente apareciam como quebradas porque o código estava convertendo `data:` URLs em `blob:` URLs instáveis. Este processo de "lavagem de URL" foi removido. A aplicação agora usa as `data:` URLs estáveis diretamente.

2.  **Background Incorreto do Modelo:** Na geração automática, a imagem de fundo do modelo não estava sendo aplicada a todos os posts subsequentes. A lógica foi reestruturada para primeiro gerar uma única imagem de fundo do modelo e, em seguida, aplicar essa mesma imagem a todos os posts da série.

3.  **Regressão no Upload Manual:** O upload manual de imagens também resultava em imagens quebradas. Ao padronizar o uso de `data:` URLs em todo o fluxo de imagens, a funcionalidade de upload manual agora funciona de forma confiável novamente.

4.  **Imagem Quebrada no Editor:** Após a geração, a imagem de fundo aparecia quebrada no editor (`FieldPositioner`). A causa era que um elemento `<canvas>` estava sendo passado para o atributo `src` de uma tag `<img>`. A correção converte o canvas para uma `data:` URL usando `.toDataURL()` antes de passá-lo para a tag `<img>`, garantindo que a imagem seja renderizada corretamente.

Além disso, uma importação ausente de `composeSingleImage` em `HomePage.jsx` foi adicionada para corrigir um bug de tempo de execução.