### PR TITLE
fix: Align preview and generated image text wrapping

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -511,7 +511,7 @@ const DraggableElementInternal = ({
 
   const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
   const paddingInPixels = 8 * 2;
-  const textLines = enableHtmlRendering ? [content] : wrapText(editedContent, originalBoxWidth - paddingInPixels, baseFontSize);
+  const textLines = enableHtmlRendering ? [content] : wrapText(editedContent, originalBoxWidth - paddingInPixels, scaledFontSize);
 
   const handleSize = isMobile ? 24 : 12;
 


### PR DESCRIPTION
This commit resolves the final outstanding issue causing a mismatch between the editor preview and the generated image. The previous fixes addressed font and object scaling, but a subtle bug remained in the text wrapping logic for the preview.

The core of this fix is in `DraggableElement.jsx`:

- The text wrapping function (`wrapText`) for the preview was being called with the base (unscaled) font size.
- The final image generation, however, was using the correctly scaled font size for its wrapping calculation.

This discrepancy caused text to wrap differently in the preview versus the final output, especially at different screen resolutions.

The `wrapText` call in `DraggableElement.jsx` has been updated to use `scaledFontSize` instead of `baseFontSize`. This ensures that the text wrapping calculation in the preview is identical to the one used for the final image generation, guaranteeing a true WYSIWYG result.