### PR TITLE
fix: Correct font size calculation in final image generation

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -508,14 +508,9 @@ const DraggableElementInternal = ({
   const lineHeight = baseFontSize * (style.lineHeightMultiplier || 1.2);
   const scaledLineHeight = lineHeight * fontScale;
 
-  const scaledPadding = 8 * fontScale;
-  const textLines = enableHtmlRendering
-    ? [content]
-    : wrapText(
-        editedContent,
-        pixelPosition.width - (2 * scaledPadding),
-        scaledFontSize
-      );
+  const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
+  const paddingInPixels = 8 * 2;
+  const textLines = enableHtmlRendering ? [content] : wrapText(editedContent, originalBoxWidth - paddingInPixels, baseFontSize);
 
   const handleSize = isMobile ? 24 : 12;
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -22,7 +22,7 @@ export const containsHtml = (text) => {
  * @param {Object} style - Estilos CSS a serem aplicados ao elemento HTML temporário.
  *                         Deve incluir propriedades como fontFamily, fontSize, color, textAlign, etc.
  */
-export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style, fontScale = 1) => {
+export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style) => {
   const tempDiv = document.createElement('div');
   tempDiv.style.position = 'absolute';
   tempDiv.style.left = '-9999px'; // Move off-screen
@@ -67,7 +67,6 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     const canvasFromHtml = await html2canvas(tempDiv, {
       backgroundColor: null,
       useCORS: true,
-      scale: fontScale,
     });
 
     // Desenhar o canvas gerado no canvas principal na posição X ajustada

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -69,9 +69,9 @@ export const applyTextEffects = (ctx, style) => {
     }
 };
 
-export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight, fontScale = 1) => {
+export const drawTextWithEffects = async (ctx, text, x, y, style, maxWidth, maxHeight) => {
     if (containsHtml(text)) {
-        await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style, fontScale);
+        await renderHtmlToCanvas(ctx, text, x, y, maxWidth, maxHeight, style);
     } else {
         if (style.textStroke) {
             ctx.strokeText(text, x, y);
@@ -202,7 +202,7 @@ export const composeSingleImage = async ({
             ctx.translate(-centerX, -centerY);
         }
 
-        const finalFontSize = (style.fontSize || 24) * fontScale;
+        const finalFontSize = style.fontSize || 24;
         const finalStyle = { ...style, fontSize: finalFontSize };
 
         applyTextEffects(ctx, finalStyle);
@@ -225,7 +225,7 @@ export const composeSingleImage = async ({
         }
 
         if (containsHtml(text)) {
-            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight, fontScale);
+            await drawTextWithEffects(ctx, text, textContentStartX, textContentStartY, finalStyle, effectiveTextWidth, effectiveTextHeight);
         } else {
             for (const line of lines) {
                 let currentLineRenderX;
@@ -237,7 +237,7 @@ export const composeSingleImage = async ({
                     currentLineRenderX = textContentStartX;
                 }
                 const finalLineY = currentLineRenderY + (lines.indexOf(line) * lineHeight);
-                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight, fontScale);
+                await drawTextWithEffects(ctx, line, currentLineRenderX, finalLineY, finalStyle, effectiveTextWidth, effectiveTextHeight);
             }
         }
         ctx.restore();


### PR DESCRIPTION
This commit fixes a bug where the font size in the generated image was inconsistent with the editor preview, appearing much smaller. The root cause was the incorrect application of a `fontScale` factor during the final image composition.

The `fontScale` is calculated in the preview component (`FieldPositioner`) to correctly scale the preview for different screen sizes. However, this same scale factor was being erroneously applied to the font size when rendering the final, full-resolution image on the canvas.

This change removes the `fontScale` multiplier from the `finalFontSize` calculation within `imageComposer.js`. The final image is rendered on a canvas with the same dimensions as the original image, so the font size should be applied directly without scaling. This ensures the font size in the final output is true to the user's settings and correctly corresponds to the preview.