### PR TITLE
Fix: Unify preview and final image rendering logic

### DIFF
--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -21,6 +21,7 @@ const FormattingDrawer = ({
   onOpenHtmlEditor,
   isHtmlField,
   standardsColors,
+  fontScale,
 }) => {
   return (
     <Drawer anchor="right" open={open} onClose={onClose} sx={{ zIndex: 1400 }}>
@@ -47,6 +48,7 @@ const FormattingDrawer = ({
           onOpenHtmlEditor={onOpenHtmlEditor}
           isHtmlField={isHtmlField}
           standardsColors={standardsColors}
+          fontScale={fontScale}
         />
       </Box>
     </Drawer>

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -66,6 +66,7 @@ const FormattingPanel = ({
   onDeselectField,
   onOpenHtmlEditor,
   standardsColors,
+  fontScale = 1,
 }) => {
   const fonts = [
     // Sans-serif
@@ -362,15 +363,17 @@ const FormattingPanel = ({
                       </Grid>
                       <Grid item xs={12}>
                         <Typography gutterBottom sx={{ mt: 1 }}>
-                          Tamanho: {currentElement.style.fontSize || 24}px
+                          Tamanho: {Math.round((currentElement.style.fontSize || 24) * fontScale)}px
                         </Typography>
                         <Slider
-                          value={currentElement.style.fontSize || 24}
-                          onChange={(e, value) => updateFieldStyle(selectedField, 'fontSize', value)}
-                          min={8}
-                          max={120}
+                          value={Math.round((currentElement.style.fontSize || 24) * fontScale)}
+                          onChange={(e, value) => {
+                            const newBaseSize = Math.round(value / fontScale);
+                            updateFieldStyle(selectedField, 'fontSize', newBaseSize);
+                          }}
+                          min={Math.round(8 * fontScale)}
+                          max={Math.round(120 * fontScale)}
                           valueLabelDisplay="auto"
-                          marks={[{ value: 12, label: '12' }, { value: 24, label: '24' }, { value: 48, label: '48' }, { value: 72, label: '72' }]}
                         />
                       </Grid>
                       <Grid item xs={12}>

--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -246,6 +246,7 @@ const GeneratedImageEditor = ({
                   setBrandElements={setEditedBrandElements}
                   onDeselectField={handleDeselectField}
                   onOpenHtmlEditor={handleOpenHtmlEditor}
+                  fontScale={fontScale}
                 />
               </Grid>
             )}
@@ -283,6 +284,7 @@ const GeneratedImageEditor = ({
             setImageFilters={setEditedImageFilters}
             brandElements={editedBrandElements}
             setBrandElements={setEditedBrandElements}
+            fontScale={fontScale}
           />
         </>
       )}


### PR DESCRIPTION
This commit addresses a critical bug where the generated image did not match the live preview in the editor. The root causes were twofold: inconsistent HTML rendering and a discrepancy in how font sizes were scaled between the preview and the final output.

1.  **Robust HTML Rendering:** The `renderHtmlToCanvas` utility has been refactored to use a `display: table-cell` layout instead of `flexbox`. This provides a more stable and reliable rendering context for `html2canvas`, fixing issues where HTML text would overflow its container.

2.  **Unified Font Scaling:** The font size controls in the `FormattingPanel` now account for the `fontScale` of the preview. The UI displays the visually-correct scaled font size, while the `onChange` handler calculates and saves the appropriate *base* font size for the full-resolution image. This is achieved by lifting the `fontScale` state from `FieldPositioner` up to `GeneratedImageEditor` and passing it down to `FormattingPanel`.

This ensures that the font size stored in the application's state is always the correct value for the final render (which uses a scale of 1), resolving the primary inconsistency between what the user sees in the preview and the final generated image.