### PR TITLE
feat: Save background images instead of merged images

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -107,6 +107,56 @@ const ImageGeneratorFrontendOnly = ({
     }
   }, [initialGeneratedImagesData]);
 
+  // Effect for regenerating thumbnails on load
+  useEffect(() => {
+    if (initialGeneratedImagesData && initialGeneratedImagesData.length > 0 && fontsLoaded) {
+      const regenerateMissingThumbnails = async () => {
+        const imagesToRegenerate = initialGeneratedImagesData.filter(img => img.record && img.backgroundImage && !img.url);
+
+        if (imagesToRegenerate.length === 0) return;
+
+        console.log(`[Thumbnail-Regen] Found ${imagesToRegenerate.length} images missing thumbnails. Regenerating...`);
+
+        const imagePromises = initialGeneratedImagesData.map(imgData => {
+          // If the URL already exists, or it's not an image we should regenerate, return it as is.
+          if (imgData.url || !imagesToRegenerate.some(r => r.index === imgData.index)) {
+            return Promise.resolve(imgData);
+          }
+
+          // Define parameters for regeneration, falling back to global props.
+          const positionsToUse = imgData.customFieldPositions || fieldPositions;
+          const stylesToUse = imgData.customFieldStyles || fieldStyles;
+          const elementsToUse = imgData.customBrandElements !== undefined ? imgData.customBrandElements : brandElements;
+
+          // Call the composition function to regenerate the merged image
+          return composeSingleImage({
+            record: imgData.record,
+            index: imgData.index,
+            itemBackgroundImage: imgData.backgroundImage,
+            imageFilters,
+            brandElements: elementsToUse,
+            fieldPositions: positionsToUse,
+            fieldStyles: stylesToUse,
+          }).catch(error => {
+            console.error(`[Thumbnail-Regen] Failed to regenerate thumbnail for index ${imgData.index}:`, error);
+            return imgData; // On error, return the original data to not lose it
+          });
+        });
+
+        const newImages = await Promise.all(imagePromises);
+
+        // Update state only if there are actual changes
+        if (JSON.stringify(newImages) !== JSON.stringify(generatedImages)) {
+          setGeneratedImages(newImages);
+          console.log('[Thumbnail-Regen] Successfully regenerated thumbnails and updated state.');
+        }
+      };
+
+      regenerateMissingThumbnails();
+    }
+  }, [initialGeneratedImagesData, fontsLoaded, fieldPositions, fieldStyles, imageFilters, brandElements]);
+
+
   const generateImages = async () => {
     if ((!backgroundImage && initialGeneratedImagesData.some(img => !img.backgroundImage)) || csvData.length === 0) {
       alert('Por favor, carregue um arquivo CSV e uma imagem de fundo global, ou garanta que todas as imagens tenham um fundo individual.');

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -79,7 +79,7 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     assetsToUploadCount += cleanState.brandElements.filter(el => needsUpload(el.url)).length;
   }
   if (Array.isArray(cleanState.generatedImagesData)) {
-    assetsToUploadCount += cleanState.generatedImagesData.filter(img => needsUpload(img.url)).length;
+    assetsToUploadCount += cleanState.generatedImagesData.filter(img => needsUpload(img.backgroundImage)).length;
   }
   if (Array.isArray(cleanState.generatedAudioData)) {
     assetsToUploadCount += cleanState.generatedAudioData.filter(audio => needsUpload(audio.url)).length;
@@ -129,17 +129,17 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
 
     // Generated Post Images
     if (Array.isArray(cleanState.generatedImagesData)) {
-       for (const image of cleanState.generatedImagesData) {
-        if (needsUpload(image.url)) {
-          const filename = image.filename || `post_image_${image.index}_${Date.now()}.png`;
+      for (const image of cleanState.generatedImagesData) {
+        // Upload the background image if it's a data URL, and keep the property.
+        if (needsUpload(image.backgroundImage)) {
+          const filename = `background_post_${image.index}_${Date.now()}.png`;
           console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
-          const dataUrlToUpload = image.url;
-          const permanentUrl = await uploadAsset(dataUrlToUpload, filename, campaignId, userId);
-          image.url = permanentUrl;
+          const permanentUrl = await uploadAsset(image.backgroundImage, filename, campaignId, userId);
+          image.backgroundImage = permanentUrl;
           assetsUploadedCount++;
           onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
         }
-        delete image.backgroundImage;
+        // The merged image 'url' is temporary and will be removed in the final cleanup.
       }
     }
 
@@ -185,6 +185,11 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
       assetArray.forEach(asset => {
         delete asset.dataUrl;
         delete asset.blob;
+        // The `url` for generated images is a temporary merged image, don't save it.
+        // For audio/video it's the final URL, so we only delete it from images.
+        if (asset.hasOwnProperty('backgroundImage')) { // A simple way to identify an image object
+            delete asset.url;
+        }
       });
     }
   };


### PR DESCRIPTION
This change modifies the campaign saving and loading logic to address the issue of saving merged images instead of the original background images.

When saving a campaign, the application now uploads the individual background image for each generated post, rather than the final merged image with text overlays. The temporary data for the merged image (url, blob, etc.) is discarded before saving.

When loading a campaign, a new mechanism in the `ImageGeneratorFrontendOnly` component automatically regenerates the merged thumbnails on the fly. This ensures that the user sees the final, composed images in the UI, providing a seamless experience while storing only the essential data.