### PR TITLE
Fix: Resolve editor bugs and build failure

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -162,6 +162,7 @@ const GeneratedImageEditor = ({
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
+      customOriginalImageSize: originalImageSize, // Pass back the size used for editing
     });
     onClose();
   };

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -242,8 +242,8 @@ const ImageGeneratorFrontendOnly = ({
   };
 
   const handleSaveIndividualModifications = (modifiedImageData) => {
-    const { index: imageIndex, record: updatedCsvRecord, fieldPositions: newPositions, fieldStyles: newStyles, brandElements: editedBrandElements } = modifiedImageData;
-    const updatedImages = generatedImages.map(img => (img.index === imageIndex) ? { ...img, record: updatedCsvRecord, customFieldPositions: newPositions, customFieldStyles: newStyles, customBrandElements: editedBrandElements } : img);
+    const { index: imageIndex, record: updatedCsvRecord, fieldPositions: newPositions, fieldStyles: newStyles, brandElements: editedBrandElements, customOriginalImageSize } = modifiedImageData;
+    const updatedImages = generatedImages.map(img => (img.index === imageIndex) ? { ...img, record: updatedCsvRecord, customFieldPositions: newPositions, customFieldStyles: newStyles, customBrandElements: editedBrandElements, customOriginalImageSize: customOriginalImageSize } : img);
     setGeneratedImages(updatedImages);
     if (onThumbnailRecordTextUpdate) {
       onThumbnailRecordTextUpdate(imageIndex, updatedCsvRecord);
@@ -251,7 +251,7 @@ const ImageGeneratorFrontendOnly = ({
     const imageToRegenerate = updatedImages.find(im => im.index === imageIndex);
     if (imageToRegenerate) {
       const bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
-      regenerateSingleImage(imageIndex, imageToRegenerate.record, bgToUse, newPositions, newStyles, null, editedBrandElements);
+      regenerateSingleImage(imageIndex, imageToRegenerate.record, bgToUse, newPositions, newStyles, customOriginalImageSize, editedBrandElements);
     }
     handleCloseGeneratedImageEditor();
   };
@@ -271,8 +271,9 @@ const ImageGeneratorFrontendOnly = ({
       });
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      canvas.width = img.width;
-      canvas.height = img.height;
+      const finalImageSize = customSize || { width: img.width, height: img.height };
+      canvas.width = finalImageSize.width;
+      canvas.height = finalImageSize.height;
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
       ctx.textRenderingOptimization = 'optimizeQuality';
@@ -285,10 +286,10 @@ const ImageGeneratorFrontendOnly = ({
         if (!text) continue;
         ctx.save();
         const posPx = {
-          x: Math.round((position.x / 100) * img.width),
-          y: Math.round((position.y / 100) * img.height),
-          width: Math.round((position.width / 100) * img.width),
-          height: Math.round((position.height / 100) * img.height)
+          x: Math.round((position.x / 100) * finalImageSize.width),
+          y: Math.round((position.y / 100) * finalImageSize.height),
+          width: Math.round((position.width / 100) * finalImageSize.width),
+          height: Math.round((position.height / 100) * finalImageSize.height)
         };
         if (position.rotation) {
           const centerX = posPx.x + posPx.width / 2;


### PR DESCRIPTION
This commit addresses a build failure and several critical bugs related to the image editor, particularly when editing images from a loaded campaign.

1.  **Fix Build Error:** The build failed because helper functions (`applyTextEffects`, etc.) were used in `ImageGeneratorFrontendOnly.jsx` without being exported from their source file. This has been fixed by adding the `export` keyword to these functions in `src/utils/imageComposer.js`.

2.  **Fix Incorrect Editor Background:** When opening the image editor for a specific image, it was incorrectly displaying the global campaign background. This has been fixed by passing the correct image-specific background prop (`imageToEdit.backgroundImage`) to the `GeneratedImageEditor` component.

3.  **Fix Distortion on Regeneration:** When saving an edited image, the final render was distorted because the regeneration function was not using the same image dimensions as the editor preview. This is now fixed by passing the correct `originalImageSize` from the editor back to the regeneration function, ensuring the preview and final output are identical.

4.  **Fix Regeneration Reference Error:** The regeneration function was also failing with an `applyTextEffects is not defined` error. This was resolved by the same fix for the build error (exporting and importing the necessary functions).