### PR TITLE
feat: Add image upload flow and UI feedback for LinkedIn posts

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -55,7 +55,7 @@ import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { getTimezone } from '../utils/timezone';
 import { publishToWordPress } from '../utils/wordpressAPI';
 import { dataURLtoBlob } from '../utils/imageComposer';
-import { getLinkedInProfiles, publishToLinkedIn } from '../utils/linkedinAPI';
+import { getLinkedInProfiles, publishToLinkedIn, uploadImagesForLinkedIn } from '../utils/linkedinAPI';
 import { useUserAuth } from '../context/UserAuthContext';
 import { createSchedule, getSchedulesForUser, deleteSchedule, getSchedule, updateSchedule } from '../utils/scheduleAPI';
 import { getCampaigns } from '../utils/campaignState.js';
@@ -457,23 +457,36 @@ const Publisher = ({
       toast.error('Conteúdo e alvo de publicação são obrigatórios');
       return;
     }
-    setIsPublishingLi(true);
-    setPublishingStatusLi('Publicando...');
-    try {
-      const selectedImageUrns = Object.keys(selectedImages)
-        .filter(index => selectedImages[index])
-        .map(index => generatedImagesData[parseInt(index)].id);
 
+    setIsPublishingLi(true);
+    setPublishingStatusLi('Iniciando publicação...');
+    setPublishedPostUrlLi(null);
+
+    try {
+      let imageUrns = [];
+      const selectedImageIndexes = Object.keys(selectedImages).filter(index => selectedImages[index]);
+
+      if (selectedImageIndexes.length > 0) {
+        const imageBlobsToUpload = selectedImageIndexes.map(index => unifiedMedia[parseInt(index)].blob);
+        const authorUrn = `urn:li:${selectedTarget.type === 'organization' ? 'organization' : 'person'}:${selectedTarget.id}`;
+
+        imageUrns = await uploadImagesForLinkedIn(settings?.linkedin, imageBlobsToUpload, authorUrn, setPublishingStatusLi);
+      }
+
+      setPublishingStatusLi('Criando a publicação...');
       const campaignData = {
         content: content.trim(),
         targetId: selectedTarget.id,
         targetType: selectedTarget.type,
-        images: selectedImageUrns,
+        images: imageUrns,
       };
+
       const result = await publishToLinkedIn(campaignData, settings?.linkedin);
-      const postLink = `https://www.linkedin.com/feed/update/${result.id}/`;
+      const postLink = result.id ? `https://www.linkedin.com/feed/update/${result.id}/` : null;
+
       setPublishingStatusLi('Publicado com sucesso!');
-      setPublishedPostUrlLi(postLink);
+      if(postLink) setPublishedPostUrlLi(postLink);
+
       setPublishResults(prev => [{
         id: Date.now(),
         target: selectedTarget.name,
@@ -482,6 +495,7 @@ const Publisher = ({
         timestamp: new Date().toLocaleString('pt-BR'),
         link: postLink
       }, ...prev]);
+
     } catch (error) {
       console.error('Erro na publicação:', error);
       const errorMessage = error.message || 'Ocorreu um erro desconhecido.';

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -61,6 +61,40 @@ class LinkedInAPI {
       }
     });
   }
+
+  async registerUpload(authorUrn) {
+    return this._proxyFetch('registerUpload', {
+      payload: {
+        "registerUploadRequest": {
+          "recipes": [
+              "urn:li:digitalmediaRecipe:feedshare-image"
+          ],
+          "owner": authorUrn,
+          "serviceRelationships": [
+              {
+                  "relationshipType": "OWNER",
+                  "identifier": "urn:li:userGeneratedContent"
+              }
+          ]
+        }
+      }
+    });
+  }
+
+  async uploadImage(uploadUrl, imageBlob) {
+    const imageBase64 = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result.split(',')[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(imageBlob);
+    });
+
+    return this._proxyFetch('uploadImage', {
+      uploadUrl,
+      imageBase64,
+      imageType: imageBlob.type,
+    });
+  }
 }
 
 // Wrapper function to handle caching, as requested.
@@ -124,5 +158,34 @@ export const publishToLinkedIn = async (campaignData, linkedinConfig) => {
 // The new proxy is expected to handle this complexity if needed.
 // If media uploads are still a feature, the proxy and this client will need to be updated.
 // For now, focusing on the core task: fixing profile listing and text publishing.
+
+export const uploadImagesForLinkedIn = async (linkedinConfig, imageBlobs, authorUrn, setStatus) => {
+  if (!linkedinConfig || !linkedinConfig.accessToken) {
+    throw new Error('LinkedIn configuration or Access Token not found.');
+  }
+  if (!imageBlobs || imageBlobs.length === 0) {
+    return []; // No images to upload
+  }
+
+  const api = new LinkedInAPI(linkedinConfig.accessToken);
+  const assetUrns = [];
+
+  for (let i = 0; i < imageBlobs.length; i++) {
+    const blob = imageBlobs[i];
+    setStatus(`Registering image ${i + 1} of ${imageBlobs.length}...`);
+
+    const registerResponse = await api.registerUpload(authorUrn);
+    const uploadUrl = registerResponse.value.uploadMechanism['com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest'].uploadUrl;
+    const assetUrn = registerResponse.value.asset;
+
+    setStatus(`Uploading image ${i + 1} of ${imageBlobs.length}...`);
+    await api.uploadImage(uploadUrl, blob);
+
+    assetUrns.push(assetUrn);
+  }
+
+  setStatus('Image uploads complete.');
+  return assetUrns;
+};
 
 export default LinkedInAPI;


### PR DESCRIPTION
This commit implements the full client-side workflow for posting images to LinkedIn and enhances the UI to provide users with granular feedback during the process. This addresses the user's concern that the application could appear to be stuck in a "publishing" state.

The key changes are:

1.  **Client-Side Upload Logic:**
    - New functions have been added to `src/utils/linkedinAPI.js` to handle the multi-step image upload process required by the LinkedIn API (registering the upload, sending the binary data).
    - An orchestrator function, `uploadImagesForLinkedIn`, now manages this flow and provides status updates via a callback.

2.  **UI Integration:**
    - The `handlePublishLinkedIn` function in `src/components/Publisher.jsx` has been rewritten to use the new upload logic.
    - If images are selected, it now uploads them first and then creates the post with the returned image URNs.
    - The `publishingStatusLi` state is updated at each step of the process (e.g., "Registering image 1 of 2...", "Uploading image 1 of 2...", "Creating the publication..."), providing clear feedback to the user.

3.  **Consolidated Fixes:**
    - This commit builds on all the previous work to migrate to the new Posts API, correct the API version, and improve error handling.