### PR TITLE
Fix: Ensure text wrapping in generated HTML fields

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CEYaPVQ8.js"></script>
+  <script type="module" crossorigin src="/assets/index-B6CsAnhW.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -31,6 +31,7 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
   tempDiv.style.height = 'auto'; // Altura automática para medir o conteúdo
   tempDiv.style.boxSizing = 'border-box';
   tempDiv.style.padding = `${style.padding || 0}px`;
+  tempDiv.style.overflowWrap = 'break-word';
 
   // Aplicar estilos para medição
   tempDiv.style.fontFamily = style.fontFamily || 'Arial';


### PR DESCRIPTION
This commit fixes a bug where text in HTML fields would not respect the textbox boundaries and would overflow in the final generated image.

The `renderHtmlToCanvas` function in `src/utils/htmlRenderer.js` has been updated to include the `overflow-wrap: break-word` CSS property on the temporary div used for rendering. This ensures that long words are correctly broken and the text wraps within the defined container, matching the behavior seen in the live preview.