### PR TITLE
feat: Make My Campaigns screen responsive

### DIFF
--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -13,8 +13,13 @@ import {
   Divider,
   Container,
   Paper,
+  Card,
+  CardContent,
+  CardActions,
+  Fab,
 } from '@mui/material';
 import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon } from '@mui/icons-material';
+import { useIsMobile } from '../hooks/use-mobile';
 import { getCampaigns, deleteCampaign } from '../utils/campaignState';
 import { toast } from 'sonner';
 
@@ -22,6 +27,7 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const isMobile = useIsMobile();
 
   const fetchCampaigns = () => {
     setLoading(true);
@@ -56,18 +62,20 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
 
   return (
     <Container maxWidth="md">
-      <Paper sx={{ p: { xs: 2, md: 4 }, mt: 4 }}>
+      <Paper sx={{ p: { xs: 2, md: 4 }, mt: 4, position: 'relative' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h4" component="h1">
+          <Typography variant={isMobile ? 'h5' : 'h4'} component="h1">
             Minhas Campanhas
           </Typography>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={onCreateNew}
-          >
-            Nova Campanha
-          </Button>
+          {!isMobile && (
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={onCreateNew}
+            >
+              Nova Campanha
+            </Button>
+          )}
         </Box>
         <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
           Selecione uma campanha existente para carregar e continuar editando, ou crie uma nova.
@@ -78,39 +86,48 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
         ) : error ? (
           <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>
         ) : (
-          <List>
+          <Box>
             {campaigns.length === 0 ? (
               <Typography sx={{ p: 2, textAlign: 'center' }}>
                 Nenhuma campanha salva encontrada. Crie uma nova para começar.
               </Typography>
             ) : (
               campaigns.map((campaign) => (
-                <React.Fragment key={campaign.id}>
-                  <ListItem
-                    secondaryAction={
-                      <Box>
-                        <IconButton edge="end" aria-label="edit" onClick={() => onEditCampaign(campaign)}>
-                          <EditIcon />
-                        </IconButton>
-                        <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(campaign.id, campaign.name)}>
-                          <DeleteIcon />
-                        </IconButton>
-                      </Box>
-                    }
-                    disablePadding
-                  >
-                    <ListItemButton onClick={() => onLoadCampaign(campaign.id)}>
-                      <ListItemText
-                        primary={campaign.name}
-                        secondary={`Atualizada em: ${new Date(campaign.updated_at).toLocaleString()}`}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                  <Divider />
-                </React.Fragment>
+                <Card key={campaign.id} sx={{ mb: 2, cursor: 'pointer' }} onClick={() => onLoadCampaign(campaign.id)}>
+                  <CardContent>
+                    <Typography variant="h6" component="div">
+                      {campaign.name}
+                    </Typography>
+                    <Typography sx={{ mb: 1.5 }} color="text.secondary">
+                      Atualizada em: {new Date(campaign.updated_at).toLocaleString()}
+                    </Typography>
+                  </CardContent>
+                  <CardActions sx={{ justifyContent: 'flex-end' }}>
+                    <IconButton aria-label="edit" onClick={(e) => { e.stopPropagation(); onEditCampaign(campaign); }}>
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton aria-label="delete" onClick={(e) => { e.stopPropagation(); handleDelete(campaign.id, campaign.name); }}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </CardActions>
+                </Card>
               ))
             )}
-          </List>
+          </Box>
+        )}
+        {isMobile && (
+          <Fab
+            color="primary"
+            aria-label="add"
+            sx={{
+              position: 'fixed',
+              bottom: 16,
+              right: 16,
+            }}
+            onClick={onCreateNew}
+          >
+            <AddIcon />
+          </Fab>
         )}
       </Paper>
     </Container>


### PR DESCRIPTION
Refactors the My Campaigns screen to be mobile-friendly.

- Uses a `useIsMobile` hook to detect mobile screen sizes.
- Replaces the `List` with `Card` components for each campaign to provide a more flexible and responsive layout.
- On mobile, the "New Campaign" button is a Floating Action Button (FAB).
- Adjusts typography for better readability on smaller screens.

Note: Pre-existing lint errors in other files have not been addressed in this commit.