### PR TITLE
Fix: Preserve custom styles in GeneratedImageEditor

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BDtVTUE_.js"></script>
+  <script type="module" crossorigin src="/assets/index-euOZrbr1.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -45,7 +45,7 @@ const COMPLETE_DEFAULT_STYLE = {
   borderWidth: 0,
   borderRadius: 0,
   padding: 5,
-  backgroundOpacity: 1,
+  backgroundOpacity: 0,
 };
 
 const GeneratedImageEditor = ({
@@ -97,9 +97,10 @@ const GeneratedImageEditor = ({
   };
 
   useEffect(() => {
-    if (imageData && initialFieldPositions && initialFieldStyles) {
-      const positions = JSON.parse(JSON.stringify(initialFieldPositions));
-      const brands = JSON.parse(JSON.stringify(brandElements || []));
+    if (open && imageData && initialFieldPositions && initialFieldStyles) {
+      const positions = JSON.parse(JSON.stringify(imageData.customFieldPositions || initialFieldPositions));
+      const brands = JSON.parse(JSON.stringify(imageData.customBrandElements || brandElements || []));
+      const stylesToUse = imageData.customFieldStyles || initialFieldStyles;
 
       // Defensively add filters to brand elements
       brands.forEach(el => {
@@ -143,7 +144,7 @@ const GeneratedImageEditor = ({
       globalCsvHeaders.forEach(field => {
         newEditedStyles[field] = {
           ...COMPLETE_DEFAULT_STYLE,
-          ...(initialFieldStyles?.[field] || {}),
+          ...(stylesToUse?.[field] || {}),
         };
       });
       setEditedStyles(newEditedStyles);


### PR DESCRIPTION
This commit addresses a bug where custom styles, including padding, were not being correctly loaded when opening the `GeneratedImageEditor`.

The `useEffect` hook in `GeneratedImageEditor.jsx` has been updated to prioritize `imageData.customFieldStyles` and `imageData.customFieldPositions` over the global `initialFieldStyles` and `initialFieldPositions`. This ensures that any individual modifications made to an image's layout and style are correctly loaded when the editor is reopened.

Additionally, the default `backgroundOpacity` in the editor's local default style object has been set to 0 to align with the global default.