### PR TITLE
Fix: Set transparent background and correct vertical alignment

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -95,7 +95,6 @@ const DraggableElementInternal = ({
         dangerouslySetInnerHTML={{ __html: sanitizedContent }}
         style={{
           width: '100%',
-          height: '100%',
           overflow: 'hidden',
           wordWrap: 'break-word',
           pointerEvents: 'none',

--- a/src/components/DraggableElement.module.css
+++ b/src/components/DraggableElement.module.css
@@ -54,7 +54,6 @@
 
 .textContent.htmlContent {
   width: 100%;
-  height: 100%;
 }
 
 .textContent.htmlContent ul,


### PR DESCRIPTION
- Fields in the editor and generated images had a black background by default. This change adds `backgroundColor` and `backgroundOpacity` to the default style for fields, making them transparent by default.
- Vertical alignment (top, middle, bottom) was not working in the editor preview for HTML fields. This was because the text container had a `height: 100%`, which prevented flexbox's `justify-content` from working. This change removes the fixed height, allowing vertical alignment to work as expected.