### PR TITLE
fix(campaign): Preserve individual post backgrounds on save/load

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -79,7 +79,14 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     assetsToUploadCount += cleanState.brandElements.filter(el => needsUpload(el.url)).length;
   }
   if (Array.isArray(cleanState.generatedImagesData)) {
-    assetsToUploadCount += cleanState.generatedImagesData.filter(img => needsUpload(img.url)).length;
+    for (const img of cleanState.generatedImagesData) {
+        if (needsUpload(img.url)) {
+            assetsToUploadCount++;
+        }
+        if (needsUpload(img.backgroundImage)) {
+            assetsToUploadCount++;
+        }
+    }
   }
   if (Array.isArray(cleanState.generatedAudioData)) {
     assetsToUploadCount += cleanState.generatedAudioData.filter(audio => needsUpload(audio.url)).length;
@@ -130,16 +137,24 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     // Generated Post Images
     if (Array.isArray(cleanState.generatedImagesData)) {
        for (const image of cleanState.generatedImagesData) {
+        // Upload the main composite image if it's a data URL
         if (needsUpload(image.url)) {
           const filename = image.filename || `post_image_${image.index}_${Date.now()}.png`;
-          console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
-          const dataUrlToUpload = image.url;
-          const permanentUrl = await uploadAsset(dataUrlToUpload, filename, campaignId, userId);
+          console.log(`[serializeCampaignData] Uploading asset (composite) ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
+          const permanentUrl = await uploadAsset(image.url, filename, campaignId, userId);
           image.url = permanentUrl;
           assetsUploadedCount++;
           onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
         }
-        delete image.backgroundImage;
+        // Upload the specific background image if it's a data URL
+        if (needsUpload(image.backgroundImage)) {
+            const filename = `post_bg_${image.index}_${Date.now()}.png`;
+            console.log(`[serializeCampaignData] Uploading asset (background) ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
+            const permanentUrl = await uploadAsset(image.backgroundImage, filename, campaignId, userId);
+            image.backgroundImage = permanentUrl;
+            assetsUploadedCount++;
+            onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
+        }
       }
     }
 


### PR DESCRIPTION
This commit fixes a critical bug where post-specific background images were being deleted during the campaign save process. This caused loaded campaigns to incorrectly fall back to the global background image when a user tried to edit a post.

The root cause was an explicit `delete image.backgroundImage;` statement within the `serializeCampaignData` function in `src/utils/campaignState.js`.

The fix involves two parts:
1.  The incorrect `delete image.backgroundImage;` statement has been removed.
2.  The `serializeCampaignData` function has been updated to handle the uploading of post-specific background images. It now checks if `image.backgroundImage` is a local data URL and, if so, uploads it to the blob store and replaces the data URL with the permanent remote URL.

This ensures that all post-specific background images are correctly preserved and reloaded, resolving the bug and making the campaign save/load functionality reliable.