### PR TITLE
Fix(ImageGenerator): Preserve background image on regeneration

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -351,14 +351,17 @@ const ImageGeneratorFrontendOnly = ({
       setGeneratedImages(prevImages => {
         const updatedImages = prevImages.map(img => {
           if (img.index === index) {
-            // The new object from composeSingleImage doesn't have the custom* fields,
-            // so we need to add them back.
+            // The new object from composeSingleImage contains the new url, blob, etc.
+            // We merge it with the existing `img` data to preserve all fields,
+            // especially the `backgroundImage` which might be lost otherwise.
             return {
+              ...img,
               ...newImageData,
               customFieldPositions: positionsToUse,
               customFieldStyles: stylesToUse,
               customBrandElements: elementsToUse,
               customOriginalImageSize: customSize,
+              backgroundImage: currentBackgroundImage, // Explicitly preserve the background used for regeneration
             };
           }
           return img;


### PR DESCRIPTION
The `regenerateSingleImage` function was not preserving the `backgroundImage` property when updating the component's state. This caused the image to flicker, alternating between the specific background and the global campaign background.

This commit modifies the state update logic to merge the new image data with the existing data, ensuring that the `backgroundImage` and other properties are preserved, thus fixing the visual flicker.