### PR TITLE
Fix(rendering): Enforce text wrapping in HTML-to-canvas rendering

### DIFF
--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -45,6 +45,11 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     tempDiv.style.textShadow = `${style.shadowOffsetX || 2}px ${style.shadowOffsetY || 2}px ${style.shadowBlur || 4}px ${style.shadowColor || '#000000'}`;
   }
 
+  // Explicitly set wrapping properties
+  tempDiv.style.wordWrap = 'break-word';
+  tempDiv.style.whiteSpace = 'normal';
+  tempDiv.style.overflowWrap = 'break-word';
+
   tempDiv.innerHTML = htmlContent;
   document.body.appendChild(tempDiv);
 


### PR DESCRIPTION
This commit fixes a bug where text in HTML-enabled fields was not wrapping correctly in the final generated image.

The root cause was that the temporary `div` used by the `html2canvas` library was not explicitly styled to enforce word wrapping. While modern browsers often default to wrapping, this is not guaranteed in all rendering environments, including the one used by `html2canvas`.

This commit adds explicit CSS properties (`word-wrap: 'break-word'`, `white-space: 'normal'`, `overflow-wrap: 'break-word'`) to the style of the temporary `div` before it is rendered. This ensures that text content will wrap correctly when the width of the content exceeds the width of the container.

This is a targeted fix that directly addresses the reported issue of unwrapped text in the generated images.