### PR TITLE
fix(api): Extract post ID from response header

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -74,6 +74,12 @@ async function handleGenericPost(fetch, request, response, url) {
         });
 
         if (linkedinResponse.ok) {
+            // For post creation, the ID is in the x-restli-id header.
+            const postId = linkedinResponse.headers.get('x-restli-id');
+            if (postId) {
+                return response.status(linkedinResponse.status).json({ id: postId });
+            }
+
             const responseText = await linkedinResponse.text();
             if (!responseText) {
                 console.warn('[WARN] LinkedIn API returned 200 OK with an empty response body.');


### PR DESCRIPTION
This commit fixes a critical bug where the application failed to save a record of a published post because it was not correctly retrieving the new Post ID from the LinkedIn API response.

The LinkedIn API returns the new Post URN in the `x-restli-id` response header, not in the JSON body. The `handleGenericPost` function in `api/linkedin-proxy.js` has been updated to check for this header and extract the ID from it.

This ensures that the frontend receives the correct Post ID, which in turn allows it to save a record of the publication to the `linkedin_schedules` table for monitoring.