### PR TITLE
refactor: Use dialog editor for CSV record manager

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CIgrTEkb.js"></script>
+  <script type="module" crossorigin src="/assets/index-DY6DGBYX.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CCOKjgaX.css">
 </head>
 

--- a/src/features/RecordManager/RecordManager.jsx
+++ b/src/features/RecordManager/RecordManager.jsx
@@ -4,7 +4,7 @@ import styles from './RecordManager.module.css';
 import RecordsTable from './components/RecordsTable/RecordsTable';
 import RecordModal from './components/RecordModal/RecordModal';
 import ConfirmationModal from '../../components/ui/ConfirmationModal/ConfirmationModal';
-// PapaParse não é mais usado diretamente aqui, apenas em App.jsx
+import TextEditorDialog from '../../components/TextEditorDialog';
 
 /**
  * @typedef {Object} Registro
@@ -61,6 +61,7 @@ const RecordManager = ({
     const [modalAberto, setModalAberto] = useState(null); // null, 'ADICIONAR', 'EDITAR', 'EXCLUIR'
     const [registroSelecionado, setRegistroSelecionado] = useState(null); // Para edição ou exclusão
     const [proximoId, setProximoId] = useState(1);
+    const [editingFieldInfo, setEditingFieldInfo] = useState(null); // { recordId, fieldName, content }
 
     // Renomeado para indicar que é para um único novo registro.
     const gerarIdParaNovoRegistroSingular = useCallback(() => {
@@ -212,13 +213,38 @@ const RecordManager = ({
     //     }
     // };
 
-  const containerClasses = `${styles.container} ${darkMode ? styles.darkMode : ''}`;
+    const handleStartEditField = (recordId, fieldName, content) => {
+        setEditingFieldInfo({ recordId, fieldName, content });
+    };
+
+    const handleCancelEditField = () => {
+        setEditingFieldInfo(null);
+    };
+
+    const handleSaveField = (newContent) => {
+        if (!editingFieldInfo) return;
+
+        const { recordId, fieldName } = editingFieldInfo;
+
+        const novosRegistros = registros.map(reg => {
+            if (String(reg.id) === String(recordId)) {
+                return { ...reg, [fieldName]: newContent };
+            }
+            return reg;
+        });
+
+        setRegistros(novosRegistros);
+        if (onDadosAlterados) {
+            onDadosAlterados(JSON.parse(JSON.stringify(novosRegistros)), [...colunas]);
+        }
+        setEditingFieldInfo(null);
+    };
+
+    const containerClasses = `${styles.container} ${darkMode ? styles.darkMode : ''}`;
 
     return (
         <div className={containerClasses}>
             <div className={styles.header}>
-                {/* O título agora é gerenciado pelo componente pai (PostsCurtosStep) */}
-                {/* <h1>Gerenciar Registros</h1> */}
                 <div className={styles.actionsContainer}>
                     <button onClick={handleAbrirModalAdicionar} className={`${styles.btn} ${styles.btnPrimary}`}>
                         &#43; Adicionar Novo Registro
@@ -241,10 +267,9 @@ const RecordManager = ({
                     onSalvar={handleSalvarRegistro}
                     colunasExistentes={colunas}
                     tituloModal="Adicionar Novo Registro"
-                    // Passa true se não houver colunas E não houver registros,
-                    // indicando que o formulário deve permitir definir colunas.
                     isPrimeiroRegistro={colunas.length === 0 && registros.length === 0}
                     darkMode={darkMode}
+                    onStartEditField={handleStartEditField}
                 />
             )}
 
@@ -258,6 +283,19 @@ const RecordManager = ({
                     tituloModal="Editar Registro"
                     isPrimeiroRegistro={false}
                     darkMode={darkMode}
+                    onStartEditField={handleStartEditField}
+                />
+            )}
+
+            {editingFieldInfo && (
+                <TextEditorDialog
+                    open={!!editingFieldInfo}
+                    onClose={handleCancelEditField}
+                    onSave={handleSaveField}
+                    title={`Editar ${editingFieldInfo.fieldName}`}
+                    content={editingFieldInfo.content}
+                    html={true}
+                    variant="simple"
                 />
             )}
 
@@ -271,13 +309,6 @@ const RecordManager = ({
                     darkMode={darkMode}
                 />
             )}
-
-      {/* Botão de concluir edição removido, pois a navegação é feita pelo App.jsx */}
-      {/* <div className={styles.actionsFooter}>
-        <button onClick={handleConcluir} className={`${styles.btn} ${styles.btnSuccess}`}>
-          Concluir Edição e Retornar Dados
-        </button>
-      </div> */}
         </div>
     );
 };

--- a/src/features/RecordManager/components/RecordForm/RecordForm.jsx
+++ b/src/features/RecordManager/components/RecordForm/RecordForm.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import TextEditor from '../../../../components/TextEditor';
 import styles from './RecordForm.module.css';
 
 /**
@@ -21,7 +20,8 @@ const RecordForm = ({
     onSubmit,
     onCancelar,
     isPrimeiroRegistro = false,
-    darkMode = false
+    darkMode = false,
+    onStartEditField,
 }) => {
     const [formData, setFormData] = useState({});
     const [novasColunas, setNovasColunas] = useState(
@@ -43,27 +43,22 @@ const RecordForm = ({
             });
             setFormData(initialState);
         } else if (!isPrimeiroRegistro) {
-            // Limpa o formulário se não for edição e não for o primeiro registro
             const initialState = {};
             colunas.forEach(col => {
                 initialState[col] = '';
             });
             setFormData(initialState);
         } else {
-            // Reseta o estado de novasColunas se for o primeiro registro
-            setNovasColunas([{ nome: '', valor: '' }]);
-            // Reseta o estado de novasColunas se for o primeiro registro, preenchendo com os defaults
             setNovasColunas([
                 { nome: 'titulo', valor: '' },
                 { nome: 'mensagem', valor: '' },
                 { nome: 'descrição', valor: '' },
                 { nome: 'hashtags', valor: '' }
             ]);
-            setFormData({}); // Limpa formData, pois será preenchido por novasColunas
+            setFormData({});
         }
     }, [dadosIniciais, colunas, isPrimeiroRegistro]);
 
-    // Campos que devem usar o editor rich text
     const richTextFields = ['mensagem', 'texto principal', 'descrição', 'conteúdo', 'texto'];
 
     const isRichTextField = (fieldName) => {
@@ -77,19 +72,9 @@ const RecordForm = ({
         setFormData(prev => ({ ...prev, [name]: value }));
     };
 
-    const handleRichTextChange = (fieldName, value) => {
-        setFormData(prev => ({ ...prev, [fieldName]: value }));
-    };
-
     const handleNovaColunaChange = (index, field, value) => {
         const updated = [...novasColunas];
         updated[index][field] = value;
-        setNovasColunas(updated);
-    };
-
-    const handleNovaColunaRichTextChange = (index, value) => {
-        const updated = [...novasColunas];
-        updated[index]['valor'] = value;
         setNovasColunas(updated);
     };
 
@@ -170,17 +155,13 @@ const RecordForm = ({
                             />
                         </div>
                         {/* Valor da Coluna Field */}
-                        <div className={styles.formGroup}> {/* This will also be label on top of input */}
+                        <div className={styles.formGroup}>
                             <label htmlFor={`novaColunaValor-${index}`}>Valor Coluna {index + 1}</label>
                             {isRichTextField(nc.nome) ? (
-                                <TextEditor
-                                    value={nc.valor}
-                                    onChange={(value) => handleNovaColunaRichTextChange(index, value)}
-                                    placeholder="Valor inicial com formatação"
-                                    maxHeight={150}
-                                    darkMode={darkMode}
-                                    html={true}
-                                    variant="simple"
+                                <div
+                                    className={styles.richTextPreview}
+                                    onClick={() => onStartEditField(dadosIniciais?.id || `new_${index}`, nc.nome, nc.valor)}
+                                    dangerouslySetInnerHTML={{ __html: nc.valor || '<p><em>Clique para editar...</em></p>' }}
                                 />
                             ) : (
                                 <input
@@ -222,14 +203,10 @@ const RecordForm = ({
                 <div key={col} className={styles.formGroup}>
                     <label htmlFor={`campo-${col.replace(/\s+/g, '-')}`}>{col}:</label>
                     {isRichTextField(col) ? (
-                        <TextEditor
-                            value={formData[col] || ''}
-                            onChange={(value) => handleRichTextChange(col, value)}
-                            placeholder={`Digite o conteúdo para ${col}`}
-                            maxHeight={200}
-                            darkMode={darkMode}
-                            html={true}
-                            variant="simple"
+                        <div
+                            className={styles.richTextPreview}
+                            onClick={() => onStartEditField(dadosIniciais.id, col, formData[col] || '')}
+                            dangerouslySetInnerHTML={{ __html: formData[col] || '<p><em>Clique para editar...</em></p>' }}
                         />
                     ) : (
                         <input

--- a/src/features/RecordManager/components/RecordModal/RecordModal.jsx
+++ b/src/features/RecordManager/components/RecordModal/RecordModal.jsx
@@ -25,7 +25,8 @@ const RecordModal = ({
     colunasExistentes,
     tituloModal,
     isPrimeiroRegistro,
-    darkMode = false
+    darkMode = false,
+    onStartEditField,
 }) => {
     if (!aberto) return null;
 
@@ -47,6 +48,7 @@ const RecordModal = ({
                     onCancelar={onFechar}
                     isPrimeiroRegistro={isPrimeiroRegistro}
                     darkMode={darkMode}
+                    onStartEditField={onStartEditField}
                 />
             </div>
         </div>


### PR DESCRIPTION
This commit refactors the manual CSV record editor to align its user experience with the main campaign editor. Instead of rendering an editor inline within the form, it now opens a dialog when a rich text field is clicked.

- **Updated `RecordManager.jsx`**:
  - Now manages state for an editor dialog (`TextEditorDialog`).
  - Contains the logic for opening the dialog and saving the edited content back to the appropriate record.

- **Updated `RecordModal.jsx`**:
  - Now accepts and passes down an `onStartEditField` prop to the form.

- **Updated `RecordForm.jsx`**:
  - No longer renders an editor inline.
  - Displays a read-only preview of HTML content.
  - Triggers the `onStartEditField` prop when the preview is clicked, which opens the editor dialog.