### PR TITLE
fix(editor): Enable double-click to edit text fields

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -260,7 +260,6 @@ const DraggableElementInternal = ({
   ];
 
   const doHandleMouseDown = (e, type, handle = null) => {
-    e.preventDefault();
     e.stopPropagation();
 
     if (setIsMoving) setIsMoving(true);


### PR DESCRIPTION
This commit fixes a bug where double-clicking on a text element in the preview editor did not trigger the in-place editing functionality.

The root cause was an `e.preventDefault()` call within the `onMouseDown` handler (`doHandleMouseDown`) in the `DraggableElement.jsx` component. This call was preventing the browser from correctly processing the sequence of events that leads to a `dblclick` event.

By removing the `e.preventDefault()` call, the `mousedown` event no longer interferes with the `dblclick` event, and the `onDoubleClick` handler on the component now fires as expected. This allows users to edit text fields directly by double-clicking them.