### PR TITLE
fix(renderer): Ensure visual consistency in image generation

### DIFF
--- a/src/utils/htmlRenderer.js
+++ b/src/utils/htmlRenderer.js
@@ -54,6 +54,7 @@ export const renderHtmlToCanvas = async (ctx, htmlContent, x, y, maxWidth, maxHe
     line-height: ${style.lineHeightMultiplier ? style.lineHeightMultiplier : 'normal'};
     overflow-wrap: break-word;
     word-wrap: break-word;
+    overflow: hidden;
     ${style.textShadow ? `text-shadow: ${style.shadowOffsetX || 2}px ${style.shadowOffsetY || 2}px ${style.shadowBlur || 4}px ${style.shadowColor || '#000000'};` : ''}
     ${style.textStroke ? `-webkit-text-stroke: ${style.strokeWidth || 2}px ${style.strokeColor || '#ffffff'};` : ''}
   `.replace(/\s*\n\s*/g, ' '); // Remove newlines and extra spaces.


### PR DESCRIPTION
This commit addresses two visual discrepancies between the live editor preview and the final rendered image:

1.  The rendering logic in `imageComposer.js` now checks for the presence of HTML tags in the field's content (`containsHtml(text)`) instead of relying on the field's name (`isHtmlField(field)`). This ensures that any field containing HTML is correctly rendered using the HTML-to-canvas renderer.

2.  The `htmlRenderer.js` now includes an `overflow: hidden;` style to the container div used by `html2canvas`. This prevents text from overflowing its bounding box in the final image, matching the clipping behavior seen in the live preview.

Together, these changes ensure that the generated image thumbnails are visually consistent with what the user sees in the editor.