### PR TITLE
Revert "Fix(rendering): Enforce text wrapping in HTML-to-canvas rende…

### DIFF
--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -45,11 +45,6 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     tempDiv.style.textShadow = `${style.shadowOffsetX || 2}px ${style.shadowOffsetY || 2}px ${style.shadowBlur || 4}px ${style.shadowColor || '#000000'}`;
   }
 
-  // Explicitly set wrapping properties
-  tempDiv.style.wordWrap = 'break-word';
-  tempDiv.style.whiteSpace = 'normal';
-  tempDiv.style.overflowWrap = 'break-word';
-
   tempDiv.innerHTML = htmlContent;
   document.body.appendChild(tempDiv);
 


### PR DESCRIPTION
…ring"

This reverts the previous commit that attempted to fix text wrapping by adding explicit CSS properties to the `html2canvas` rendering utility.

Reason for reversion:
While the previous change was intended to fix text wrapping, it introduced a more severe regression that caused incorrect font scaling in the final generated images. User feedback indicated that the application state before this change was preferable and handled font sizes correctly.

This reversion removes the explicit `word-wrap`, `white-space`, and `overflow-wrap` properties from `src/utils/htmlRenderer.js` to restore the correct font rendering behavior. The underlying text wrapping discrepancy will be investigated separately with a new approach that does not interfere with font scaling.