### PR TITLE
Fix: Ensure generated image matches preview

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -66,7 +66,6 @@ const FormattingPanel = ({
   onDeselectField,
   onOpenHtmlEditor,
   standardsColors,
-  fontScale = 1,
 }) => {
   const fonts = [
     // Sans-serif
@@ -363,17 +362,15 @@ const FormattingPanel = ({
                       </Grid>
                       <Grid item xs={12}>
                         <Typography gutterBottom sx={{ mt: 1 }}>
-                          Tamanho: {Math.round((currentElement.style.fontSize || 24) * fontScale)}px
+                          Tamanho: {currentElement.style.fontSize || 24}px
                         </Typography>
                         <Slider
-                          value={Math.round((currentElement.style.fontSize || 24) * fontScale)}
-                          onChange={(e, value) => {
-                            const baseFontSize = Math.round(value / fontScale);
-                            updateFieldStyle(selectedField, 'fontSize', baseFontSize);
-                          }}
-                          min={Math.round(8 * fontScale)}
-                          max={Math.round(120 * fontScale)}
+                          value={currentElement.style.fontSize || 24}
+                          onChange={(e, value) => updateFieldStyle(selectedField, 'fontSize', value)}
+                          min={8}
+                          max={120}
                           valueLabelDisplay="auto"
+                          marks={[{ value: 12, label: '12' }, { value: 24, label: '24' }, { value: 48, label: '48' }, { value: 72, label: '72' }]}
                         />
                       </Grid>
                       <Grid item xs={12}>

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -187,7 +187,7 @@ const ImageGeneratorFrontendOnly = ({
         brandElements,
         fieldPositions,
         fieldStyles,
-        fontScale: 1, // Always use 100% scale for generation
+        fontScale,
       })
       .then(imageData => {
         setProgress(p => p + 1);
@@ -324,7 +324,7 @@ const ImageGeneratorFrontendOnly = ({
         stylesToUse,
         sizeToUse,
         elementsToUse,
-        1 // Always use 100% scale for regeneration
+        modifiedImageData.fontScale || 1
       );
     }
     handleCloseGeneratedImageEditor();
@@ -388,11 +388,11 @@ const ImageGeneratorFrontendOnly = ({
           const img = new Image();
           img.onload = () => {
             const newSize = { width: img.width, height: img.height };
-            regenerateSingleImage(replacingImageIndex, imageToUpdate.record, newBgUrl, imageToUpdate.customFieldPositions || fieldPositions, imageToUpdate.customFieldStyles || fieldStyles, newSize, imageToUpdate.customBrandElements || brandElements, imageToUpdate.fontScale || 1);
+            regenerateSingleImage(replacingImageIndex, imageToUpdate.record, newBgUrl, imageToUpdate.customFieldPositions || fieldPositions, imageToUpdate.customFieldStyles || fieldStyles, newSize, imageToUpdate.customBrandElements || brandElements, fontScale);
           };
           img.onerror = () => {
             console.error('Failed to load the new background image to get its dimensions.');
-            regenerateSingleImage(replacingImageIndex, imageToUpdate.record, newBgUrl, imageToUpdate.customFieldPositions || fieldPositions, imageToUpdate.customFieldStyles || fieldStyles, null, imageToUpdate.customBrandElements || brandElements, imageToUpdate.fontScale || 1);
+            regenerateSingleImage(replacingImageIndex, imageToUpdate.record, newBgUrl, imageToUpdate.customFieldPositions || fieldPositions, imageToUpdate.customFieldStyles || fieldStyles, null, imageToUpdate.customBrandElements || brandElements, fontScale);
           };
           img.src = newBgUrl;
         }


### PR DESCRIPTION
This commit fixes a bug where the generated image's font size, wrapping, and alignment did not match the user's preview.

The root cause was that the `fontScale` calculated from the preview's dimensions was not being passed to the final image composition function (`composeSingleImage`). Instead, a hardcoded `fontScale: 1` was being used. This caused the text in the generated image to be rendered at a different effective size than in the preview.

The fix involves:
1.  In `ImageGeneratorFrontendOnly.jsx`, ensuring the `fontScale` prop (which comes from the preview component) is passed correctly to `composeSingleImage` during batch generation and single-image regeneration.
2.  Reverting a previous, incorrect workaround in `FormattingPanel.jsx`. The UI's font size slider now correctly displays and saves the raw font size, as the scaling is now properly handled in the composition function.

Additionally, the `htmlRenderer.js` has been updated to use a more robust `display: table` / `display: table-cell` structure to ensure vertical alignment is applied correctly to HTML-enabled text fields.