### PR TITLE
Fix: Resolve final build failure after html2canvas refactor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -44,8 +44,6 @@ const COMPLETE_DEFAULT_STYLE_FOR_FIELD_POSITIONER = {
   shadowOffsetY: 2,
 };
 
-import { composeImage } from '../utils/imageComposer';
-
 // Helper function to find the best font size to fit text within a box
 const findBestFitFontSize = (text, fontFamily, fontWeight, boxWidth, boxHeight) => {
   if (!text || !boxWidth || !boxHeight) {
@@ -112,35 +110,6 @@ const FieldPositioner = ({
   const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
-  const [composedImageUrl, setComposedImageUrl] = useState(null);
-  const [isComposing, setIsComposing] = useState(false);
-
-  useEffect(() => {
-    if (!backgroundImage) {
-      setComposedImageUrl(null);
-      return;
-    }
-
-    const generateComposedImage = async () => {
-      setIsComposing(true);
-      try {
-        const composedCanvas = await composeImage(
-          backgroundImage,
-          imageFilters
-          // Do not pass brandElements here to prevent ghosting.
-          // They are rendered as interactive DraggableElement components on top.
-        );
-        setComposedImageUrl(composedCanvas.toDataURL());
-      } catch (error) {
-        console.error("Error composing image in FieldPositioner:", error);
-        setComposedImageUrl(backgroundImage); // Fallback to original image
-      } finally {
-        setIsComposing(false);
-      }
-    };
-
-    generateComposedImage();
-  }, [backgroundImage, imageFilters]);
 
   const isHtmlField = useCallback((fieldName) => {
     if (!fieldName) return false;
@@ -674,13 +643,8 @@ const FieldPositioner = ({
               onTouchStart={handleContainerTouchStart}
               onTouchEnd={handleContainerTouchEnd}
             >
-              {isComposing && (
-                <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', color: 'white', backgroundColor: 'rgba(0,0,0,0.5)', padding: '10px', borderRadius: '8px' }}>
-                  <Typography>Atualizando...</Typography>
-                </Box>
-              )}
               <img
-                src={composedImageUrl || backgroundImage}
+                src={backgroundImage}
                 alt="Background"
                 style={{
                   width: '100%',
@@ -690,8 +654,8 @@ const FieldPositioner = ({
                   pointerEvents: 'none',
                   userSelect: 'none',
                   WebkitUserDrag: 'none',
-                  opacity: isComposing ? 0.5 : 1,
                   transition: 'opacity 0.3s',
+                  filter: `brightness(${imageFilters.brightness}%) contrast(${imageFilters.contrast}%) saturate(${imageFilters.saturate}%) blur(${imageFilters.blur}px) opacity(${imageFilters.opacity}%)`,
                 }}
                 draggable={false}
               />


### PR DESCRIPTION
This commit fixes a build failure that occurred after the image generation pipeline was refactored to use `html2canvas`. This is the final fix for a series of cascading build errors from the refactor.

The build failed because `FieldPositioner.jsx` was still trying to import and use the old `composeImage` function, which was deleted as part of the refactoring.

The fix involves:
1.  Removing the import and usage of `composeImage` from `FieldPositioner.jsx`.
2.  Refactoring the preview `<img>` element within `FieldPositioner.jsx` to apply image filters directly using the standard CSS `filter` property, which is a simpler and more robust method.

This resolves the last build error and completes the transition to the new `html2canvas`-based rendering pipeline.