### PR TITLE
hotfix(build): Export drawTextWithEffects to fix final runtime error

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -37,7 +37,7 @@ import {
 } from '@mui/icons-material';
 import GeneratedImageEditor from './GeneratedImageEditor';
 import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi';
-import { composeImage, composeSingleImage, dataURLtoBlob, wrapTextInArea, applyTextEffects } from '../utils/imageComposer';
+import { composeImage, composeSingleImage, dataURLtoBlob, wrapTextInArea, applyTextEffects, drawTextWithEffects } from '../utils/imageComposer';
 import { useUserAuth } from '../context/UserAuthContext';
 
 const ImageGeneratorFrontendOnly = ({

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -69,7 +69,7 @@ export const applyTextEffects = (ctx, style) => {
     }
 };
 
-const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
+export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
     if (containsHtml(text)) {
         await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style);
     } else {


### PR DESCRIPTION
This commit fixes a `ReferenceError: drawTextWithEffects is not defined` that occurred during image regeneration. This was the last of a series of errors caused by a faulty refactoring.

The `drawTextWithEffects` function had been moved to `imageComposer.js` but was not exported, causing a runtime crash when `regenerateSingleImage` was called.

This hotfix:
1. Adds the `export` keyword to `drawTextWithEffects` in `src/utils/imageComposer.js`.
2. Adds `drawTextWithEffects` to the import statement in `src/components/ImageGeneratorFrontendOnly.jsx`.

This resolves the final known bug in the image generation pipeline. I sincerely apologize for the multiple preceding failures required to fix this issue.