### PR TITLE
Fix(rendering): Add missing style properties to HTML renderer

### DIFF
--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -45,6 +45,12 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     tempDiv.style.textShadow = `${style.shadowOffsetX || 2}px ${style.shadowOffsetY || 2}px ${style.shadowBlur || 4}px ${style.shadowColor || '#000000'}`;
   }
 
+  // Decoração e contorno de texto
+  tempDiv.style.textDecoration = style.textDecoration || 'none';
+  if (style.textStroke) {
+    tempDiv.style.webkitTextStroke = `${style.strokeWidth || 2}px ${style.strokeColor || '#ffffff'}`;
+  }
+
   tempDiv.innerHTML = htmlContent;
   document.body.appendChild(tempDiv);
 


### PR DESCRIPTION
This commit fixes a visual inconsistency between the editor preview and the final generated image for HTML-enabled text fields.

A detailed comparison of the rendering paths revealed that the `renderHtmlToCanvas` function, which uses `html2canvas` for image generation, was not applying all the style properties that were visible in the preview. Specifically, `text-decoration` and `-webkit-text-stroke` were missing.

This resulted in text outlines and underlines appearing in the editor but disappearing in the final image, making the font look different and causing perceived size differences.

This commit adds the logic to apply `text-decoration` and `-webkit-text-stroke` to the temporary DOM element that `html2canvas` renders, ensuring that the final image is visually consistent with the editor preview.