### PR TITLE
feat: Migrate from deprecated UGC API to new Posts API

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -19,7 +19,8 @@ class LinkedInAPI {
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({ message: 'Proxy response was not valid JSON.' }));
-      throw new Error(`LinkedIn Proxy Error for action '${action}': ${errorData.message || response.statusText}`);
+      const errorMessage = errorData.message || errorData.error || response.statusText;
+      throw new Error(`LinkedIn Proxy Error for action '${action}': ${errorMessage}`);
     }
 
     return response.json();


### PR DESCRIPTION
This commit migrates the LinkedIn integration from the deprecated UGC (User Generated Content) API to the new, modern Posts API. This resolves the persistent 500 Internal Server Error during post creation.

The following changes have been made:

1.  **Payload Structure Migration:**
    - The `handleCreatePost` function in `api/linkedin-proxy.js` has been completely rewritten to build a payload that conforms to the new Posts API schema.
    - The new structure removes the legacy `specificContent` and `com.linkedin.ugc.ShareContent` wrappers and uses the top-level `commentary` and `content` fields.
    - The function now correctly handles text-only, single-image, and multi-image posts according to the new API documentation.

2.  **API Version Update:**
    - The `LinkedIn-Version` header has been updated to `202411`, a recent and stable version, to ensure compatibility.

3.  **Enhanced Error Handling:**
    - The proxy's retry logic in `fetchWithRetry` has been improved to handle 5xx server errors.
    - Client-side error parsing in `src/utils/linkedinAPI.js` has been made more robust to ensure error messages are always displayed.

4.  **Frontend Improvements:**
    - The `Publisher.jsx` component now includes a character counter and disables the publish button when the 3000-character limit is exceeded, improving user experience and preventing client-side errors.