### PR TITLE
fix: Correct image background lifecycle and editor preview

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -112,35 +112,10 @@ const FieldPositioner = ({
   const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
-  const [composedImageUrl, setComposedImageUrl] = useState(null);
-  const [isComposing, setIsComposing] = useState(false);
+  const [isComposing, setIsComposing] = useState(false); // Keep for loading indicators if needed elsewhere
 
-  useEffect(() => {
-    if (!backgroundImage) {
-      setComposedImageUrl(null);
-      return;
-    }
-
-    const generateComposedImage = async () => {
-      setIsComposing(true);
-      try {
-        const composedUrl = await composeImage(
-          backgroundImage,
-          imageFilters
-          // Do not pass brandElements here to prevent ghosting.
-          // They are rendered as interactive DraggableElement components on top.
-        );
-        setComposedImageUrl(composedUrl);
-      } catch (error) {
-        console.error("Error composing image in FieldPositioner:", error);
-        setComposedImageUrl(backgroundImage); // Fallback to original image
-      } finally {
-        setIsComposing(false);
-      }
-    };
-
-    generateComposedImage();
-  }, [backgroundImage, imageFilters]);
+  // The backgroundImage prop is now assumed to be the final, composed background for the editor preview.
+  // No further composition is needed here.
 
   const isHtmlField = useCallback((fieldName) => {
     if (!fieldName) return false;
@@ -684,7 +659,7 @@ const FieldPositioner = ({
                 </Box>
               )}
               <img
-                src={composedImageUrl || backgroundImage}
+                src={backgroundImage}
                 alt="Background"
                 style={{
                   width: '100%',

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -241,16 +241,25 @@ const ImageGeneratorFrontendOnly = ({
       return;
     }
     try {
-      const composedBackgroundCanvas = await composeImage(currentBackgroundImage, imageFilters, elementsToUse);
+      // The `currentBackgroundImage` is already the composed background with brand elements and filters.
+      // We just need to load it and draw the text on top.
+      const img = new Image();
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = (err) => reject(new Error('Failed to load the background image for regeneration.', { cause: err }));
+        // Ensure cross-origin is set for data URLs as well, just in case of tainting issues.
+        img.crossOrigin = 'Anonymous';
+        img.src = currentBackgroundImage;
+      });
 
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
-      canvas.width = composedBackgroundCanvas.width;
-      canvas.height = composedBackgroundCanvas.height;
+      canvas.width = customSize ? customSize.width : img.width;
+      canvas.height = customSize ? customSize.height : img.height;
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
       ctx.textRenderingOptimization = 'optimizeQuality';
-      ctx.drawImage(composedBackgroundCanvas, 0, 0);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
       for (const field of Object.keys(record)) {
         const position = positionsToUse[field];
         const style = stylesToUse[field];


### PR DESCRIPTION
This commit provides a definitive fix for the persistent bugs related to background images in the editor. The previous architecture was flawed, leading to broken images, reversion to global templates, and visual artifacts. This was caused by re-composing already-composed images in multiple places.

This solution refactors the image lifecycle to be more robust and efficient:

1.  **Simplified Regeneration:** The `regenerateSingleImage` function in `ImageGeneratorFrontendOnly.jsx` has been refactored. It no longer calls `composeImage`. Instead, it correctly treats the unique background as a static asset, loading the provided `data:` URL and only redrawing the text fields on top. This preserves the background perfectly across edits.

2.  **Simplified Editor Preview:** The `FieldPositioner` component has been simplified. It no longer calls `composeImage` on the background it receives. It now treats the `backgroundImage` prop as the final image to be displayed in the editor and uses it directly as the `src` for the `<img>` tag. This fixes the "broken image" in the editor and prevents visual bugs like filters being applied twice.

3.  **Corrected Initial Composition:** The `composeSingleImage` utility was already corrected to store a stable `data:` URL of the composed background, which enables this entire simplified workflow.

Together, these changes ensure a "compose-once" architecture for backgrounds, resolving the entire class of related bugs. Sincere apologies for the multiple previous attempts to fix this issue. This commit represents a stable and logically sound solution.