### PR TITLE
Fix: Change html2canvas rendering strategy to fix wrapping

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-C1MLxZ5n.js"></script>
+  <script type="module" crossorigin src="/assets/index-BoUX4Jnb.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-BA7fPfg4.css">
 </head>
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -25,8 +25,9 @@ export const containsHtml = (text) => {
 export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style) => {
   const tempDiv = document.createElement('div');
   tempDiv.style.position = 'absolute';
-  tempDiv.style.left = '-9999px'; // Move off-screen
-  tempDiv.style.top = '-9999px';
+  tempDiv.style.visibility = 'hidden'; // Render on-screen but hidden
+  tempDiv.style.top = '0';
+  tempDiv.style.left = '0';
   tempDiv.style.width = `${maxWidth}px`;
   tempDiv.style.height = 'auto'; // Altura automática para medir o conteúdo
   tempDiv.style.boxSizing = 'border-box';


### PR DESCRIPTION
This commit addresses a persistent and complex bug where text in HTML fields would not wrap correctly within its defined textbox in the final generated image.

The previous off-screen rendering technique (`left: -9999px`) was causing the browser and/or `html2canvas` to incorrectly calculate the layout of the text, leading to overflows.

This commit changes the rendering strategy in `src/utils/htmlRenderer.js`. The temporary `div` is now rendered on-screen but made invisible with `visibility: hidden`. This forces the browser to perform a full, correct layout calculation before `html2canvas` captures the element, ensuring that text wrapping and dimensions are respected as they appear in the live preview.