### PR TITLE
fix(renderer): Ensure full visual consistency in image generation

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -151,6 +151,7 @@ const GeneratedImageEditor = ({
       setStylesAreInitialized(true);
 
       setEditedImageFilters(imageFilters || defaultFilters);
+      setFontScale(imageData.fontScale || 1); // Initialize font scale from imageData
     } else {
       setStylesAreInitialized(false);
     }

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -303,6 +303,7 @@ export const composeSingleImage = async ({
         index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
         backgroundImage: itemBackgroundImage, // Always preserve the original background
+        fontScale, // Preserve the font scale used for generation
         // customFieldPositions and customFieldStyles are not handled here as this is for initial generation
     };
 };


### PR DESCRIPTION
This commit addresses a series of visual discrepancies between the live editor preview and the final rendered image.

1.  **HTML Content Rendering:** The logic for deciding when to use the HTML renderer (`html2canvas`) is changed from checking the field's name (`isHtmlField`) to checking if the field's content actually contains HTML tags (`containsHtml`). This ensures all rich text is rendered with high fidelity.

2.  **Text Overflow Behavior:** The `overflow: hidden;` CSS property is added to the style of the container rendered by `html2canvas`. This fixes a bug where text would overflow its bounding box in the generated image. Now, the text is clipped, matching the behavior of the fixed-size container in the live preview.

3.  **Font Scale Preservation:** The `fontScale` setting is now correctly preserved through the edit-save-regenerate cycle. The `composeSingleImage` function now includes the `fontScale` in its returned object, and the `GeneratedImageEditor` correctly initializes its state with this value when opened. This prevents fonts from shrinking to their default size after an image is edited.

These changes work together to ensure that the generated image thumbnails are a faithful representation of the user's configuration in the editor.