### PR TITLE
feat: Handle video content in LinkedIn post creation

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -180,7 +180,7 @@ async function handleCreatePost(fetch, request, response) {
 
         console.log('[DEBUG] Entering handleCreatePost with received payload:', JSON.stringify(payload, null, 2));
 
-        const { targetId, targetType, content, images } = payload;
+        const { targetId, targetType, content, images, video } = payload;
         if (!targetId || !targetType || !content) {
             console.error('[DEBUG] Validation failed in handleCreatePost:', { targetId, targetType, contentExists: !!content });
             return response.status(400).json({ error: 'Missing targetId, targetType, or content for creating post.' });
@@ -202,20 +202,25 @@ async function handleCreatePost(fetch, request, response) {
             isReshareDisabledByAuthor: false
         };
 
-        // Handle images according to the new API structure
-        if (images && images.length > 0) {
+        if (video) {
+            postData.content = {
+                media: {
+                    id: video
+                }
+            };
+        } else if (images && images.length > 0) {
             if (images.length === 1) {
                 // Single image post
                 postData.content = {
                     media: {
-                        id: images[0] // Assuming images is an array of URNs
+                        id: images[0]
                     }
                 };
             } else {
                 // Multi-image post
                 postData.content = {
                     multiImage: {
-                        images: images.map(urn => ({ id: urn })) // Map string URNs to objects with an 'id' key
+                        images: images.map(urn => ({ id: urn }))
                     }
                 };
             }


### PR DESCRIPTION
The `handleCreatePost` function in the LinkedIn proxy was not correctly handling video posts. It only accounted for text and image content.

This change updates the function to check for a `video` property in the payload from the frontend. If a video URN is present, it constructs the post payload with the correct content structure for a video post, ensuring that videos can be successfully published to LinkedIn.

This resolves the issue where video uploads were failing despite the upload actions being correctly defined.