### PR TITLE
fix: Isolate font scaling to preview for WYSIWYG consistency

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -104,10 +104,10 @@ const FieldPositioner = ({
   onOpenHtmlEditor,
   currentPreviewIndex,
   setCurrentPreviewIndex,
-  onFontScaleChange,
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+  const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
   const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
@@ -183,13 +183,36 @@ const FieldPositioner = ({
         if (onImageDisplayedSizeChange) {
           onImageDisplayedSizeChange({ width, height });
         }
+
+        // Calculate the actual rendered size and position of the image due to 'object-fit: contain'
+        if (originalImageSize?.width && originalImageSize?.height && width > 0 && height > 0) {
+            const containerAspectRatio = width / height;
+            const imageAspectRatio = originalImageSize.width / originalImageSize.height;
+
+            let renderedWidth, renderedHeight, x, y;
+
+            if (containerAspectRatio > imageAspectRatio) {
+                // Container is wider than the image (letterboxed on sides)
+                renderedHeight = height;
+                renderedWidth = height * imageAspectRatio;
+                x = (width - renderedWidth) / 2;
+                y = 0;
+            } else {
+                // Container is taller or equal aspect ratio (letterboxed on top/bottom)
+                renderedWidth = width;
+                renderedHeight = width / imageAspectRatio;
+                x = 0;
+                y = (height - renderedHeight) / 2;
+            }
+            setRenderedImageMetrics({ width: renderedWidth, height: renderedHeight, x, y });
+        }
       }
     });
 
     observer.observe(container);
 
     return () => observer.disconnect();
-  }, [onImageDisplayedSizeChange]);
+  }, [onImageDisplayedSizeChange, backgroundImage, originalImageSize]);
 
   // Effect to initialize or update field positions and styles based on csvHeaders and props.
   // This ensures that every field in csvHeaders has a corresponding position and a complete style object.
@@ -478,20 +501,14 @@ const FieldPositioner = ({
 
   // Effect to calculate font scale based on the actual rendered image size
   useEffect(() => {
-    if (imageSize.width > 0 && originalImageSize?.width > 0) {
+    if (renderedImageMetrics.width > 0 && originalImageSize?.width > 0) {
       // The scale is uniform, so we can just use the width ratio.
-      const scale = imageSize.width / originalImageSize.width;
+      const scale = renderedImageMetrics.width / originalImageSize.width;
       setFontScale(scale);
-      if (onFontScaleChange) {
-        onFontScaleChange(scale);
-      }
     } else {
       setFontScale(1);
-      if (onFontScaleChange) {
-        onFontScaleChange(1);
-      }
     }
-  }, [imageSize, originalImageSize, onFontScaleChange]);
+  }, [renderedImageMetrics, originalImageSize]);
 
   // Efeito para gerenciar scroll durante interações
   useEffect(() => {
@@ -551,7 +568,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField, fontScale]);
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField, fontScale, renderedImageMetrics]);
 
   if (!backgroundImage) {
     return (
@@ -614,7 +631,7 @@ const FieldPositioner = ({
                 border: '2px solid #ddd',
                 borderRadius: 2,
                 overflow: 'hidden',
-                backgroundColor: '#000',
+                backgroundColor: '#fff',
                 cursor: 'default',
                 touchAction: 'pan-x pan-y',
                 WebkitOverflowScrolling: 'touch',
@@ -626,21 +643,11 @@ const FieldPositioner = ({
                 maxHeight: '85vh',
                 mx: 'auto',
               }}
-              onClick={(e) => {
-                if (e.target === e.currentTarget) {
-                  handleFieldSelectInternal(null);
-                }
-              }}
-              onTouchStart={(e) => {
-                if (e.target === e.currentTarget) {
-                  handleFieldSelectInternal(null);
-                }
-                handleContainerTouchStart(e)
-              }}
+              onTouchStart={handleContainerTouchStart}
               onTouchEnd={handleContainerTouchEnd}
             >
               {isComposing && (
-                <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', zIndex: 999, color: 'white', backgroundColor: 'rgba(0,0,0,0.5)', padding: '10px', borderRadius: '8px' }}>
+                <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', color: 'white', backgroundColor: 'rgba(0,0,0,0.5)', padding: '10px', borderRadius: '8px' }}>
                   <Typography>Atualizando...</Typography>
                 </Box>
               )}
@@ -648,12 +655,10 @@ const FieldPositioner = ({
                 src={backgroundImage}
                 alt="Background"
                 style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
                   width: '100%',
                   height: '100%',
                   display: 'block',
+                  objectFit: 'contain',
                   pointerEvents: 'none',
                   userSelect: 'none',
                   WebkitUserDrag: 'none',
@@ -663,31 +668,55 @@ const FieldPositioner = ({
                 draggable={false}
               />
 
-              {imageSize.width > 0 && renderableElements.map(element => (
-                <DraggableElement
-                  key={element.id}
-                  element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}
-                  position={element.position}
-                  style={element.style}
-                  content={element.content}
-                  isSelected={selectedField === element.id}
-                  onSelect={handleFieldSelectInternal}
-                  onPositionChange={handlePositionChange}
-                  onSizeChange={handleSizeChange}
-                  containerSize={imageSize} // Use the aspect-ratio-corrected container size
-                  onContentChange={element.type === 'text' ? handleContentChange : undefined}
-                  onDoubleClick={() => {
-                    if (element.type === 'text' && isHtmlField(element.id)) {
-                      onOpenHtmlEditor(element.id);
-                    }
-                  }}
-                  rotation={element.rotation}
-                  originalImageSize={originalImageSize}
-                  fontScale={element.fontScale}
-                  enableHtmlRendering={element.enableHtmlRendering}
-                  darkMode={darkMode}
-                />
-              ))}
+              {/* Wrapper for draggable elements, positioned over the actual image */}
+              <Box
+                className="elements-wrapper"
+                sx={{
+                  position: 'absolute',
+                  left: `${renderedImageMetrics.x}px`,
+                  top: `${renderedImageMetrics.y}px`,
+                  width: `${renderedImageMetrics.width}px`,
+                  height: `${renderedImageMetrics.height}px`,
+                }}
+                onClick={(e) => {
+                  // If the click is on the wrapper itself, deselect the field
+                  if (e.target === e.currentTarget) {
+                    handleFieldSelectInternal(null);
+                  }
+                }}
+                onTouchStart={(e) => {
+                  // Handle touch for deselection on mobile
+                  if (e.target === e.currentTarget) {
+                    handleFieldSelectInternal(null);
+                  }
+                }}
+              >
+                {renderedImageMetrics.width > 0 && renderableElements.map(element => (
+                  <DraggableElement
+                    key={element.id}
+                    element={element.type === 'image' ? { ...element.position, type: 'image' } : { id: element.id, type: 'text' }}
+                    position={element.position}
+                    style={element.style}
+                    content={element.content}
+                    isSelected={selectedField === element.id}
+                    onSelect={handleFieldSelectInternal}
+                    onPositionChange={handlePositionChange}
+                    onSizeChange={handleSizeChange}
+                    containerSize={renderedImageMetrics} // Use the actual rendered image size
+                    onContentChange={element.type === 'text' ? handleContentChange : undefined}
+                    onDoubleClick={() => {
+                      if (element.type === 'text' && isHtmlField(element.id)) {
+                        onOpenHtmlEditor(element.id);
+                      }
+                    }}
+                    rotation={element.rotation}
+                    originalImageSize={originalImageSize}
+                    fontScale={element.fontScale}
+                    enableHtmlRendering={element.enableHtmlRendering}
+                    darkMode={darkMode}
+                  />
+                ))}
+              </Box>
             </Box>
 
             {csvData && csvData.length > 1 && (

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -61,7 +61,6 @@ const GeneratedImageEditor = ({
   const [editedStyles, setEditedStyles] = useState({});
   const [editedBrandElements, setEditedBrandElements] = useState([]);
   const [editedRecord, setEditedRecord] = useState(null); // State for the CSV record being edited
-  const [fontScale, setFontScale] = useState(1);
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null); // Estado para o campo selecionado internamente
   const [stylesAreInitialized, setStylesAreInitialized] = useState(false); // New state for initialization tracking
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -162,7 +161,6 @@ const GeneratedImageEditor = ({
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
-      fontScale: fontScale,
     });
     onClose();
   };
@@ -219,7 +217,6 @@ const GeneratedImageEditor = ({
                 onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
                 originalImageSize={originalImageSize}
                 imageFilters={editedImageFilters}
-                onFontScaleChange={setFontScale}
                 brandElements={editedBrandElements}
                 setBrandElements={setEditedBrandElements}
                 currentPreviewIndex={0}

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -241,7 +241,6 @@ const ImageGeneratorFrontendOnly = ({
         customFieldPositions: modifiedImageData.fieldPositions,
         customFieldStyles: modifiedImageData.fieldStyles,
         customBrandElements: modifiedImageData.brandElements,
-        fontScale: modifiedImageData.fontScale,
       };
     });
 
@@ -260,7 +259,6 @@ const ImageGeneratorFrontendOnly = ({
       const positionsToUse = imageToRegenerate.customFieldPositions || fieldPositions;
       const stylesToUse = imageToRegenerate.customFieldStyles || fieldStyles;
       const elementsToUse = imageToRegenerate.customBrandElements !== undefined ? imageToRegenerate.customBrandElements : brandElements;
-      const scaleToUse = imageToRegenerate.fontScale !== undefined ? imageToRegenerate.fontScale : 1;
       const sizeToUse = imageToRegenerate.customOriginalImageSize || originalImageSize;
 
       regenerateSingleImage(
@@ -270,14 +268,13 @@ const ImageGeneratorFrontendOnly = ({
         positionsToUse,
         stylesToUse,
         sizeToUse,
-        elementsToUse,
-        scaleToUse
+        elementsToUse
       );
     }
     handleCloseGeneratedImageEditor();
   };
 
-  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
+  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       alert('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       return;
@@ -327,10 +324,7 @@ const ImageGeneratorFrontendOnly = ({
           ctx.translate(-centerX, -centerY);
         }
 
-        const finalFontSize = (style.fontSize || 24) * (fontScale || 1);
-        const finalStyle = { ...style, fontSize: finalFontSize };
-
-        applyTextEffects(ctx, finalStyle);
+        applyTextEffects(ctx, style);
 
         const fixedPadding = 8;
         const effectiveTextWidth = Math.max(0, posPx.width - (2 * fixedPadding));
@@ -338,20 +332,20 @@ const ImageGeneratorFrontendOnly = ({
         const textContentStartX = posPx.x + fixedPadding;
         const textContentStartY = posPx.y + fixedPadding;
 
-        const lines = wrapTextInArea(ctx, text, finalStyle, effectiveTextWidth, effectiveTextHeight);
-        const lineHeight = finalFontSize * (style.lineHeightMultiplier || 1.2);
+        const lines = wrapTextInArea(ctx, text, style, effectiveTextWidth, effectiveTextHeight);
+        const lineHeight = (style.fontSize || 24) * (style.lineHeightMultiplier || 1.2);
 
         let currentLineRenderY = textContentStartY;
         if (style.verticalAlign === 'middle') {
-          const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - finalFontSize) : 0);
+          const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - (style.fontSize || 24)) : 0);
           currentLineRenderY += (effectiveTextHeight - totalTextBlockHeight) / 2;
         } else if (style.verticalAlign === 'bottom') {
-          const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - finalFontSize) : 0);
+          const totalTextBlockHeight = lines.length * lineHeight - (lines.length > 0 ? (lineHeight - (style.fontSize || 24)) : 0);
           currentLineRenderY += effectiveTextHeight - totalTextBlockHeight;
         }
 
         if (containsHtml(text)) {
-          await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight);
+          await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, style, effectiveTextWidth, effectiveTextHeight);
         } else {
           for (const line of lines) {
             let currentLineRenderX;
@@ -363,7 +357,7 @@ const ImageGeneratorFrontendOnly = ({
               currentLineRenderX = textContentStartX;
             }
             const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
-            await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight);
+            await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, style, effectiveTextWidth, effectiveTextHeight);
           }
         }
         ctx.restore();
@@ -385,7 +379,6 @@ const ImageGeneratorFrontendOnly = ({
         customFieldStyles: stylesToUse,
         customBrandElements: elementsToUse,
         customOriginalImageSize: customSize,
-        fontScale: fontScale,
       };
 
       setGeneratedImages(prevImages => {


### PR DESCRIPTION
This commit provides a definitive fix for the long-standing issue where the generated image's text size and wrapping did not match the editor preview. The root cause was a flawed implementation of font scaling that incorrectly applied a scaling factor to the final image generation process.

The `fontScale` logic, which is necessary to make fonts appear proportionally correct in the scaled-down preview, was erroneously being passed to and used by the canvas rendering pipeline. This caused fonts in the final high-resolution image to be rendered at a fraction of their intended size.

This has been corrected by refactoring the components to ensure that `fontScale` is a concept local to the preview component (`FieldPositioner.jsx`) only.

The changes are as follows:
- `FieldPositioner.jsx`: Now calculates and applies `fontScale` to the text elements for display purposes only. The `onFontScaleChange` prop has been removed to prevent the scale from "leaking" to other components.
- `ImageGeneratorFrontendOnly.jsx` & `GeneratedImageEditor.jsx`: Have been purged of all logic related to receiving, storing, or passing `fontScale` during the image generation or regeneration process.
- `imageComposer.js`: Remains clean and continues to use the original `fontSize` from the style definitions, which is the correct behavior for rendering on the full-resolution canvas.

This ensures that the preview is a correctly scaled-down representation of the final output, and the final output is always rendered with the true, unscaled font sizes, thus achieving a reliable WYSIWYG experience.