### PR TITLE
fix(linkedin): Differentiate 'shares' param for single vs. multiple URNs

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -343,9 +343,13 @@ async function handleGetShareStatistics(fetch, request, response) {
         return response.status(400).json({ error: 'Missing accessToken, authorUrn, or shareUrns.' });
     }
 
-    // Based on LinkedIn API documentation, the 'shares' parameter must be a single string
-    // formatted as "List(urn1,urn2,...)", with each URN individually encoded.
-    const sharesParam = `shares=List(${shareUrns.map(urn => encodeURIComponent(urn)).join(',')})`;
+    // The 'shares' parameter has a different format for single vs. multiple items.
+    let sharesParam;
+    if (shareUrns.length === 1) {
+        sharesParam = `shares=${encodeURIComponent(shareUrns[0])}`;
+    } else {
+        sharesParam = `shares=List(${shareUrns.map(urn => encodeURIComponent(urn)).join(',')})`;
+    }
     const url = `https://api.linkedin.com/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=${encodeURIComponent(authorUrn)}&${sharesParam}`;
 
     try {


### PR DESCRIPTION
This commit provides a targeted fix for the 'Array parameter 'shares' value is invalid' error from the LinkedIn API.

The root cause appears to be that the API requires a different format for the `shares` parameter when a single URN is provided versus when multiple URNs are provided.

This change modifies `api/linkedin-proxy.js` to:
- When a single URN is passed, format the parameter as `shares=urn`.
- When multiple URNs are passed, format the parameter as `shares=List(urn1,urn2,...)`.

This is the most likely solution based on the specific error message received from the user.