### PR TITLE
feat: Improve editor UI and fix runtime error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@mui/x-date-pickers": "^8.10.0",
         "@react-oauth/google": "^0.12.2",
         "@tiptap/extension-bubble-menu": "^3.3.0",
+        "@tiptap/extension-character-count": "^3.3.0",
         "@tiptap/react": "^3.3.0",
         "@tiptap/starter-kit": "^3.3.0",
         "@uppy/core": "^4.4.7",
@@ -2732,6 +2733,19 @@
       },
       "peerDependencies": {
         "@tiptap/extension-list": "^3.3.0"
+      }
+    },
+    "node_modules/@tiptap/extension-character-count": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-character-count/-/extension-character-count-3.3.0.tgz",
+      "integrity": "sha512-TyuVKWFV+A8nsiyWRNwbdeZ9iGrFPp1tnJ0yvoVeNYbu3mpUmfAeOhm1q4UVow9L1SQIeas4jZDb8ipuN6l/7w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.3.0"
       }
     },
     "node_modules/@tiptap/extension-code": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mui/x-date-pickers": "^8.10.0",
     "@react-oauth/google": "^0.12.2",
     "@tiptap/extension-bubble-menu": "^3.3.0",
+    "@tiptap/extension-character-count": "^3.3.0",
     "@tiptap/react": "^3.3.0",
     "@tiptap/starter-kit": "^3.3.0",
     "@uppy/core": "^4.4.7",

--- a/src/components/InlineEditor.jsx
+++ b/src/components/InlineEditor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useEditor, EditorContent } from '@tiptap/react';
-import BubbleMenu from '@tiptap/extension-bubble-menu';
+import { useEditor, EditorContent, BubbleMenu } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
+import CharacterCount from '@tiptap/extension-character-count';
 import {
   FormatBold,
   FormatItalic,
@@ -10,11 +10,14 @@ import {
   FormatListNumbered,
   FormatQuote,
 } from '@mui/icons-material';
-import { Box, IconButton, Paper, Tooltip, Divider } from '@mui/material';
+import { Box, IconButton, Paper, Tooltip, Divider, Typography } from '@mui/material';
 
 const InlineEditor = ({ value, onChange, html = false }) => {
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [
+      StarterKit,
+      CharacterCount,
+    ],
     content: value,
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML());
@@ -26,14 +29,15 @@ const InlineEditor = ({ value, onChange, html = false }) => {
   }
 
   return (
-    <Box sx={{ position: 'relative' }}>
+    <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100%' }}>
       <EditorContent
         editor={editor}
         style={{
           border: '1px solid #ccc',
           borderRadius: '4px',
           padding: '10px',
-          minHeight: '200px',
+          flexGrow: 1,
+          overflowY: 'auto',
           outline: 'none',
         }}
       />
@@ -108,6 +112,18 @@ const InlineEditor = ({ value, onChange, html = false }) => {
           )}
         </Paper>
       </BubbleMenu>
+      <Box sx={{
+        position: 'absolute',
+        bottom: 8,
+        right: 8,
+        backgroundColor: 'rgba(255, 255, 255, 0.8)',
+        padding: '2px 8px',
+        borderRadius: '4px',
+      }}>
+        <Typography variant="caption" color="textSecondary">
+          {editor.storage.characterCount.characters()} caracteres
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/src/components/TextEditorDialog.jsx
+++ b/src/components/TextEditorDialog.jsx
@@ -23,12 +23,11 @@ const TextEditorDialog = ({ open, title, content, onSave, onClose, html = false 
       }
     }}>
       <DialogTitle>{title}</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 1 }}>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column', p: 2, height: '100%' }}>
         <TextEditor
           value={editedContent}
           onChange={setEditedContent}
           html={html}
-          maxHeight="100%" // Allow editor to fill the space
         />
       </DialogContent>
       <DialogActions sx={{ pb: 2, px: 3 }}>


### PR DESCRIPTION
This commit addresses user feedback following the editor replacement. It fixes a critical runtime error and implements several UI/UX improvements.

- **Fix**: Corrected the import for the `BubbleMenu` component. It was being imported from the base extension package instead of the React-specific package, causing a runtime error when rendering the editor for HTML fields.
- **Feature**: Added a character counter to the rich text editor. The count is displayed at the bottom-right of the editor, as requested. This uses the `@tiptap/extension-character-count` package.
- **UI**: Adjusted the editor and dialog styles to make better use of available screen space. The editor now expands to fill the dialog, providing a larger, more comfortable writing area.