### PR TITLE
fix: Correct thumbnail and preview mismatch in image generation

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -51,6 +51,7 @@ const ImageGeneratorFrontendOnly = ({
   initialGeneratedImagesData,
   onThumbnailRecordTextUpdate,
   originalImageSize,
+  displayedImageSize,
   imageFilters,
   brandElements,
   onBrandElementsChange
@@ -120,6 +121,10 @@ const ImageGeneratorFrontendOnly = ({
     setProgress(0);
     isCancelledRef.current = false;
 
+    const fontScale = (displayedImageSize?.width && originalImageSize?.width)
+      ? displayedImageSize.width / originalImageSize.width
+      : 1;
+
     const imagePromises = csvData.map((record, i) => {
       if (isCancelledRef.current) return Promise.resolve(null);
 
@@ -134,6 +139,7 @@ const ImageGeneratorFrontendOnly = ({
         brandElements,
         fieldPositions,
         fieldStyles,
+        fontScale,
       })
       .then(imageData => {
         setProgress(p => p + 1);

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -161,7 +161,8 @@ export const composeSingleImage = async ({
     imageFilters,
     brandElements,
     fieldPositions,
-    fieldStyles
+    fieldStyles,
+    fontScale = 1
 }) => {
     if (!itemBackgroundImage) {
         throw new Error(`Background image is missing for record index ${index}.`);
@@ -201,27 +202,30 @@ export const composeSingleImage = async ({
             ctx.translate(-centerX, -centerY);
         }
 
-        applyTextEffects(ctx, style);
+        const finalFontSize = (style.fontSize || 24) * (fontScale || 1);
+        const finalStyle = { ...style, fontSize: finalFontSize };
+
+        applyTextEffects(ctx, finalStyle);
         const fixedPadding = 8;
         const effectiveTextWidth = Math.max(0, posPx.width - (2 * fixedPadding));
         const effectiveTextHeight = Math.max(0, posPx.height - (2 * fixedPadding));
         const textContentStartX = posPx.x + fixedPadding;
         const textContentStartY = posPx.y + fixedPadding;
 
-        const lines = wrapTextInArea(ctx, text, style, effectiveTextWidth, effectiveTextHeight);
-        const lineHeight = (style.fontSize || 24) * (style.lineHeightMultiplier || 1.2);
+        const lines = wrapTextInArea(ctx, text, finalStyle, effectiveTextWidth, effectiveTextHeight);
+        const lineHeight = finalFontSize * (style.lineHeightMultiplier || 1.2);
 
         let currentLineRenderY = textContentStartY;
         if (style.verticalAlign === 'middle') {
-            const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - (style.fontSize || 24)) : 0);
+            const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - finalFontSize) : 0);
             currentLineRenderY += (effectiveTextHeight - totalTextBlockHeight) / 2;
         } else if (style.verticalAlign === 'bottom') {
-            const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - (style.fontSize || 24)) : 0);
+            const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - finalFontSize) : 0);
             currentLineRenderY += effectiveTextHeight - totalTextBlockHeight;
         }
 
         if (containsHtml(text)) {
-            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, style, effectiveTextWidth, effectiveTextHeight);
+            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight);
         } else {
             for (const line of lines) {
                 let currentLineRenderX;
@@ -233,7 +237,7 @@ export const composeSingleImage = async ({
                     currentLineRenderX = textContentStartX;
                 }
                 const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
-                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, style, effectiveTextWidth, effectiveTextHeight);
+                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight);
             }
         }
         ctx.restore();


### PR DESCRIPTION
This commit fixes a bug where the generated image thumbnail did not match the editor preview. The issue was caused by the image generation process not applying the same font scaling as the preview.

The following changes have been made:
- `imageComposer.js`: The `composeSingleImage` function now accepts a `fontScale` parameter and applies it to the font size and related calculations before rendering the text.
- `ImageGeneratorFrontendOnly.jsx`: The `generateImages` function now calculates the `fontScale` based on the ratio between the displayed image size and the original image size. This scale is then passed to `composeSingleImage`.
- `HomePage.jsx`: The `displayedImageSize` state is now passed down to the `ImageGeneratorFrontendOnly` component.

These changes ensure that the generated images are consistent with the preview in the editor, providing a more accurate and reliable user experience.