### PR TITLE
fix(linkedin): Add support for carousel URNs in post monitoring

### DIFF
--- a/api/campaigns/[id]/publications.js
+++ b/api/campaigns/[id]/publications.js
@@ -23,8 +23,8 @@ async function handler(req, res) {
 
     // The URN is the last part of the post URL.
     const publications = rows.map(row => {
-        // Use a regex to robustly find the URN, which can be either a share or ugcPost.
-        const match = row.linkedin_post_url.match(/(urn:li:(?:share|ugcPost):\d+)/);
+        // Use a regex to robustly find the URN, which can be a share, ugcPost, or carousel for multi-image posts.
+        const match = row.linkedin_post_url.match(/(urn:li:(?:share|ugcPost|carousel):\d+)/);
         const urn = match ? match[0] : null;
         return {
             ...row,


### PR DESCRIPTION
Multi-image posts on LinkedIn are often created as 'carousel' posts, which result in a `urn:li:carousel:...` URN.

The previous regular expression for extracting URNs from post URLs only supported `share` and `ugcPost` types. This caused multi-image posts to be ignored by the monitoring page, disabling the 'Update Statistics' button because no valid publications were found for the campaign.

This change updates the regex in `api/campaigns/[id]/publications.js` to include `carousel` as a valid URN type, allowing the application to correctly identify and monitor these posts.