### PR TITLE
fix: Implement comprehensive fix for font size discrepancy

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -508,9 +508,16 @@ const DraggableElementInternal = ({
   const lineHeight = baseFontSize * (style.lineHeightMultiplier || 1.2);
   const scaledLineHeight = lineHeight * fontScale;
 
-  const originalBoxWidth = (position.width / 100) * (originalImageSize?.width || 1);
-  const paddingInPixels = 8 * 2;
-  const textLines = enableHtmlRendering ? [content] : wrapText(editedContent, originalBoxWidth - paddingInPixels, baseFontSize);
+  // For consistent wrapping between preview and final render, calculate wrapping
+  // in the scaled-down coordinate space of the preview.
+  const scaledPadding = 8 * fontScale;
+  const textLines = enableHtmlRendering
+    ? [content]
+    : wrapText(
+        editedContent,
+        pixelPosition.width - (2 * scaledPadding),
+        scaledFontSize
+      );
 
   const handleSize = isMobile ? 24 : 12;
 

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -113,6 +113,25 @@ const FieldPositioner = ({
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
   const [isComposing, setIsComposing] = useState(false); // Keep for loading indicators if needed elsewhere
+  const [internalImageSize, setInternalImageSize] = useState(originalImageSize);
+
+  useEffect(() => {
+    // When the backgroundImage changes, load it to get its actual dimensions.
+    if (backgroundImage) {
+      const img = new Image();
+      img.onload = () => {
+        const newSize = { width: img.width, height: img.height };
+        // Update the internal size state only if it's different, to avoid loops.
+        if (internalImageSize?.width !== newSize.width || internalImageSize?.height !== newSize.height) {
+            setInternalImageSize(newSize);
+        }
+      };
+      img.src = backgroundImage;
+    }
+  }, [backgroundImage]);
+
+  // Use the verified internal size for all calculations, falling back to the prop if not yet loaded.
+  const effectiveImageSize = internalImageSize || originalImageSize;
 
   // The backgroundImage prop is now assumed to be the final, composed background for the editor preview.
   // No further composition is needed here.
@@ -343,8 +362,8 @@ const FieldPositioner = ({
         visible: true,
       };
 
-      const titleBoxWidthPx = (titleWidth / 100) * (originalImageSize?.width || imageSize.width);
-      const titleBoxHeightPx = (titleHeight / 100) * (originalImageSize?.height || imageSize.height);
+      const titleBoxWidthPx = (titleWidth / 100) * (effectiveImageSize?.width || imageSize.width);
+      const titleBoxHeightPx = (titleHeight / 100) * (effectiveImageSize?.height || imageSize.height);
       const titleText = csvData[currentPreviewIndex]?.[titleField] || `[${titleField}]`;
 
       const bestFontSize = findBestFitFontSize(
@@ -396,7 +415,7 @@ const FieldPositioner = ({
       const fontSizePx = sideLabelStyle.fontSize || 24;
 
       // A altura da caixa (que se torna a largura do texto após rotação) é baseada na altura da fonte.
-      const labelHeight = (fontSizePx / (originalImageSize?.height || imageSize.height || 1)) * 100 * 1.5;
+      const labelHeight = (fontSizePx / (effectiveImageSize?.height || imageSize.height || 1)) * 100 * 1.5;
       // A largura da caixa (que se torna a altura do texto) é uma grande parte da altura da zona segura.
       const labelWidth = safeZone.height * 0.7;
 
@@ -477,15 +496,15 @@ const FieldPositioner = ({
     setCurrentPreviewIndex(csvData.length - 1);
   };
 
-  const aspectRatio = (originalImageSize?.width && originalImageSize?.height)
-    ? `${originalImageSize.width} / ${originalImageSize.height}`
+  const aspectRatio = (effectiveImageSize?.width && effectiveImageSize?.height)
+    ? `${effectiveImageSize.width} / ${effectiveImageSize.height}`
     : '16 / 9';
 
   // Effect to calculate font scale based on the actual rendered image size
   useEffect(() => {
-    if (renderedImageMetrics.width > 0 && originalImageSize?.width > 0) {
+    if (renderedImageMetrics.width > 0 && effectiveImageSize?.width > 0) {
       // The scale is uniform, so we can just use the width ratio.
-      const scale = renderedImageMetrics.width / originalImageSize.width;
+      const scale = renderedImageMetrics.width / effectiveImageSize.width;
       setFontScale(scale);
       if (onFontScaleChange) {
         onFontScaleChange(scale);
@@ -496,7 +515,7 @@ const FieldPositioner = ({
         onFontScaleChange(1);
       }
     }
-  }, [renderedImageMetrics, originalImageSize, onFontScaleChange]);
+  }, [renderedImageMetrics, effectiveImageSize, onFontScaleChange]);
 
   // Efeito para gerenciar scroll durante interações
   useEffect(() => {
@@ -556,7 +575,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, originalImageSize, isHtmlField, fontScale, renderedImageMetrics]);
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, imageSize, effectiveImageSize, isHtmlField, fontScale, renderedImageMetrics]);
 
   if (!backgroundImage) {
     return (
@@ -698,7 +717,7 @@ const FieldPositioner = ({
                       }
                     }}
                     rotation={element.rotation}
-                    originalImageSize={originalImageSize}
+                    originalImageSize={effectiveImageSize}
                     fontScale={element.fontScale}
                     enableHtmlRendering={element.enableHtmlRendering}
                     darkMode={darkMode}

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -67,6 +67,9 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     const canvasFromHtml = await html2canvas(tempDiv, {
       backgroundColor: null,
       useCORS: true,
+      width: maxWidth,
+      height: maxHeight,
+      scale: window.devicePixelRatio,
     });
 
     // Desenhar o canvas gerado no canvas principal na posição X ajustada

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -202,7 +202,7 @@ export const composeSingleImage = async ({
             ctx.translate(-centerX, -centerY);
         }
 
-        const finalFontSize = style.fontSize || 24;
+        const finalFontSize = (style.fontSize || 24) * fontScale;
         const finalStyle = { ...style, fontSize: finalFontSize };
 
         applyTextEffects(ctx, finalStyle);


### PR DESCRIPTION
This commit implements a robust, multi-part solution to fix the visual inconsistency where fonts in the generated image appeared smaller than in the editor preview.

The changes include:

1.  **Robust Image Sizing**: `FieldPositioner.jsx` now internally loads the background image to verify its true dimensions. This ensures that the `fontScale` used for all calculations is accurate and not based on potentially stale or incorrect props.

2.  **Consistent Preview Wrapping**: `DraggableElement.jsx` has been updated to calculate text wrapping using the same scaled coordinate system as the preview rendering. This makes the text layout in the preview a more accurate representation of the final output.

3.  **Correct `html2canvas` Scaling**: `htmlRenderer.js` now explicitly sets `width`, `height`, and `scale: window.devicePixelRatio` in the `html2canvas` options. This forces consistent rendering and scaling on high-DPI displays, which was a primary source of the discrepancy for HTML text.