### PR TITLE
fix: Correct font size discrepancy between preview and generated image

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -508,9 +508,14 @@ const DraggableElementInternal = ({
   const lineHeight = baseFontSize * (style.lineHeightMultiplier || 1.2);
   const scaledLineHeight = lineHeight * fontScale;
 
-  const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
-  const paddingInPixels = 8 * 2;
-  const textLines = enableHtmlRendering ? [content] : wrapText(editedContent, originalBoxWidth - paddingInPixels, baseFontSize);
+  const scaledPadding = 8 * fontScale;
+  const textLines = enableHtmlRendering
+    ? [content]
+    : wrapText(
+        editedContent,
+        pixelPosition.width - (2 * scaledPadding),
+        scaledFontSize
+      );
 
   const handleSize = isMobile ? 24 : 12;
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -22,7 +22,7 @@ export const containsHtml = (text) => {
  * @param {Object} style - Estilos CSS a serem aplicados ao elemento HTML temporário.
  *                         Deve incluir propriedades como fontFamily, fontSize, color, textAlign, etc.
  */
-export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style) => {
+export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style, fontScale = 1) => {
   const tempDiv = document.createElement('div');
   tempDiv.style.position = 'absolute';
   tempDiv.style.left = '-9999px'; // Move off-screen
@@ -67,6 +67,7 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     const canvasFromHtml = await html2canvas(tempDiv, {
       backgroundColor: null,
       useCORS: true,
+      scale: fontScale,
     });
 
     // Desenhar o canvas gerado no canvas principal na posição X ajustada

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -69,9 +69,9 @@ export const applyTextEffects = (ctx, style) => {
     }
 };
 
-export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
+export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight, fontScale = 1) => {
     if (containsHtml(text)) {
-        await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style);
+        await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style, fontScale);
     } else {
         if (style.textStroke) {
             ctx.strokeText(text, x, y);
@@ -225,7 +225,7 @@ export const composeSingleImage = async ({
         }
 
         if (containsHtml(text)) {
-            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight);
+            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight, fontScale);
         } else {
             for (const line of lines) {
                 let currentLineRenderX;
@@ -237,7 +237,7 @@ export const composeSingleImage = async ({
                     currentLineRenderX = textContentStartX;
                 }
                 const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
-                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight);
+                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight, fontScale);
             }
         }
         ctx.restore();


### PR DESCRIPTION
This commit addresses a significant visual inconsistency where the font size in the generated image was smaller than in the editing preview.

The fix involves two main corrections:

1.  **Consistent Text Wrapping:** The text wrapping logic in the `DraggableElement` preview component was updated. It now calculates line breaks using the same scaled font size and dimensions that are used for rendering the preview. This ensures that the text layout (wrapping) seen in the preview accurately reflects the layout in the final image.

2.  **Correct HTML Rendering Scale:** For text fields containing HTML, the `html2canvas` rendering process was the source of the error. The `fontScale` is now explicitly passed to `html2canvas` via its `scale` option. This forces `html2canvas` to render at the correct scale, preventing issues related to device pixel ratio and ensuring the font size in the final image is consistent with the preview.