### PR TITLE
fix: Add required title to video posts for LinkedIn

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -180,7 +180,7 @@ async function handleCreatePost(fetch, request, response) {
 
         console.log('[DEBUG] Entering handleCreatePost with received payload:', JSON.stringify(payload, null, 2));
 
-        const { targetId, targetType, content, images, video } = payload;
+        const { targetId, targetType, content, images, video, title } = payload;
         if (!targetId || !targetType || !content) {
             console.error('[DEBUG] Validation failed in handleCreatePost:', { targetId, targetType, contentExists: !!content });
             return response.status(400).json({ error: 'Missing targetId, targetType, or content for creating post.' });
@@ -205,7 +205,8 @@ async function handleCreatePost(fetch, request, response) {
         if (video) {
             postData.content = {
                 media: {
-                    id: video
+                    id: video,
+                    title: title || 'Video Post'
                 }
             };
         } else if (images && images.length > 0) {

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -242,10 +242,14 @@ async function handleRunScheduler(request, response) {
                     }
                 }
 
+                const videoUrn = post.post_content?.video;
+
                 const payload = {
                     author: authorUrn,
                     content: postText,
-                    images: imageUrns
+                    images: imageUrns,
+                    video: videoUrn,
+                    title: post.post_content?.titulo || 'Video Post'
                 };
 
                 const proxyUrl = `${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`;


### PR DESCRIPTION
This commit fixes an issue where video posts were being published to LinkedIn without the actual video. The root cause was a missing `title` field in the `media` object of the post payload, which is required by the LinkedIn API for video content.

The following changes have been made:
- In `api/linkedin-proxy.js`, the `handleCreatePost` function has been updated to include the `title` in the payload for video posts. It will use a title from the request payload or a default value.
- In `api/schedule.js`, the `handleRunScheduler` function has been updated to pass the post's title to the proxy when creating a scheduled video post.

These changes ensure that the payload for video posts is correctly formatted, resolving the issue for both direct and scheduled publications.