### PR TITLE
fix(linkedin): Filter organization acls and add scope

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -158,7 +158,7 @@ async function handleGetProfiles(fetch, request, response) {
   try {
     const [personalResponse, orgAclsResponse] = await Promise.all([
       fetch('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))', { headers }),
-      fetch('https://api.linkedin.com/rest/organizationAcls?q=roleAssignee', { headers })
+      fetch('https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED', { headers })
     ]);
     if (!personalResponse.ok) throw new Error(`Failed to fetch personal profile: ${personalResponse.status}`);
     const personalData = await personalResponse.json();
@@ -166,15 +166,19 @@ async function handleGetProfiles(fetch, request, response) {
     let organizations = [];
     if (orgAclsResponse.ok) {
       const orgAclsData = await orgAclsResponse.json();
-      const orgUrns = orgAclsData.elements?.map(el => el.organization) || [];
-      const uniqueOrgIds = [...new Set(orgUrns.map(urn => urn.split(':').pop()))];
-      const cacheKeys = uniqueOrgIds.map(id => `linkedin:org:${id}`);
 
-      if (forceRefresh && cacheKeys.length > 0) {
-        await kv.del(cacheKeys);
-      }
+      const allowedRoles = new Set(['ADMINISTRATOR', 'CONTENT_ADMINISTRATOR']);
+      const approvedAcls = orgAclsData.elements?.filter(acl => allowedRoles.has(acl.role)) || [];
 
-      if (uniqueOrgIds.length > 0) {
+      if (approvedAcls.length > 0) {
+        const orgUrns = approvedAcls.map(el => el.organization);
+        const uniqueOrgIds = [...new Set(orgUrns.map(urn => urn.split(':').pop()))];
+        const cacheKeys = uniqueOrgIds.map(id => `linkedin:org:${id}`);
+
+        if (forceRefresh && cacheKeys.length > 0) {
+          await kv.del(cacheKeys);
+        }
+
         const allOrgDetails = {};
         const cachedResults = await kv.mget(cacheKeys);
 
@@ -206,7 +210,7 @@ async function handleGetProfiles(fetch, request, response) {
           }
         }
 
-        organizations = orgAclsData.elements.map(acl => {
+        organizations = approvedAcls.map(acl => {
           const orgId = acl.organization.split(':').pop();
           const orgDetails = allOrgDetails[orgId];
           return { id: orgId, name: orgDetails?.localizedName || 'Nome Indisponível', role: acl.role, logo: orgDetails?.logoV2?.['original~']?.elements?.[0]?.identifiers?.[0]?.identifier, type: 'organization' };

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -104,7 +104,7 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
       if (onBeforeRedirect) await onBeforeRedirect();
 
       const redirectUri = window.location.origin;
-      const scope = encodeURIComponent('r_basicprofile w_member_social w_organization_social rw_organization_admin');
+      const scope = encodeURIComponent('r_basicprofile r_organization_social w_member_social w_organization_social rw_organization_admin');
       const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&prompt=select_account`;
       window.location.href = authUrl;
     } else {


### PR DESCRIPTION
This commit fixes an issue where LinkedIn company pages were not being listed for users who manage them.

The `handleGetProfiles` function in `api/linkedin-proxy.js` has been updated to:
- Fetch only organization ACLs with an 'APPROVED' state.
- Filter the returned ACLs to only include users with 'ADMINISTRATOR' or 'CONTENT_ADMINISTRATOR' roles.

Additionally, the `r_organization_social` scope has been added to the LinkedIn authentication flow in `src/components/LinkedinAuthSetup.jsx` to ensure all necessary permissions are requested.