### PR TITLE
fix(image-gen): Corrige múltiplos bugs no fluxo de geração e edição

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -254,16 +254,24 @@ const ImageGeneratorFrontendOnly = ({
     const imageToRegenerate = updatedImages.find(im => im.index === imageIndex);
 
     if (imageToRegenerate) {
+      // Explicitly define the parameters to be used for regeneration,
+      // falling back to global props if custom ones don't exist.
       const bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
+      const positionsToUse = imageToRegenerate.customFieldPositions || fieldPositions;
+      const stylesToUse = imageToRegenerate.customFieldStyles || fieldStyles;
+      const elementsToUse = imageToRegenerate.customBrandElements !== undefined ? imageToRegenerate.customBrandElements : brandElements;
+      const scaleToUse = imageToRegenerate.fontScale !== undefined ? imageToRegenerate.fontScale : 1;
+      const sizeToUse = imageToRegenerate.customOriginalImageSize || originalImageSize;
+
       regenerateSingleImage(
         imageIndex,
         imageToRegenerate.record,
         bgToUse,
-        imageToRegenerate.customFieldPositions,
-        imageToRegenerate.customFieldStyles,
-        imageToRegenerate.customOriginalImageSize, // Pass the correct size
-        imageToRegenerate.customBrandElements,
-        imageToRegenerate.fontScale
+        positionsToUse,
+        stylesToUse,
+        sizeToUse,
+        elementsToUse,
+        scaleToUse
       );
     }
     handleCloseGeneratedImageEditor();


### PR DESCRIPTION
This commit provides a comprehensive fix for several critical bugs in the image generation and editing workflow, and also implements a new feature.

The following issues have been resolved:

1.  **Bug Fix (Data Loss):** Corrected `handleDadosAlterados` in `HomePage.jsx` to ensure unique, AI-generated background images are preserved when post data is edited. Previously, they were being overwritten by the global template background.

2.  **Bug Fix (Broken Images):** Fixed a `ReferenceError` in `HomePage.jsx` by importing `composeSingleImage`. This error crashed the automatic image generation loop, resulting in broken images in the UI.

3.  **Bug Fix (Image Resizing on Save):** Resolved an issue in `ImageGeneratorFrontendOnly.jsx` where images would shrink after being edited. The `regenerateSingleImage` function is now called with the correct `customOriginalImageSize`.

4.  **Bug Fix (Element Distortion on Save):** Fixed a bug where text and brand elements would have distorted scale and position after saving an edit. The call to `regenerateSingleImage` in `handleSaveIndividualModifications` was made more robust to explicitly use custom values for positions, styles, brand elements, and font scale, falling back to global defaults only when appropriate.

5.  **Feature (Update General Background):** Implemented a new requirement where the first unique background generated by the AI automatically becomes the new "General Model Background Image" for the campaign, using `updateImageAndPalette` to ensure the color palette is also refreshed.

These changes result in a more stable, correct, and robust image generation and editing experience.