### PR TITLE
fix: Prevent tab from resetting after editor save

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -205,13 +205,19 @@ const Campaign = ({
         },
     };
 
+    const prevCampaignContentRef = useRef();
     useEffect(() => {
-        // Quando o conteúdo da campanha é gerado com sucesso e o processo de geração termina,
-        // muda para a segunda aba.
-        if (campaignContent && !isGeneratingCampaign) {
+        prevCampaignContentRef.current = campaignContent;
+    });
+    const prevCampaignContent = prevCampaignContentRef.current;
+
+    useEffect(() => {
+        // Only switch to tab 1 if campaignContent just became available (was null or undefined before)
+        // and the campaign is not currently being generated.
+        if (campaignContent && !prevCampaignContent && !isGeneratingCampaign) {
             setActiveTab(1);
         }
-    }, [campaignContent, isGeneratingCampaign]);
+    }, [campaignContent, prevCampaignContent, isGeneratingCampaign]);
 
     const handleTabChange = (event, newValue) => {
       setActiveTab(newValue);


### PR DESCRIPTION
This commit fixes a bug where the active tab in the campaign editor would reset to the 'Conteúdo Principal' tab after saving an edit in any other tab (e.g., 'Conteúdo WordPress').

The issue was caused by a `useEffect` hook that was designed to switch to the second tab after initial campaign generation, but was unintentionally being triggered on every subsequent edit to the `campaignContent` state.

The fix involves using a `useRef` hook to track the previous value of `campaignContent`. The `useEffect` is now conditioned to only run if `campaignContent` transitions from a falsy value to a truthy value, ensuring it only runs once after the initial generation.