### PR TITLE
fix(api): Use correct table name for publications

### DIFF
--- a/api/campaigns/[id]/publications.js
+++ b/api/campaigns/[id]/publications.js
@@ -11,7 +11,7 @@ async function handler(req, res) {
   try {
     const { rows } = await query(
       `SELECT id, campaign_id, scheduled_at, status, linkedin_post_url, post_content
-       FROM schedules
+       FROM linkedin_schedules
        WHERE campaign_id = $1 AND status = 'published' AND linkedin_post_url IS NOT NULL
        ORDER BY scheduled_at DESC`,
       [campaignId]


### PR DESCRIPTION
This commit fixes a critical bug where the publications API endpoint was querying the wrong table name.

The code was looking for a table named `schedules`, but the database schema defines it as `linkedin_schedules`. This caused a 'relation does not exist' error in the database and a 500 Internal Server Error on the frontend.

The SQL query in `api/campaigns/[id]/publications.js` has been updated to use the correct `linkedin_schedules` table name.