### PR TITLE
fix: Ensure stable backgrounds for all image generation flows

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -696,19 +696,24 @@ function HomePage() {
             try {
               const rawBgImageUrl = await generateCampaignImage({ content: { titulo: imagePrompt }, aspectRatio });
 
-              // Launder the data URL
+              // Convert the generated image URL to a stable base64 data URL
               const blob = await (await fetch(rawBgImageUrl)).blob();
-              const cleanUrl = URL.createObjectURL(blob);
+              const stableDataUrl = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onloadend = () => resolve(reader.result);
+                reader.onerror = reject;
+                reader.readAsDataURL(blob);
+              });
 
               if (!firstImageSet) {
-                setBackgroundImage(cleanUrl);
+                setBackgroundImage(stableDataUrl);
                 firstImageSet = true;
               }
 
               const finalImageData = await composeSingleImage({
                 record: record,
                 index: i,
-                itemBackgroundImage: cleanUrl,
+                itemBackgroundImage: stableDataUrl,
                 imageFilters,
                 brandElements,
                 fieldPositions: updatedFieldPositions,


### PR DESCRIPTION
This commit provides a holistic fix for the image generation lifecycle, addressing a critical bug in the 'Quick Post' (Posts Curtos) workflow that was missed in previous fixes.

The `handleGenerateIAContent` function was creating unstable `blob:` URLs for AI-generated backgrounds. These URLs would expire before the component could render, leading to broken images in the UI and causing the editor to fall back to the global template background.

The fix refactors this logic to convert the generated image `blob` into a stable, self-contained `data:` URL using a `FileReader`. This `data:` URL is then passed into the image composition pipeline.

This ensures that all image generation paths in the application—both from CSV and from the 'Quick Post' AI generator—now use stable background image identifiers, resolving all known bugs related to broken or incorrect backgrounds.