### PR TITLE
fix: Correctly persist background image on save

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -221,16 +221,45 @@ const ImageGeneratorFrontendOnly = ({
   };
 
   const handleSaveIndividualModifications = (modifiedImageData) => {
-    const { index: imageIndex, record: updatedCsvRecord, fieldPositions: newPositions, fieldStyles: newStyles, brandElements: editedBrandElements, fontScale } = modifiedImageData;
-    const updatedImages = generatedImages.map(img => (img.index === imageIndex) ? { ...img, record: updatedCsvRecord, customFieldPositions: newPositions, customFieldStyles: newStyles, customBrandElements: editedBrandElements, fontScale: fontScale } : img);
+    const { index: imageIndex } = modifiedImageData;
+
+    const updatedImages = generatedImages.map(img => {
+      if (img.index !== imageIndex) {
+        return img;
+      }
+      // The modifiedImageData from the editor contains the correct backgroundImage
+      // and all the edited fields. We merge it with the existing `img` state
+      // to ensure properties like `url` and `blob` are preserved until regeneration.
+      return {
+        ...img,
+        ...modifiedImageData,
+        // Ensure custom fields are named consistently
+        customFieldPositions: modifiedImageData.fieldPositions,
+        customFieldStyles: modifiedImageData.fieldStyles,
+        customBrandElements: modifiedImageData.brandElements,
+      };
+    });
+
     setGeneratedImages(updatedImages);
+
     if (onThumbnailRecordTextUpdate) {
-      onThumbnailRecordTextUpdate(imageIndex, updatedCsvRecord);
+      onThumbnailRecordTextUpdate(imageIndex, modifiedImageData.record);
     }
+
     const imageToRegenerate = updatedImages.find(im => im.index === imageIndex);
+
     if (imageToRegenerate) {
       const bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
-      regenerateSingleImage(imageIndex, imageToRegenerate.record, bgToUse, newPositions, newStyles, null, editedBrandElements, fontScale);
+      regenerateSingleImage(
+        imageIndex,
+        imageToRegenerate.record,
+        bgToUse,
+        imageToRegenerate.customFieldPositions,
+        imageToRegenerate.customFieldStyles,
+        null,
+        imageToRegenerate.customBrandElements,
+        imageToRegenerate.fontScale
+      );
     }
     handleCloseGeneratedImageEditor();
   };


### PR DESCRIPTION
This commit provides the definitive fix for the persistent bug where unique background images were lost after an image was edited.

The root cause was a flaw in the `handleSaveIndividualModifications` function. The logic for updating the image's state was inadvertently discarding the `backgroundImage` property before the regeneration step was called. This caused the application to fall back to the global background image.

The handler has been refactored to be more robust. It now correctly merges the incoming data from the editor with the existing image state, explicitly preserving the `backgroundImage` property throughout the entire save/regeneration cycle.

This resolves the bug and ensures unique backgrounds are correctly maintained.