### PR TITLE
Fix: Unify preview and final image rendering logic

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -324,7 +324,7 @@ const ImageGeneratorFrontendOnly = ({
         stylesToUse,
         sizeToUse,
         elementsToUse,
-        1 // Always use 100% scale for regeneration
+        imageToRegenerate.fontScale || 1 // Use the saved fontScale
       );
     }
     handleCloseGeneratedImageEditor();


### PR DESCRIPTION
This commit addresses a critical bug where the generated image did not match the live preview in the editor. The root causes were twofold: inconsistent HTML rendering and a discrepancy in how font sizes were scaled between the preview and the final output.

1.  **Unified Font Scaling:** The core of the fix is ensuring the `fontScale` calculated for the preview is also used during the final image generation. The `fontScale` is now passed from `FieldPositioner` through `GeneratedImageEditor` to `ImageGeneratorFrontendOnly`, which then correctly uses it in the call to `composeSingleImage`. This ensures that font sizes are scaled consistently, resolving the main discrepancy in text layout and wrapping.

2.  **Robust HTML Rendering:** The `renderHtmlToCanvas` utility was previously refactored to use a `display: table-cell` layout instead of `flexbox`. This provides a more stable and reliable rendering context for `html2canvas`, fixing issues where HTML text would overflow its container. This change is preserved in this final commit.

These changes work together to ensure that the final rendered image is a faithful, pixel-perfect representation of the editor preview.