### PR TITLE
fix(styles): Ensure new fields get default transparent background

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -617,7 +617,7 @@ function HomePage() {
     };
     novasColunas.forEach((header, index) => {
       updatedFieldPositions[header] = fieldPositions[header] || { x: 10 + (index % 5) * 18, y: 10 + Math.floor(index / 5) * 12, width: 15, height: 10, visible: true };
-      updatedFieldStyles[header] = fieldStyles[header] || { ...defaultStylesBase };
+      updatedFieldStyles[header] = { ...defaultStylesBase, ...(fieldStyles[header] || {}) };
     });
     setFieldPositions(updatedFieldPositions);
     setFieldStyles(updatedFieldStyles);


### PR DESCRIPTION
This commit fixes a bug where new text fields were being created with an opaque black background instead of a transparent one.

The root cause was in the `handleDadosAlterados` function in `HomePage.jsx`. The logic for creating new field styles was not correctly merging a complete set of default styles if an empty style object (`{}`) already existed for a field. This meant new fields were missing the default `backgroundColor` and `backgroundOpacity` properties, causing the rendering engine to fall back to a black fill.

The logic has been changed to always merge the `defaultStylesBase` object with any existing or new style object, ensuring all fields are initialized with a complete and correct set of default styles, including a transparent background.