### PR TITLE
feat: Update UI and defaults for "Posts Curtos" step

### DIFF
--- a/src/components/PostsCurtosStep.jsx
+++ b/src/components/PostsCurtosStep.jsx
@@ -156,7 +156,7 @@ const PostsCurtosStep = ({
                       onChange={(e) => setGenerateImagesAutomatically(e.target.checked)}
                     />
                   }
-                  label="Gerar imagens de fundo automaticamente para cada post"
+                  label="Gerar imagens"
                   sx={{ mb: 2, display: 'block' }}
                 />
                 <Button

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -108,9 +108,9 @@ function HomePage() {
   const [selectedImages, setSelectedImages] = useState({});
   const [selectedVideos, setSelectedVideos] = useState({});
   const [inputMethod, setInputMethod] = useState('ia');
-  const [promptNumRecords, setPromptNumRecords] = useState(10);
+  const [promptNumRecords, setPromptNumRecords] = useState(5);
   const [promptText, setPromptText] = useState('');
-  const [generateImagesAutomatically, setGenerateImagesAutomatically] = useState(false);
+  const [generateImagesAutomatically, setGenerateImagesAutomatically] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
This commit implements several UI and behavior changes for the "Posts Curtos" (Short Posts) step as requested.

The changes include:
1.  The "Generate background images automatically" checkbox is now checked by default.
2.  The label for this checkbox has been shortened to "Gerar imagens" (Generate images) for clarity.
3.  The default value for the post quantity slider has been changed from 10 to 5, and its max value has been confirmed to be compatible.

These changes streamline the user experience for the AI content generation feature.