### PR TITLE
fix(image-composer): Use content-based check for HTML rendering

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -265,7 +265,7 @@ export const composeSingleImage = async ({
             currentLineRenderY += effectiveTextHeight - totalTextBlockHeight;
         }
 
-        if (isHtmlField(field)) {
+        if (containsHtml(text)) {
             // For HTML fields, we delegate the entire rendering, including wrapping, to the HTML renderer.
             await renderHtmlToCanvas(ctx, text, textContentStartX, textContentStartY, effectiveTextWidth, effectiveTextHeight, finalStyle);
         } else {


### PR DESCRIPTION
The image generation logic was previously using `isHtmlField` to decide whether to use the HTML renderer (`html2canvas`) or the plain text renderer. This function checked the field's name against a hardcoded list, which failed to correctly render fields that were not on the list but contained HTML content inserted by the user.

This change replaces the `isHtmlField(field)` check with `containsHtml(text)`. This ensures that the rendering path is chosen based on the actual content of the field, guaranteeing that any text containing HTML tags is processed by the HTML renderer. This resolves the visual discrepancy between the editor preview and the final generated image thumbnail.