### PR TITLE
Fix: Set default transparent background for fields. The fields in the…

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -42,6 +42,8 @@ const COMPLETE_DEFAULT_STYLE_FOR_FIELD_POSITIONER = {
   shadowBlur: 4,
   shadowOffsetX: 2,
   shadowOffsetY: 2,
+  backgroundColor: '#000000',
+  backgroundOpacity: 0,
 };
 
 import { isHtmlField } from '../lib/utils';


### PR DESCRIPTION
… editor and the generated images had a black background by default. This was because the default style for fields was missing `backgroundColor` and `backgroundOpacity` properties. This change adds these properties to the default style, setting the `backgroundOpacity` to 0 to make the background transparent by default.