### PR TITLE
fix: Handle LinkedIn API errors and add frontend validation

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -67,8 +67,24 @@ async function handleGenericPost(fetch, request, response, url) {
             headers: { 'Authorization': `Bearer ${accessToken}`, 'Content-Type': 'application/json', 'X-Restli-Protocol-Version': '2.0.0', 'LinkedIn-Version': '202507' },
             body: JSON.stringify(payload),
         });
-        const data = await linkedinResponse.json();
-        return response.status(linkedinResponse.status).json(linkedinResponse.ok ? data.value || data : data);
+
+        if (linkedinResponse.ok) {
+            const data = await linkedinResponse.json();
+            // The LinkedIn API sometimes returns the created object directly, and sometimes under a 'value' key.
+            return response.status(linkedinResponse.status).json(data.value || data);
+        } else {
+            // Handle error response
+            const errorBody = await linkedinResponse.text();
+            console.error(`[ERROR] LinkedIn API responded with status ${linkedinResponse.status}:`, errorBody);
+            try {
+                // Try to parse the error body as JSON, as LinkedIn often returns structured errors.
+                const errorJson = JSON.parse(errorBody);
+                return response.status(linkedinResponse.status).json(errorJson);
+            } catch (e) {
+                // If the error body is not JSON, return it as a plain text message.
+                return response.status(linkedinResponse.status).json({ message: errorBody });
+            }
+        }
     } catch (error) {
         console.error(`[FATAL] Error during POST to ${url}:`, error.message, error.stack);
         return response.status(500).json({ error: `Internal Server Error during POST to ${url}` });

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -479,13 +479,15 @@ const Publisher = ({
       }, ...prev]);
     } catch (error) {
       console.error('Erro na publicação:', error);
-      setPublishingStatusLi(`Erro ao publicar: ${error.message}`);
+      const errorMessage = error.message || 'Ocorreu um erro desconhecido.';
+      setPublishingStatusLi(`Erro ao publicar: ${errorMessage}`);
+      toast.error(`Erro ao publicar: ${errorMessage}`);
       setPublishResults(prev => [{
         id: Date.now(),
         target: selectedTarget.name,
         content: content.substring(0, 100) + (content.length > 100 ? '...' : ''),
         success: false,
-        error: error.message,
+        error: errorMessage,
         timestamp: new Date().toLocaleString('pt-BR')
       }, ...prev]);
     } finally {
@@ -556,8 +558,18 @@ const Publisher = ({
                     variant="outlined"
                     sx={{ my: 2 }}
                     placeholder="O que você gostaria de compartilhar?"
-                    maxLength={3000}
+                    inputProps={{ maxLength: 3000 }}
                 />
+                <Typography
+                    variant="caption"
+                    sx={{
+                        textAlign: 'right',
+                        display: 'block',
+                        color: content.length > 3000 ? 'error.main' : 'text.secondary'
+                    }}
+                >
+                    {content.length} / 3000
+                </Typography>
               <Typography variant="subtitle1" gutterBottom sx={{ mt: 2 }}>
                 Selecionar Mídia
               </Typography>
@@ -710,7 +722,7 @@ const Publisher = ({
                 size="large"
                 color="primary"
                 onClick={handlePublishLinkedIn}
-                disabled={isPublishingLi || (isScheduled) || !selectedTarget || !content.trim()}
+                disabled={isPublishingLi || (isScheduled) || !selectedTarget || !content.trim() || content.length > 3000}
               >
                 {isPublishingLi ? 'Publicando...' : 'Publicar Agora no LinkedIn'}
               </Button>


### PR DESCRIPTION
This commit addresses a 500 Internal Server Error that occurred when publishing to LinkedIn.

The error was caused by the `/api/linkedin-proxy` endpoint not gracefully handling error responses from the LinkedIn API, particularly when a post exceeded the character limit.

The fix includes:
-   **Backend:** The `handleGenericPost` function in `api/linkedin-proxy.js` has been updated to catch non-200 responses from the LinkedIn API. It now logs the error body and forwards a structured error message to the client instead of crashing.
-   **Frontend:** The `Publisher.jsx` component has been enhanced to prevent the error and provide better user feedback:
    -   A character counter has been added to the text area, showing the user their current character count out of the 3000-character limit.
    -   The "Publish" button is now disabled if the content exceeds the character limit.
    -   Error toast notifications have been added to ensure any API errors are clearly displayed to the user.