### PR TITLE
fix(renderer): Ensure brand elements have transparent background

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -560,10 +560,16 @@ const DraggableElementInternal = ({
           height: `${position.height}%`,
           transform: `rotate(${rotation || 0}deg)`,
           zIndex: position.zIndex || 'auto',
-          backgroundColor: hexToRgba(style.backgroundColor || '#000000', style.backgroundOpacity !== undefined ? style.backgroundOpacity : 1),
-          border: `${style.borderWidth || 0}px solid ${style.borderColor || '#000000'}`,
+          // Conditional styling based on element type
+          backgroundColor: element.type === 'image'
+            ? 'transparent'
+            : hexToRgba(style.backgroundColor || '#000000', style.backgroundOpacity !== undefined ? style.backgroundOpacity : 1),
+          border: element.type === 'image'
+            ? 'none'
+            : `${style.borderWidth || 0}px solid ${style.borderColor || '#000000'}`,
           borderRadius: `${style.borderRadius || 0}px`,
-          padding: `${style.padding || 0}px`,
+          // Padding should only apply to text boxes, not image containers
+          padding: element.type === 'image' ? 0 : `${style.padding || 0}px`,
         }}
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
         onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}


### PR DESCRIPTION
This commit fixes a bug where new brand elements (images) added to the preview were being rendered with an opaque black background.

The root cause was that the main container for all draggable elements had a default black background for text boxes, which was also being applied to image-type elements.

The fix adds conditional styling to the main `Box` container in `DraggableElement.jsx`. It now checks if the element's type is 'image'. If it is, it forces a transparent background and removes any border or padding. This ensures brand elements are rendered correctly without an unwanted background.