### PR TITLE
Debug: Add extensive logging for style data flow

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -179,7 +179,7 @@ const ImageGeneratorFrontendOnly = ({
       const initialImageDataItem = initialGeneratedImagesData.find(img => img.index === i);
       const itemBackgroundImage = initialImageDataItem?.backgroundImage || backgroundImage;
 
-      return composeSingleImage({
+      const compositionParams = {
         record,
         index: i,
         itemBackgroundImage,
@@ -188,7 +188,14 @@ const ImageGeneratorFrontendOnly = ({
         fieldPositions,
         fieldStyles,
         fontScale,
-      })
+      };
+
+      console.log(`[IGFO] About to generate image #${i}. Params:`, {
+        styles: JSON.parse(JSON.stringify(fieldStyles)),
+        scale: fontScale
+      });
+
+      return composeSingleImage(compositionParams)
       .then(imageData => {
         setProgress(p => p + 1);
         return imageData;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -138,6 +138,10 @@ function HomePage() {
   const [uploadProgress, setUploadProgress] = useState({ current: 0, total: 0 });
   const [fontScale, setFontScale] = useState(1);
 
+  useEffect(() => {
+    console.log(`[HomePage] fontScale updated to: ${fontScale}`);
+  }, [fontScale]);
+
   const fileInputRef = useRef(null);
   const imageInputRef = useRef(null);
 

--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -21,6 +21,7 @@ export const containsHtml = (text) => {
  * @param {Object} style The CSS styles to apply.
  */
 export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHeight, style) => {
+  console.log(`[renderHtmlToCanvas] Rendering with style:`, JSON.parse(JSON.stringify(style)));
   // Create an off-screen parent container that will act as a table.
   const tableContainer = document.createElement('div');
   tableContainer.style.position = 'absolute';

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -190,6 +190,10 @@ export const composeSingleImage = async ({
     fieldStyles,
     fontScale = 1
 }) => {
+    console.log(`[composeSingleImage] Received params:`, {
+        fieldStyles: JSON.parse(JSON.stringify(fieldStyles)),
+        fontScale,
+    });
     if (!itemBackgroundImage) {
         throw new Error(`Background image is missing for record index ${index}.`);
     }


### PR DESCRIPTION
This commit adds extensive `console.log` statements to trace the flow of `fontScale` and `fieldStyles` data throughout the application. This is intended to diagnose a persistent bug where the final generated image does not match the preview.

Logging has been added to the following locations:
- `HomePage.jsx`: When the `fontScale` state is updated.
- `ImageGeneratorFrontendOnly.jsx`: Immediately before calling `composeSingleImage`, logging the parameters.
- `imageComposer.js`: At the start of `composeSingleImage`, logging the received parameters.
- `htmlRenderer.js`: At the start of `renderHtmlToCanvas`, logging the final `style` object used for rendering.