### PR TITLE
Fix: Ensure HTML content wraps correctly in generated images

### DIFF
--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -61,6 +61,22 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
 
   tempDiv.innerHTML = htmlContent;
 
+  // Force styles on all child elements to ensure consistent rendering
+  const allElements = tempDiv.getElementsByTagName('*');
+  for (const el of allElements) {
+      // Force wrapping and prevent default browser styles from interfering
+      el.style.overflowWrap = 'break-word';
+      el.style.wordWrap = 'break-word';
+      el.style.whiteSpace = 'normal';
+      // Force style inheritance from the parent container
+      el.style.color = 'inherit';
+      el.style.fontFamily = 'inherit';
+      el.style.fontWeight = 'inherit';
+      el.style.fontStyle = 'inherit';
+      el.style.textAlign = 'inherit';
+      el.style.lineHeight = 'inherit';
+  }
+
   // Build the DOM structure and append to the body
   container.appendChild(tempDiv);
   document.body.appendChild(container);


### PR DESCRIPTION
The `renderHtmlToCanvas` function was not reliably rendering HTML content with the correct text wrapping, causing a mismatch between the preview and the final generated image. This was because styles applied to the main container were not always inherited by all child elements within the user-provided HTML.

This change addresses the issue by programmatically iterating through all descendant elements of the temporary rendering div after the user's HTML has been injected. It forcefully applies `overflowWrap`, `wordWrap`, and `whiteSpace` styles to every element.

Additionally, it sets other crucial CSS properties like `color`, `fontFamily`, `fontWeight`, etc., to `inherit`. This ensures that all parts of the HTML content respect the container's dimensions and styling, producing a final image that is a faithful representation of the preview.