### PR TITLE
Fix: Resolve multiple rendering and state management bugs

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CvzWFEbi.js"></script>
+  <script type="module" crossorigin src="/assets/index-D7qtJU8P.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -68,11 +68,9 @@ const FieldPositioner = ({
   onOpenHtmlEditor,
   currentPreviewIndex,
   setCurrentPreviewIndex,
-  onFontScaleChange,
 }) => {
   const [selectedField, setSelectedField] = useState(null);
   const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
-  const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
   const containerRef = useRef(null);
   const [internalImageSize, setInternalImageSize] = useState(null);
@@ -308,23 +306,6 @@ const FieldPositioner = ({
     ? `${effectiveImageSize.width} / ${effectiveImageSize.height}`
     : '16 / 9';
 
-  // Effect to calculate font scale based on the actual rendered image size
-  useEffect(() => {
-    if (renderedImageMetrics.width > 0 && effectiveImageSize?.width > 0) {
-      // The scale is uniform, so we can just use the width ratio.
-      const scale = renderedImageMetrics.width / effectiveImageSize.width;
-      setFontScale(scale);
-      if (onFontScaleChange) {
-        onFontScaleChange(scale);
-      }
-    } else {
-      setFontScale(1);
-      if (onFontScaleChange) {
-        onFontScaleChange(1);
-      }
-    }
-  }, [renderedImageMetrics, effectiveImageSize, onFontScaleChange]);
-
   // Efeito para gerenciar scroll durante interações
   useEffect(() => {
     if (isInteracting) {
@@ -358,7 +339,7 @@ const FieldPositioner = ({
             content: sampleData,
             zIndex: position.zIndex || 0,
             rotation: position.rotation,
-            fontScale: fontScale,
+            fontScale: 1,
             enableHtmlRendering: isHtmlField(header),
           };
         })


### PR DESCRIPTION
This commit addresses several issues reported by the user, culminating in a fix for a font size discrepancy between the preview and the final generated image.

The following fixes are included:

1.  **Default Field Styles**: The default `backgroundOpacity` for new text fields is now correctly set to `0` instead of `1`, making them transparent by default.

2.  **Campaign Generation Crash**: Fixed a `ReferenceError` for `setCampaignGenerationFailed` on the Campaign step by adding the missing state variables (`campaignGenerationFailed`, `generationError`) in `HomePage.jsx` and passing them down to the `Campaign` component.

3.  **Rich Text Editor Logic**: Corrected the `activeStep` checks in `HomePage.jsx` for the `TextEditorDialog` to ensure the correct content was being loaded for the right step.

4.  **HTML Field Padding**: The `renderHtmlToCanvas` function in `htmlRenderer.js` now correctly applies the `padding` style to the temporary `div` used for rendering, ensuring it's respected in the final image.

5.  **HTML Field Font Loading**: Added a call to `document.fonts.load()` in `htmlRenderer.js` to ensure custom fonts are loaded before `html2canvas` attempts to render the text, preventing font fallbacks.

6.  **Font Size Discrepancy**: The root cause of the font size mismatch between the preview and the final image was an incorrect manual `fontScale` calculation in `FieldPositioner.jsx`. This logic has been removed. The preview now relies on the browser's natural scaling, aligning its appearance with the final render, which uses a scale of 1.