### PR TITLE
fix(renderer): Unify initial and post-edit image rendering logic

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -134,11 +134,11 @@ const ImageGeneratorFrontendOnly = ({
             record: imgData.record,
             index: imgData.index,
             itemBackgroundImage: imgData.backgroundImage,
-            imageFilters,
+            imageFilters: imgData.customImageFilters || imageFilters, // Use custom filters if available
             brandElements: elementsToUse,
             fieldPositions: positionsToUse,
             fieldStyles: stylesToUse,
-            fontScale: 1, // Always use 100% scale for regeneration
+            fontScale: imgData.fontScale || 1, // Use custom font scale if available
           }).catch(error => {
             console.error(`[Thumbnail-Regen] Failed to regenerate thumbnail for index ${imgData.index}:`, error);
             return imgData; // On error, return the original data to not lose it
@@ -324,13 +324,14 @@ const ImageGeneratorFrontendOnly = ({
         stylesToUse,
         sizeToUse,
         elementsToUse,
-        modifiedImageData.fontScale || 1
+        modifiedImageData.fontScale || 1,
+        modifiedImageData.imageFilters || imageFilters
       );
     }
     handleCloseGeneratedImageEditor();
   };
 
-  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
+  const regenerateSingleImage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1, customImageFilters = imageFilters) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       alert('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       return;
@@ -340,7 +341,7 @@ const ImageGeneratorFrontendOnly = ({
         record,
         index,
         itemBackgroundImage: currentBackgroundImage,
-        imageFilters,
+        imageFilters: customImageFilters,
         brandElements: elementsToUse,
         fieldPositions: positionsToUse,
         fieldStyles: stylesToUse,


### PR DESCRIPTION
This commit fixes the final remaining discrepancy between the initial image rendering (on campaign load) and the rendering that occurs after saving from the preview editor.

The root cause was that the `regenerateMissingThumbnails` function, which runs on initial load, was using global default values for `fontScale` and `imageFilters` instead of the specific values saved with each individual image. This caused inconsistencies in font size, padding, border radius, and image filters compared to the post-edit render, which was using the correct, specific values.

The fix modifies `ImageGeneratorFrontendOnly.jsx` to ensure the `regenerateMissingThumbnails` function sources its parameters (`fontScale`, `customImageFilters`, etc.) from the individual image data (`imgData`), falling back to global props only if necessary. This unifies the two rendering paths, ensuring that the initial render is now identical to the post-edit render.

This commit, combined with all previous fixes in this branch, provides a comprehensive solution to all reported rendering and state consistency issues.