### PR TITLE
fix(wordpress): Ensure default endpoint URLs are saved

### DIFF
--- a/src/components/WordpressAuthSetup.jsx
+++ b/src/components/WordpressAuthSetup.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -24,7 +24,36 @@ const WordpressAuthSetup = () => {
   const [testResult, setTestResult] = useState(null);
   const [showInfobox, setShowInfobox] = useState(false);
 
-  const wordpressConfig = settings.wordpress || {};
+  const wordpressConfig = useMemo(() => settings.wordpress || {}, [settings.wordpress]);
+
+  useEffect(() => {
+    // This effect ensures that when a user first enters a WordPress URL,
+    // the default endpoint URLs are populated in the state if they are empty.
+    if (wordpressConfig.wordpressUrl) {
+      const defaults = {
+        tagsUrl: '/wp-json/wp/v2/tags',
+        mediaUrl: '/wp-json/wp/v2/media',
+        postsUrl: '/wp-json/wp/v2/posts',
+      };
+      const configToUpdate = { ...wordpressConfig };
+      let updated = false;
+      if (!configToUpdate.tagsUrl) {
+        configToUpdate.tagsUrl = defaults.tagsUrl;
+        updated = true;
+      }
+      if (!configToUpdate.mediaUrl) {
+        configToUpdate.mediaUrl = defaults.mediaUrl;
+        updated = true;
+      }
+      if (!configToUpdate.postsUrl) {
+        configToUpdate.postsUrl = defaults.postsUrl;
+        updated = true;
+      }
+      if (updated) {
+        updateSetting('wordpress', configToUpdate);
+      }
+    }
+  }, [wordpressConfig, updateSetting]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;


### PR DESCRIPTION
This commit fixes a bug where publishing to WordPress would fail with a `net::ERR_NAME_NOT_RESOLVED` error. This was caused by the endpoint URLs (for tags, media, etc.) being `undefined` when constructing the request URL.

The root cause was a UI issue in `WordpressAuthSetup.jsx`. Although the form fields for the endpoint URLs displayed default values, these values were not being saved to the application's state unless the user manually interacted with those fields. This led to an incomplete configuration object being used during the publishing process.

This fix introduces a `useEffect` hook in `WordpressAuthSetup.jsx`. This hook ensures that when a user first provides their main WordPress URL, the default values for the endpoint URLs are programmatically saved to the state if they are not already present. This guarantees that the configuration object is always complete, preventing the `undefined` URL issue.