### PR TITLE
Fix: Resolve build failure after html2canvas refactor

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -3,7 +3,6 @@ import { Box } from '@mui/material';
 import RichTextEditor from './RichTextEditor';
 import styles from './DraggableElement.module.css';
 import TextEditorDialog from './TextEditorDialog';
-import { wrapTextInArea } from '../utils/imageComposer';
 
 const DraggableElementInternal = ({
   element, // Combined object for field/element data
@@ -489,10 +488,7 @@ const DraggableElementInternal = ({
 
   const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
   const paddingInPixels = 8 * 2;
-  // Create a dummy canvas context to pass to the wrapping function, to mimic the final render environment
-  const dummyCanvas = document.createElement('canvas');
-  const dummyCtx = dummyCanvas.getContext('2d');
-  const textLines = enableHtmlRendering ? [content] : wrapTextInArea(dummyCtx, editedContent, { ...style, fontSize: scaledFontSize }, pixelPosition.width - paddingInPixels, pixelPosition.height - paddingInPixels);
+  const textLines = []; // This is no longer used for rendering plain text directly.
 
   const handleSize = isMobile ? 24 : 12;
 
@@ -604,11 +600,7 @@ const DraggableElementInternal = ({
                     }}
                   />
                 ) : (
-                  textLines.map((line, index) => (
-                    <div key={index} style={{ marginBottom: index < textLines.length - 1 ? '2px' : 0 }}>
-                      {line}
-                    </div>
-                  ))
+                  <div style={{whiteSpace: 'pre-wrap', width: '100%', height: '100%'}}>{content}</div>
                 )}
               </Box>
             )}

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -40,7 +40,7 @@ import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi'
 import { composeImage } from '../utils/imageComposer';
 import { useUserAuth } from '../context/UserAuthContext';
 
-import { composeSingleImage, applyTextEffects, wrapTextInArea, drawTextWithEffects, dataURLtoBlob } from '../utils/imageComposer';
+import { composeSingleImage } from '../utils/imageComposer';
 
 const ImageGeneratorFrontendOnly = ({
   csvData,


### PR DESCRIPTION
This commit fixes a build failure that occurred after the image generation pipeline was refactored to use `html2canvas`.

The build failed because `DraggableElement.jsx` was still trying to import and use the `wrapTextInArea` function, which had been deleted from `imageComposer.js` as part of the refactoring.

The fix involves:
1.  Removing the import and usage of `wrapTextInArea` from `DraggableElement.jsx` and restoring its simpler, CSS-based text rendering for the preview. This is the correct approach, as `html2canvas` relies on the browser's DOM rendering.
2.  Cleaning up the corresponding unused imports in `ImageGeneratorFrontendOnly.jsx` to prevent future issues.

This resolves the build error and completes the transition to the robust `html2canvas`-based rendering pipeline.