### PR TITLE
fix: Correct image generation scaling and layout issues

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -321,6 +321,10 @@ const FieldPositioner = ({
   };
 
   const autoArrangeFields = () => {
+    if (!originalImageSize?.width || !originalImageSize?.height) {
+      alert("A imagem original ainda não foi carregada. Por favor, aguarde.");
+      return;
+    }
     // 1. Define Safe Zone and Field Roles
     const safeZoneMargins = {
       top: 10, // 10%
@@ -362,8 +366,8 @@ const FieldPositioner = ({
         visible: true,
       };
 
-      const titleBoxWidthPx = (titleWidth / 100) * (originalImageSize?.width || imageSize.width);
-      const titleBoxHeightPx = (titleHeight / 100) * (originalImageSize?.height || imageSize.height);
+      const titleBoxWidthPx = (titleWidth / 100) * originalImageSize.width;
+      const titleBoxHeightPx = (titleHeight / 100) * originalImageSize.height;
       const titleText = csvData[currentPreviewIndex]?.[titleField] || `[${titleField}]`;
 
       const bestFontSize = findBestFitFontSize(
@@ -415,7 +419,7 @@ const FieldPositioner = ({
       const fontSizePx = sideLabelStyle.fontSize || 24;
 
       // A altura da caixa (que se torna a largura do texto após rotação) é baseada na altura da fonte.
-      const labelHeight = (fontSizePx / (originalImageSize?.height || imageSize.height || 1)) * 100 * 1.5;
+      const labelHeight = (fontSizePx / originalImageSize.height) * 100 * 1.5;
       // A largura da caixa (que se torna a altura do texto) é uma grande parte da altura da zona segura.
       const labelWidth = safeZone.height * 0.7;
 


### PR DESCRIPTION
This commit addresses two separate but related bugs that caused inconsistencies between the editor preview and the final generated image.

The first fix addresses an issue where the font size in the generated image did not match the preview. This was because the font size was not being scaled relative to the original image size. A `fontScale` is now calculated based on the ratio of the displayed image size to the original image size and is applied during image composition.

The second fix addresses an issue where the "Auto Organizar" feature would produce layouts that were dependent on the screen resolution. This was caused by the layout calculation falling back to using the container's dimensions instead of the image's dimensions. The function has been updated to only use the original image's dimensions and to prevent execution until those dimensions are available.

These changes ensure a consistent and predictable user experience, where the generated image is a faithful representation of the preview, regardless of screen resolution.