### PR TITLE
fix(renderer): Prevent font scale regression on image regeneration

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -187,7 +187,7 @@ const ImageGeneratorFrontendOnly = ({
         brandElements,
         fieldPositions,
         fieldStyles,
-        fontScale,
+        fontScale: 1, // Final render should always be at 100% scale.
       })
       .then(imageData => {
         setProgress(p => p + 1);
@@ -323,14 +323,13 @@ const ImageGeneratorFrontendOnly = ({
         positionsToUse,
         stylesToUse,
         sizeToUse,
-        elementsToUse,
-        modifiedImageData.fontScale || 1
+        elementsToUse
       );
     }
     handleCloseGeneratedImageEditor();
   };
 
-  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
+  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       alert('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       return;
@@ -344,7 +343,7 @@ const ImageGeneratorFrontendOnly = ({
         brandElements: elementsToUse,
         fieldPositions: positionsToUse,
         fieldStyles: stylesToUse,
-        fontScale,
+        fontScale: 1, // Final render should always be at 100% scale.
       });
 
       setGeneratedImages(prevImages => {


### PR DESCRIPTION
This commit fixes a bug where the font size of a text element would shrink after being edited in the preview.

The root cause was that a dynamic `fontScale` value, calculated for rendering the preview accurately on different screen sizes, was being incorrectly passed to the final image generation function. The final render should always use a scale of 100% (or 1.0) as it operates on the original, full-resolution canvas.

The fix modifies `ImageGeneratorFrontendOnly.jsx` to ensure that all calls to the `composeSingleImage` function (for both batch generation and post-edit regeneration) use a hardcoded `fontScale` of 1. This isolates the preview's dynamic scaling factor from the final rendering logic, ensuring font sizes are consistent and correct.