### PR TITLE
hotfix(regeneration): Fix 'img is not defined' ReferenceError

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -261,10 +261,10 @@ const ImageGeneratorFrontendOnly = ({
         if (!text) continue;
         ctx.save();
         const posPx = {
-          x: Math.round((position.x / 100) * img.width),
-          y: Math.round((position.y / 100) * img.height),
-          width: Math.round((position.width / 100) * img.width),
-          height: Math.round((position.height / 100) * img.height)
+          x: Math.round((position.x / 100) * canvas.width),
+          y: Math.round((position.y / 100) * canvas.height),
+          width: Math.round((position.width / 100) * canvas.width),
+          height: Math.round((position.height / 100) * canvas.height)
         };
         if (position.rotation) {
           const centerX = posPx.x + posPx.width / 2;


### PR DESCRIPTION
This is an immediate hotfix for a ReferenceError that was introduced in the previous commit.

While refactoring `regenerateSingleImage` to correctly handle a canvas object, references to the old `img` variable were left behind in the `posPx` (pixel position) calculation. This caused an "img is not defined" crash when regenerating an image.

This commit replaces the incorrect `img.width` and `img.height` references with `canvas.width` and `canvas.height`, respectively. This resolves the ReferenceError and restores the functionality of the image editor.