### PR TITLE
Fix: Correct text wrapping for HTML fields in generated images

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-B6CsAnhW.js"></script>
+  <script type="module" crossorigin src="/assets/index-C1MLxZ5n.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -83,11 +83,10 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
 
   try {
     const canvasFromHtml = await html2canvas(tempDiv, {
-      backgroundColor: null,
-      useCORS: true,
-      width: maxWidth,
-      height: maxHeight,
-      scale: window.devicePixelRatio,
+      backgroundColor: null, // Fundo transparente
+      useCORS: true, // Permitir imagens de outras origens se houver
+      scale: window.devicePixelRatio, // Melhorar a resolução em telas de alta DPI
+      // Omitir width e height para que o html2canvas use as dimensões do próprio elemento
     });
 
     // Desenhar o canvas gerado no canvas principal na posição X ajustada


### PR DESCRIPTION
This commit addresses a persistent bug where text in HTML fields would not wrap correctly within its defined textbox, instead overflowing to the edge of the entire image.

The root cause appears to be a conflict in how `html2canvas` handles dimensions. The previous code set the width and height of the temporary `div` via CSS and also passed `width` and `height` as options to the `html2canvas` function.

This commit modifies the `renderHtmlToCanvas` function in `src/utils/htmlRenderer.js` to remove the explicit `width` and `height` options from the `html2canvas` call. The library will now rely solely on the dimensions of the styled `div` element, which are correctly calculated to match the textbox size. This should force `html2canvas` to respect the container's boundaries for text wrapping.