### PR TITLE
Corrige bugs no ciclo de vida da imagem de fundo e na renderização

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -156,8 +156,9 @@ const GeneratedImageEditor = ({
 
   const handleSave = () => {
     onSave({
-      ...imageData, // Mantém outros dados da imagem original (index etc.)
-      record: editedRecord, // Passa o record atualizado
+      ...imageData, // Keeps original data like index
+      record: editedRecord, // Passes the updated record
+      backgroundImage: currentBackgroundImageForEditor, // Explicitly pass back the background being used
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,


### PR DESCRIPTION
Esta alteração corrige uma série de bugs relacionados ao manuseio de imagens de fundo para posts gerados, especialmente no fluxo de "Posts Curtos" com geração de imagem por IA.

As correções lógicas incluem:

- **`imageComposer.js`:** A função `composeSingleImage` foi modificada para sempre preservar e retornar a URL da imagem de fundo original (`itemBackgroundImage`) no objeto de estado, em vez de retornar uma URL de uma imagem já composta.
-   **`GeneratedImageEditor.jsx`:** A função `handleSave` foi corrigida para incluir a `backgroundImage` no objeto de dados retornado, que era a causa raiz do problema de perda de dados ao salvar.
-   **`ImageGeneratorFrontendOnly.jsx`:**
    -   A função `regenerateSingleImage` foi refatorada para espelhar a lógica de `composeSingleImage`. Ela agora recebe a URL da imagem de fundo original e aplica os filtros e elementos de marca no momento da regeneração.
    -   A `key` do React para a tag `<img>` na lista de pré-visualização foi alterada de `imageData.url` (que era instável e inicialmente nula) para `index`. Isso corrige um bug onde o React não atualizava o atributo `src` da imagem no DOM após a geração.

Essas alterações, em conjunto, devem resolver todos os sintomas relatados, garantindo que as imagens de fundo específicas do post sejam preservadas durante a edição, salvamento e carregamento de campanhas.