### PR TITLE
fix(publisher): Use correct key for WordPress settings

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -349,7 +349,7 @@ const Publisher = ({
     setPublishingStatusWp('Iniciando publicação...');
     setPublishedPostUrlWp(null);
     try {
-      if (!settings.wordpressConfig) {
+      if (!settings.wordpress) {
         throw new Error('Configuração do WordPress não encontrada. Por favor, configure-a primeiro.');
       }
       if (!campaignContent || !campaignContent.conteudoFormatado || !generatedImagesData || generatedImagesData.length === 0) {
@@ -365,7 +365,7 @@ const Publisher = ({
         imageBlob: firstImage.blob,
       };
       setPublishingStatusWp('Publicando no WordPress... Isso pode levar um momento.');
-      const post = await publishToWordPress(campaignData, settings.wordpressConfig);
+      const post = await publishToWordPress(campaignData, settings.wordpress);
       setPublishingStatusWp(`Post "${post.title.rendered}" criado como rascunho com sucesso!`);
       setPublishedPostUrlWp(post.link);
     } catch (error) {


### PR DESCRIPTION
This commit fixes a bug where WordPress publishing failed because it was trying to access the configuration from the wrong key in the settings object.

The component was looking for `settings.wordpressConfig`, but the configuration is actually stored under `settings.wordpress`.

This change corrects the key to `settings.wordpress`, which resolves the "Configuração do WordPress não encontrada" error during publishing. The previous refactoring to pass the settings object as a parameter is kept as it improves the code's robustness.