### PR TITLE
fix(wordpress): Ensure default endpoint URLs are saved

### DIFF
--- a/src/components/WordpressAuthSetup.jsx
+++ b/src/components/WordpressAuthSetup.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -24,40 +24,19 @@ const WordpressAuthSetup = () => {
   const [testResult, setTestResult] = useState(null);
   const [showInfobox, setShowInfobox] = useState(false);
 
-  const wordpressConfig = useMemo(() => settings.wordpress || {}, [settings.wordpress]);
-
-  useEffect(() => {
-    // This effect ensures that when a user first enters a WordPress URL,
-    // the default endpoint URLs are populated in the state if they are empty.
-    if (wordpressConfig.wordpressUrl) {
-      const defaults = {
-        tagsUrl: '/wp-json/wp/v2/tags',
-        mediaUrl: '/wp-json/wp/v2/media',
-        postsUrl: '/wp-json/wp/v2/posts',
-      };
-      const configToUpdate = { ...wordpressConfig };
-      let updated = false;
-      if (!configToUpdate.tagsUrl) {
-        configToUpdate.tagsUrl = defaults.tagsUrl;
-        updated = true;
-      }
-      if (!configToUpdate.mediaUrl) {
-        configToUpdate.mediaUrl = defaults.mediaUrl;
-        updated = true;
-      }
-      if (!configToUpdate.postsUrl) {
-        configToUpdate.postsUrl = defaults.postsUrl;
-        updated = true;
-      }
-      if (updated) {
-        updateSetting('wordpress', configToUpdate);
-      }
-    }
-  }, [wordpressConfig, updateSetting]);
+  const wordpressConfig = settings.wordpress || {};
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    const newWordpressConfig = { ...wordpressConfig, [name]: value };
+    let newWordpressConfig = { ...wordpressConfig, [name]: value };
+
+    // When the main URL is entered, populate the endpoint URLs with defaults if they are empty.
+    if (name === 'wordpressUrl' && value) {
+        newWordpressConfig.tagsUrl = newWordpressConfig.tagsUrl || '/wp-json/wp/v2/tags';
+        newWordpressConfig.mediaUrl = newWordpressConfig.mediaUrl || '/wp-json/wp/v2/media';
+        newWordpressConfig.postsUrl = newWordpressConfig.postsUrl || '/wp-json/wp/v2/posts';
+    }
+
     updateSetting('wordpress', newWordpressConfig);
     setTestResult(null);
   };


### PR DESCRIPTION
This commit fixes a bug where publishing to WordPress would fail with a `net::ERR_NAME_NOT_RESOLVED` error. This was caused by the endpoint URLs (for tags, media, etc.) being `undefined` when constructing the request URL.

The root cause was that the `WordpressAuthSetup.jsx` component, while displaying default values for the API endpoints, did not save these defaults into the application's state unless the user manually edited those fields. This resulted in an incomplete configuration object being used during publishing.

This fix modifies the `handleChange` function in `WordpressAuthSetup.jsx`. Now, when the user enters their main WordPress URL, the default values for the endpoint URLs are programmatically added to the configuration object in the same state update. This ensures that the configuration is always complete, preventing the `undefined` URL issue.