### PR TITLE
fix(regeneration): Correctly handle canvas object to prevent crash

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -243,21 +243,16 @@ const ImageGeneratorFrontendOnly = ({
       return;
     }
     try {
-      const composedBackgroundImageUrl = await composeImage(currentBackgroundImage, imageFilters, elementsToUse);
-      const img = new Image();
-      await new Promise((resolve, reject) => {
-        img.onload = resolve;
-        img.onerror = (err) => reject(new Error('Failed to load composed background for regeneration.', { cause: err }));
-        img.src = composedBackgroundImageUrl;
-      });
+      const composedBackgroundCanvas = await composeImage(currentBackgroundImage, imageFilters, elementsToUse);
+
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      canvas.width = img.width;
-      canvas.height = img.height;
+      canvas.width = composedBackgroundCanvas.width;
+      canvas.height = composedBackgroundCanvas.height;
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
       ctx.textRenderingOptimization = 'optimizeQuality';
-      ctx.drawImage(img, 0, 0);
+      ctx.drawImage(composedBackgroundCanvas, 0, 0);
       for (const field of Object.keys(record)) {
         const position = positionsToUse[field];
         const style = stylesToUse[field];


### PR DESCRIPTION
This commit fixes a critical bug that caused a crash when saving an edited image.

The `regenerateSingleImage` function was attempting to use the `HTMLCanvasElement` returned by the `composeImage` utility as an image `src` URL. This is incorrect and was causing an unhandled error: "Failed to load composed background for regeneration."

The fix modifies `regenerateSingleImage` to correctly handle the returned canvas object. Instead of trying to load it as a new image, the code now directly uses `ctx.drawImage()` to draw the composed background canvas onto the final canvas. This resolves the crash and makes the image regeneration process robust.