### PR TITLE
fix: Comprehensive stability fixes for image editor

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -93,8 +93,6 @@ const GeneratedImageEditor = ({
 
   useEffect(() => {
     if (imageData && initialFieldPositions && initialFieldStyles) {
-      setSelectedFieldInternal(null);
-
       const positions = JSON.parse(JSON.stringify(initialFieldPositions));
       const brands = JSON.parse(JSON.stringify(brandElements || []));
 

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -37,10 +37,8 @@ import {
 } from '@mui/icons-material';
 import GeneratedImageEditor from './GeneratedImageEditor';
 import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi';
-import { composeImage } from '../utils/imageComposer';
+import { composeImage, composeSingleImage, dataURLtoBlob, wrapTextInArea, applyTextEffects } from '../utils/imageComposer';
 import { useUserAuth } from '../context/UserAuthContext';
-
-import { composeSingleImage } from '../utils/imageComposer';
 
 const ImageGeneratorFrontendOnly = ({
   csvData,

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -169,6 +169,7 @@ export const composeSingleImage = async ({
 
     // 1. Compose the background with filters and brand elements
     const backgroundCanvas = await composeImage(itemBackgroundImage, imageFilters, brandElements);
+    const composedBackgroundDataUrl = backgroundCanvas.toDataURL('image/png', 1.0);
 
     // 2. Create a new canvas to draw the final image with text
     const finalCanvas = document.createElement('canvas');
@@ -251,7 +252,7 @@ export const composeSingleImage = async ({
         record,
         index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
-        backgroundImage: itemBackgroundImage,
+        backgroundImage: composedBackgroundDataUrl,
         // customFieldPositions and customFieldStyles are not handled here as this is for initial generation
     };
 };


### PR DESCRIPTION
This commit addresses a cascade of bugs reported in the image editor, providing comprehensive fixes to stabilize the feature.

1.  **fix(regeneration): Resolve `applyTextEffects is not defined` crash.** The `regenerateSingleImage` function was calling utility functions (`applyTextEffects`, `wrapTextInArea`, `dataURLtoBlob`) that were not imported after a previous refactor. This commit adds the necessary imports to `ImageGeneratorFrontendOnly.jsx`, resolving the `ReferenceError` crash.

2.  **fix(state): Ensure stable background images for regeneration.** When an image was first generated, the `composeSingleImage` function was incorrectly storing the original, temporary background URL in the final image object instead of the newly composed one. This caused the background to appear broken and all subsequent edits to fail. The function has been corrected to store a stable `data:` URL of the composed background, ensuring its validity for all future operations.

3.  **fix(ux): Prevent unintended field deselection in editor.** An overly sensitive `useEffect` hook in the `GeneratedImageEditor` was resetting the selected field to `null` during re-renders triggered by editing actions (e.g., resizing a field). This made the properties panel unusable. The line causing the reset has been removed, ensuring the selection state is only modified by direct user interaction.