### PR TITLE
Fix: Correct image regeneration and editor background bugs

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -40,7 +40,7 @@ import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi'
 import { composeImage } from '../utils/imageComposer';
 import { useUserAuth } from '../context/UserAuthContext';
 
-import { composeSingleImage } from '../utils/imageComposer';
+import { composeSingleImage, applyTextEffects, wrapTextInArea, drawTextWithEffects, dataURLtoBlob } from '../utils/imageComposer';
 
 const ImageGeneratorFrontendOnly = ({
   csvData,
@@ -722,7 +722,7 @@ const ImageGeneratorFrontendOnly = ({
             initialFieldStyles={JSON.parse(JSON.stringify(stylesToLoad || {}))}
             onSave={handleSaveIndividualModifications}
             colorPalette={colorPalette}
-            globalBackgroundImage={backgroundImage}
+            globalBackgroundImage={imageToEdit.backgroundImage || backgroundImage}
             originalImageSize={imageToEdit.customOriginalImageSize || originalImageSize}
             imageFilters={imageFilters}
             brandElements={brandElementsToLoad}


### PR DESCRIPTION
This commit addresses two critical bugs that occurred when editing a generated image from a loaded campaign.

1.  **Fix `applyTextEffects` Reference Error:** The `regenerateSingleImage` function would fail with an `applyTextEffects is not defined` error because the function was not imported. This has been resolved by importing `applyTextEffects` and its related utilities from `imageComposer.js` into `ImageGeneratorFrontendOnly.jsx`.

2.  **Fix Incorrect Editor Background:** When opening the image editor for a specific image, it was incorrectly displaying the global campaign background instead of the background belonging to that specific image. This has been fixed by passing the correct prop (`imageToEdit.backgroundImage`) to the `GeneratedImageEditor` component.