### PR TITLE
Fix: Unify preview and final render logic to prevent distortion

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -104,6 +104,7 @@ const FieldPositioner = ({
   onOpenHtmlEditor,
   currentPreviewIndex,
   setCurrentPreviewIndex,
+  onFontScaleChange,
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
@@ -526,14 +527,16 @@ const FieldPositioner = ({
 
   // Effect to calculate font scale based on the actual rendered image size
   useEffect(() => {
+    let scale = 1;
     if (renderedImageMetrics.width > 0 && originalImageSize?.width > 0) {
       // The scale is uniform, so we can just use the width ratio.
-      const scale = renderedImageMetrics.width / originalImageSize.width;
-      setFontScale(scale);
-    } else {
-      setFontScale(1);
+      scale = renderedImageMetrics.width / originalImageSize.width;
     }
-  }, [renderedImageMetrics, originalImageSize]);
+    setFontScale(scale);
+    if (onFontScaleChange) {
+      onFontScaleChange(scale);
+    }
+  }, [renderedImageMetrics, originalImageSize, onFontScaleChange]);
 
   // Efeito para gerenciar scroll durante interações
   useEffect(() => {

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -63,6 +63,7 @@ const GeneratedImageEditor = ({
   const [editedRecord, setEditedRecord] = useState(null); // State for the CSV record being edited
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null); // Estado para o campo selecionado internamente
   const [stylesAreInitialized, setStylesAreInitialized] = useState(false); // New state for initialization tracking
+  const [fontScale, setFontScale] = useState(1);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [editingField, setEditingField] = useState(null);
   const theme = useTheme();
@@ -163,6 +164,7 @@ const GeneratedImageEditor = ({
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
       customOriginalImageSize: originalImageSize, // Pass back the size used for editing
+      fontScale: fontScale,
     });
     onClose();
   };
@@ -218,6 +220,7 @@ const GeneratedImageEditor = ({
                 onSelectFieldExternal={handleInternalFieldSelection} // Use memoized handler
                 onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
                 originalImageSize={originalImageSize}
+                onFontScaleChange={setFontScale}
                 imageFilters={editedImageFilters}
                 brandElements={editedBrandElements}
                 setBrandElements={setEditedBrandElements}

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -242,7 +242,7 @@ const ImageGeneratorFrontendOnly = ({
   };
 
   const handleSaveIndividualModifications = (modifiedImageData) => {
-    const { index: imageIndex, record: updatedCsvRecord, fieldPositions: newPositions, fieldStyles: newStyles, brandElements: editedBrandElements, customOriginalImageSize } = modifiedImageData;
+    const { index: imageIndex, record: updatedCsvRecord, fieldPositions: newPositions, fieldStyles: newStyles, brandElements: editedBrandElements, customOriginalImageSize, fontScale } = modifiedImageData;
     const updatedImages = generatedImages.map(img => (img.index === imageIndex) ? { ...img, record: updatedCsvRecord, customFieldPositions: newPositions, customFieldStyles: newStyles, customBrandElements: editedBrandElements, customOriginalImageSize: customOriginalImageSize } : img);
     setGeneratedImages(updatedImages);
     if (onThumbnailRecordTextUpdate) {
@@ -251,12 +251,12 @@ const ImageGeneratorFrontendOnly = ({
     const imageToRegenerate = updatedImages.find(im => im.index === imageIndex);
     if (imageToRegenerate) {
       const bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
-      regenerateSingleImage(imageIndex, imageToRegenerate.record, bgToUse, newPositions, newStyles, customOriginalImageSize, editedBrandElements);
+      regenerateSingleImage(imageIndex, imageToRegenerate.record, bgToUse, newPositions, newStyles, customOriginalImageSize, editedBrandElements, fontScale);
     }
     handleCloseGeneratedImageEditor();
   };
 
-  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements) => {
+  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       alert('Pré-requisitos para regeneração não atendidos. Fontes foram carregadas?');
       return;
@@ -298,15 +298,16 @@ const ImageGeneratorFrontendOnly = ({
           ctx.rotate(position.rotation * Math.PI / 180);
           ctx.translate(-centerX, -centerY);
         }
-        const fontSize = style.fontSize || 24;
-        applyTextEffects(ctx, { ...style, fontSize: fontSize });
+        const baseFontSize = style.fontSize || 24;
+        const scaledFontSize = baseFontSize * fontScale;
+        applyTextEffects(ctx, { ...style, fontSize: scaledFontSize });
         const fixedPadding = 8;
         const effectiveTextWidth = Math.max(0, posPx.width - (2 * fixedPadding));
         const effectiveTextHeight = Math.max(0, posPx.height - (2 * fixedPadding));
         const textContentStartX = posPx.x + fixedPadding;
         const textContentStartY = posPx.y + fixedPadding;
-        const lines = wrapTextInArea(ctx, text, 0, 0, effectiveTextWidth, effectiveTextHeight, { ...style, fontSize: fontSize });
-        const lineHeight = fontSize * (style.lineHeightMultiplier || 1.2);
+        const lines = wrapTextInArea(ctx, text, { ...style, fontSize: scaledFontSize }, effectiveTextWidth, effectiveTextHeight);
+        const lineHeight = scaledFontSize * (style.lineHeightMultiplier || 1.2);
         let currentLineRenderY = textContentStartY;
         if (style.verticalAlign === 'middle') {
           const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - fontSize) : 0);
@@ -316,7 +317,7 @@ const ImageGeneratorFrontendOnly = ({
           currentLineRenderY += effectiveTextHeight - totalTextBlockHeight;
         }
         if (containsHtml(text)) {
-          await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, { ...style, fontSize: fontSize }, effectiveTextWidth, effectiveTextHeight);
+          await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, { ...style, fontSize: scaledFontSize }, effectiveTextWidth, effectiveTextHeight);
         } else {
           for (const line of lines) {
             let currentLineRenderX;
@@ -328,7 +329,7 @@ const ImageGeneratorFrontendOnly = ({
               currentLineRenderX = textContentStartX;
             }
             const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
-            await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, { ...style, fontSize: fontSize }, effectiveTextWidth, effectiveTextHeight);
+            await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, { ...style, fontSize: scaledFontSize }, effectiveTextWidth, effectiveTextHeight);
           }
         }
         ctx.restore();


### PR DESCRIPTION
This commit fixes a critical bug where the final rendered image was distorted and did not match the editor preview. The cause was a discrepancy between the rendering logic of the preview component and the final canvas drawing function.

The fix involves the following changes:

1.  **Propagate Font Scale:** The `fontScale`, which is calculated in `FieldPositioner.jsx` based on the preview size, is now passed up to the `GeneratedImageEditor` via a callback.
2.  **Pass Full Context on Save:** The `GeneratedImageEditor` now includes both the `fontScale` and the specific `originalImageSize` used for the preview in its `onSave` payload.
3.  **Unify Regeneration Logic:** The `regenerateSingleImage` function in `ImageGeneratorFrontendOnly.jsx` now accepts the `fontScale` and `originalImageSize` from the editor. It uses these values to calculate the font size and canvas dimensions, ensuring that the final render is a 1:1 match with the preview and eliminating the distortion.