### PR TITLE
fix(monitor): Make publication link icon always visible

### DIFF
--- a/src/components/Monitor.jsx
+++ b/src/components/Monitor.jsx
@@ -185,20 +185,26 @@ const Monitor = ({ currentCampaign }) => {
                             }
                             variant="outlined"
                         />
-                        {pub.linkedin_post_url && (
-                            <Tooltip title="Ver no LinkedIn">
-                                <IconButton
-                                    component="a"
-                                    href={pub.linkedin_post_url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    size="small"
-                                    onClick={(e) => e.stopPropagation()} // Prevent ListItem click event
-                                >
-                                    <LinkIcon fontSize="inherit" />
-                                </IconButton>
-                            </Tooltip>
-                        )}
+                        <Tooltip title={pub.linkedin_post_url ? "Ver no LinkedIn" : "Link indisponível"}>
+                          <span>
+                            <IconButton
+                                component="a"
+                                href={pub.linkedin_post_url || undefined}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                size="small"
+                                disabled={!pub.linkedin_post_url}
+                                onClick={(e) => {
+                                    if (!pub.linkedin_post_url) {
+                                        e.preventDefault();
+                                    }
+                                    e.stopPropagation();
+                                }}
+                            >
+                                <LinkIcon fontSize="inherit" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
                       </Box>
                     </ListItem>
                   ))}


### PR DESCRIPTION
This change modifies the link icon in the publications list on the Monitor page to be always visible, even if the post URL is missing.

If the `linkedin_post_url` is not available, the icon button will be disabled. This provides better UI feedback and helps diagnose issues where the URL might not be correctly passed to the frontend.