### PR TITLE
fix(linkedin): Improve page discovery and add post logging

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -140,8 +140,14 @@ async function handleUploadImage(fetch, request, response) {
 async function handleCreatePost(fetch, request, response) {
     const { accessToken, payload } = request.body;
     if (!accessToken || !payload) return response.status(400).json({ error: 'Missing accessToken or payload for creating post.' });
+
+    console.error('[DEBUG] Received payload for createPost:', JSON.stringify(payload, null, 2));
+
     const { author, content, images } = payload;
-    if (!author || !content) return response.status(400).json({ error: 'Missing author or content for creating post.' });
+    if (!author || !content) {
+        console.error(`[DEBUG] createPost validation failed. Author: ${author}, Content: ${content ? 'provided' : 'missing'}`);
+        return response.status(400).json({ error: 'Missing author or content for creating post.' });
+    }
     const shareContent = { shareCommentary: { text: content }, shareMediaCategory: (images && images.length > 0) ? 'IMAGE' : 'NONE' };
     if (images && images.length > 0) {
         shareContent.media = images.map(assetURN => ({ status: 'READY', media: assetURN }));


### PR DESCRIPTION
This commit addresses several issues with the LinkedIn integration.

1.  **Rate Limiting on Profile Fetch:** The logic for fetching organization details has been refactored to be more resilient to API rate limits. Instead of a single batch request, details are now fetched sequentially with a delay. The retry logic has also been made more patient.

2.  **Incorrect Profile Filtering:** The `organizationAcls` API call now correctly filters for `state=APPROVED` and for roles that permit content creation (`ADMINISTRATOR`, `CONTENT_ADMINISTRATOR`).

3.  **Missing OAuth Scope:** The `r_organization_social` scope has been added to the authentication flow to ensure all necessary permissions are requested.

4.  **Debugging `createPost` Errors:** Diagnostic logging has been added to the `handleCreatePost` function to inspect the payload received from the client. This will help diagnose a `400 Bad Request` error that occurs during publishing.