### PR TITLE
Hotfix: Correct ReferenceError for fontScale in FieldPositioner

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-D7qtJU8P.js"></script>
+  <script type="module" crossorigin src="/assets/index-CEYaPVQ8.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -364,7 +364,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
+  }, [csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex]);
 
   if (!backgroundImage) {
     return (


### PR DESCRIPTION
This commit fixes a `ReferenceError: fontScale is not defined` that occurred in the `FieldPositioner` component.

The error was introduced in a previous commit where the `fontScale` state variable was removed, but a reference to it remained in the dependency array of a `useMemo` hook. This commit removes the dangling reference from the dependency array, resolving the crash.