### PR TITLE
fix: Ensure consistent font scaling between preview and generated image

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -181,9 +181,6 @@ const FieldPositioner = ({
       for (let entry of entries) {
         const { width, height } = entry.contentRect;
         setImageSize({ width, height });
-        if (onImageDisplayedSizeChange) {
-          onImageDisplayedSizeChange({ width, height });
-        }
 
         // Calculate the actual rendered size and position of the image due to 'object-fit: contain'
         if (originalImageSize?.width && originalImageSize?.height && width > 0 && height > 0) {
@@ -206,6 +203,9 @@ const FieldPositioner = ({
                 y = (height - renderedHeight) / 2;
             }
             setRenderedImageMetrics({ width: renderedWidth, height: renderedHeight, x, y });
+            if (onImageDisplayedSizeChange) {
+              onImageDisplayedSizeChange({ width: renderedWidth, height: renderedHeight });
+            }
         }
       }
     });


### PR DESCRIPTION
This commit fixes a persistent bug where the generated image's text size and wrapping did not match the editor preview. The root cause was an incorrect value being passed to the `onImageDisplayedSizeChange` callback, which resulted in an inaccurate `fontScale` being used during the final image composition.

The following changes have been made:

1.  **`src/components/FieldPositioner.jsx`:** The `ResizeObserver` callback has been modified to pass the actual rendered image dimensions (`renderedImageMetrics`) to the `onImageDisplayedSizeChange` prop, instead of the container's dimensions. This ensures that the parent component has an accurate understanding of the image's on-screen size, including any letterboxing.

2.  **Data Flow Correction:** By fixing the value passed by the callback, the entire data flow for the `fontScale` is now correct. The scale factor used in the preview is now identical to the one used during the final image generation, ensuring that text size and wrapping are consistent between both.

This resolves the issue of fonts appearing proportionally smaller in the generated image and ensures a WYSIWYG experience for the user.