### PR TITLE
fix: Migrate to Posts API and improve error reporting

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -92,7 +92,11 @@ async function handleGenericPost(fetch, request, response, url) {
         }
     } catch (error) {
         console.error(`[FATAL] Error during POST to ${url}:`, error.message, error.stack);
-        return response.status(500).json({ error: `Internal Server Error during POST to ${url}` });
+        return response.status(500).json({
+            error: `Internal Server Error during POST to ${url}`,
+            details: error.message,
+            stack: error.stack,
+        });
     }
 }
 

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -19,7 +19,14 @@ class LinkedInAPI {
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({ message: 'Proxy response was not valid JSON.' }));
-      const errorMessage = errorData.message || errorData.error || response.statusText;
+      let errorMessage = errorData.message || errorData.error || response.statusText;
+      if (errorData.details) {
+        errorMessage += ` | Details: ${errorData.details}`;
+      }
+      if (errorData.stack) {
+        // For debugging, we can log the stack to the console
+        console.error("LinkedIn Proxy Error Stack:", errorData.stack);
+      }
       throw new Error(`LinkedIn Proxy Error for action '${action}': ${errorMessage}`);
     }
 


### PR DESCRIPTION
This commit resolves a persistent 500 Internal Server Error when publishing posts to LinkedIn. The fix involves a migration from the deprecated UGC API to the new Posts API and significant improvements to error handling and reporting for better diagnostics.

The following changes have been made:

1.  **API Migration:**
    - The `handleCreatePost` function in `api/linkedin-proxy.js` has been rewritten to build a payload that conforms to the new Posts API schema, removing the legacy `com.linkedin.ugc.ShareContent` structure.

2.  **API Version Update:**
    - The `LinkedIn-Version` header is now set to `202411`, a recent and stable version.

3.  **Enhanced Error Handling & Debugging:**
    - The proxy's retry logic in `fetchWithRetry` now handles 5xx server errors.
    - The `catch` block in `handleGenericPost` has been updated to return detailed error information, including the error message and stack trace, to aid in debugging any future issues.
    - Client-side error parsing in `src/utils/linkedinAPI.js` has been made more robust to display these detailed error messages.

4.  **Frontend Improvements:**
    - A character counter was added to `Publisher.jsx` to guide users.