### PR TITLE
Fix: Resolve build error and editor bugs

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -2,7 +2,7 @@ import { containsHtml, renderHtmlToCanvas } from './htmlRenderer';
 
 // Helper functions moved from ImageGeneratorFrontendOnly.jsx and adapted for utility use
 
-const dataURLtoBlob = (dataurl) => {
+export const dataURLtoBlob = (dataurl) => {
     if (!dataurl) return null;
     const arr = dataurl.split(',');
     if (arr.length < 2) return null;
@@ -18,7 +18,7 @@ const dataURLtoBlob = (dataurl) => {
     return new Blob([u8arr], {type:mime});
 };
 
-const wrapTextInArea = (ctx, text, style, maxWidth, maxHeight) => {
+export const wrapTextInArea = (ctx, text, style, maxWidth, maxHeight) => {
     if (!text) return [];
     const fontSize = style.fontSize || 24;
     const lineHeight = fontSize * (style.lineHeightMultiplier || 1.2);
@@ -45,7 +45,7 @@ const wrapTextInArea = (ctx, text, style, maxWidth, maxHeight) => {
     return lines;
 };
 
-const applyTextEffects = (ctx, style) => {
+export const applyTextEffects = (ctx, style) => {
     ctx.fillStyle = style.color || '#000000';
     ctx.font = `${style.fontWeight || 'normal'} ${style.fontStyle || 'normal'} ${style.fontSize || 24}px ${style.fontFamily || 'Arial'}`;
     ctx.textAlign = style.textAlign || 'left';
@@ -69,7 +69,7 @@ const applyTextEffects = (ctx, style) => {
     }
 };
 
-const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
+export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
     if (containsHtml(text)) {
         await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style);
     } else {


### PR DESCRIPTION
This commit fixes a build error and two bugs related to the image editor that occurred after loading a campaign.

1.  **Fix Build Error:** The previous build failed because several helper functions (`applyTextEffects`, etc.) were used in `ImageGeneratorFrontendOnly.jsx` without being exported from their source file. This has been fixed by adding the `export` keyword to these functions in `src/utils/imageComposer.js`, making them available for import and resolving the build failure.

2.  **Fix Incorrect Editor Background:** When opening the image editor for a specific image, it was incorrectly displaying the global campaign background. This has been fixed by passing the correct image-specific background prop (`imageToEdit.backgroundImage`) to the `GeneratedImageEditor` component.

3.  **Fix Image Regeneration Error:** A bug in the `regenerateSingleImage` function was causing an error when saving edits. The function was attempting to use a canvas element as an image source. This was corrected by converting the canvas to a data URL with `.toDataURL()` before use.