### PR TITLE
feat: Add block styles and fix empty editor bug

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CmWnkRyo.js"></script>
+  <script type="module" crossorigin src="/assets/index-CIgrTEkb.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CCOKjgaX.css">
 </head>
 

--- a/src/components/AdvancedEditor.jsx
+++ b/src/components/AdvancedEditor.jsx
@@ -29,6 +29,12 @@ const AdvancedEditor = ({ value, onChange, html = false }) => {
     },
   });
 
+  React.useEffect(() => {
+    if (editor && value !== editor.getHTML()) {
+      editor.commands.setContent(value, false);
+    }
+  }, [value, editor]);
+
   if (!editor) {
     return null;
   }

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -104,6 +104,35 @@ const Toolbar = ({ editor }) => {
 
       <Divider orientation="vertical" flexItem />
 
+      {/* Block Styles */}
+      <FormControl size="small" sx={{ minWidth: 120 }}>
+        <Select
+          value={
+            editor.isActive('heading', { level: 1 }) ? 'h1' :
+            editor.isActive('heading', { level: 2 }) ? 'h2' :
+            editor.isActive('heading', { level: 3 }) ? 'h3' :
+            editor.isActive('codeBlock') ? 'code' : 'p'
+          }
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === 'p') editor.chain().focus().setParagraph().run();
+            if (value === 'h1') editor.chain().focus().toggleHeading({ level: 1 }).run();
+            if (value === 'h2') editor.chain().focus().toggleHeading({ level: 2 }).run();
+            if (value === 'h3') editor.chain().focus().toggleHeading({ level: 3 }).run();
+            if (value === 'code') editor.chain().focus().toggleCodeBlock().run();
+          }}
+          displayEmpty
+        >
+          <MenuItem value="p">Paragraph</MenuItem>
+          <MenuItem value="h1">Heading 1</MenuItem>
+          <MenuItem value="h2">Heading 2</MenuItem>
+          <MenuItem value="h3">Heading 3</MenuItem>
+          <MenuItem value="code">Code Block</MenuItem>
+        </Select>
+      </FormControl>
+
+      <Divider orientation="vertical" flexItem />
+
       {/* Basic Formatting */}
       <Tooltip title="Bold">
         <IconButton onClick={() => editor.chain().focus().toggleBold().run()} color={editor.isActive('bold') ? 'primary' : 'default'} size="small">


### PR DESCRIPTION
This commit adds new block styling capabilities to the advanced text editor and fixes a bug where the editor would fail to load existing content on its first activation.

- **Feature: Block Styles**:
  - The editor's toolbar now includes a dropdown menu for applying block-level styles.
  - Users can now format text as Paragraphs, Headings (H1, H2, H3), and Code Blocks.

- **Bug Fix**:
  - Added a `useEffect` hook to the `AdvancedEditor` component to properly synchronize its state with the `value` prop.
  - This resolves the issue where the editor would appear empty when opened for the first time with pre-existing content.