### PR TITLE
fix: Repair CSV record editor and introduce editor variants

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CoMTTI5h.js"></script>
+  <script type="module" crossorigin src="/assets/index-CmWnkRyo.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CCOKjgaX.css">
 </head>
 

--- a/src/components/InlineEditor.jsx
+++ b/src/components/InlineEditor.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useEditor, EditorContent } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
+import StarterKit from '@tiptap/starter-kit';
+import CharacterCount from '@tiptap/extension-character-count';
+import {
+  FormatBold,
+  FormatItalic,
+  StrikethroughS,
+  FormatListBulleted,
+  FormatListNumbered,
+  FormatQuote,
+} from '@mui/icons-material';
+import { Box, IconButton, Paper, Tooltip, Divider, Typography } from '@mui/material';
+
+const InlineEditor = ({ value, onChange, html = false }) => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      CharacterCount,
+    ],
+    content: value,
+    onUpdate: ({ editor }) => {
+      onChange(editor.getHTML());
+    },
+  });
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ position: 'relative', display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <EditorContent
+        editor={editor}
+        style={{
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          padding: '10px',
+          flexGrow: 1,
+          overflowY: 'auto',
+          outline: 'none',
+        }}
+      />
+      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
+        <Paper
+          elevation={3}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            p: 0.5,
+            borderRadius: 1,
+          }}
+        >
+          <Tooltip title="Bold">
+            <IconButton
+              onClick={() => editor.chain().focus().toggleBold().run()}
+              color={editor.isActive('bold') ? 'primary' : 'default'}
+              size="small"
+            >
+              <FormatBold />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Italic">
+            <IconButton
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+              color={editor.isActive('italic') ? 'primary' : 'default'}
+              size="small"
+            >
+              <FormatItalic />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Strike">
+            <IconButton
+              onClick={() => editor.chain().focus().toggleStrike().run()}
+              color={editor.isActive('strike') ? 'primary' : 'default'}
+              size="small"
+            >
+              <StrikethroughS />
+            </IconButton>
+          </Tooltip>
+          {html && (
+            <>
+              <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+              <Tooltip title="Bullet List">
+                <IconButton
+                  onClick={() => editor.chain().focus().toggleBulletList().run()}
+                  color={editor.isActive('bulletList') ? 'primary' : 'default'}
+                  size="small"
+                >
+                  <FormatListBulleted />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Numbered List">
+                <IconButton
+                  onClick={() => editor.chain().focus().toggleOrderedList().run()}
+                  color={editor.isActive('orderedList') ? 'primary' : 'default'}
+                  size="small"
+                >
+                  <FormatListNumbered />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Blockquote">
+                <IconButton
+                  onClick={() => editor.chain().focus().toggleBlockquote().run()}
+                  color={editor.isActive('blockquote') ? 'primary' : 'default'}
+                  size="small"
+                >
+                  <FormatQuote />
+                </IconButton>
+              </Tooltip>
+            </>
+          )}
+        </Paper>
+      </BubbleMenu>}
+      <Box sx={{
+        p: 1,
+        textAlign: 'right',
+        borderTop: '1px solid #ccc',
+        backgroundColor: '#f5f5f5',
+      }}>
+        <Typography variant="caption" color="textSecondary">
+          {editor.storage.characterCount.characters()} caracteres
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default InlineEditor;

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import AdvancedEditor from './AdvancedEditor';
+import InlineEditor from './InlineEditor';
 import { TextField } from '@mui/material';
 
-const TextEditor = ({ value, onChange, html = false, ...props }) => {
+const TextEditor = ({ value, onChange, html = false, variant = 'full', ...props }) => {
   if (html) {
+    if (variant === 'simple') {
+      return <InlineEditor value={value} onChange={onChange} html={html} {...props} />;
+    }
     return <AdvancedEditor value={value} onChange={onChange} html={html} {...props} />;
   }
 

--- a/src/components/TextEditorDialog.jsx
+++ b/src/components/TextEditorDialog.jsx
@@ -28,6 +28,7 @@ const TextEditorDialog = ({ open, title, content, onSave, onClose, html = false 
           value={editedContent}
           onChange={setEditedContent}
           html={html}
+          variant="full"
         />
       </DialogContent>
       <DialogActions sx={{ pb: 2, px: 3 }}>

--- a/src/features/RecordManager/components/RecordForm/RecordForm.jsx
+++ b/src/features/RecordManager/components/RecordForm/RecordForm.jsx
@@ -180,6 +180,7 @@ const RecordForm = ({
                                     maxHeight={150}
                                     darkMode={darkMode}
                                     html={true}
+                                    variant="simple"
                                 />
                             ) : (
                                 <input
@@ -228,6 +229,7 @@ const RecordForm = ({
                             maxHeight={200}
                             darkMode={darkMode}
                             html={true}
+                            variant="simple"
                         />
                     ) : (
                         <input


### PR DESCRIPTION
This commit fixes a regression where the manual CSV record editor became non-functional after the introduction of the new advanced text editor.

The advanced editor's layout with a full toolbar was not compatible with the simple modal used for record editing. To resolve this, the editor implementation has been refactored:

- **Re-introduced `InlineEditor`**: A simple editor variant using a `BubbleMenu` has been re-created.
- **Created Editor Variants**: The main `TextEditor` component now acts as a switcher, accepting a `variant` prop (`'full'` or `'simple'`) to render either the `AdvancedEditor` (with toolbar) or the `InlineEditor` (with bubble menu).
- **Contextual Usage**:
  - The main `TextEditorDialog` used for campaign content now explicitly requests the `'full'` variant.
  - The `RecordForm` used in the CSV editor now requests the `'simple'` variant, restoring its functionality with a more appropriate UI.