### PR TITLE
fix(api): Correct import path in publications endpoint

### DIFF
--- a/api/campaigns/[id]/publications.js
+++ b/api/campaigns/[id]/publications.js
@@ -1,5 +1,5 @@
-import { withAuth } from '../../../middleware/auth';
-import { query } from '../../../db';
+import { withAuth } from '../../middleware/auth.js';
+import { query } from '../../db.js';
 
 async function handler(req, res) {
   const { id: campaignId } = req.query;


### PR DESCRIPTION
This commit fixes a 'Cannot find module' error in the `api/campaigns/[id]/publications.js` endpoint.

The import paths for the `withAuth` middleware and the `db` query function were incorrect for the Vercel serverless environment, causing the endpoint to crash.

The paths have been corrected from `../../../` to `../../` to ensure the modules are resolved correctly when deployed.