### PR TITLE
feat(linkedin): Implement fetching for personal post statistics

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -337,10 +337,10 @@ async function handleRefreshToken(fetch, request, response) {
 }
 
 async function handleGetShareStatistics(fetch, request, response) {
-    const { accessToken, organizationUrn: authorUrn, shareUrns } = request.body;
+    const { accessToken, authorUrn, shareUrns } = request.body.payload;
 
     if (!accessToken || !authorUrn || !shareUrns || !Array.isArray(shareUrns)) {
-        return response.status(400).json({ error: 'Missing accessToken, authorUrn, or shareUrns.' });
+        return response.status(400).json({ error: 'Missing accessToken, authorUrn, or shareUrns in payload.' });
     }
 
     // The 'shares' parameter has a different format for single vs. multiple items.
@@ -379,6 +379,43 @@ async function handleGetShareStatistics(fetch, request, response) {
     }
 }
 
+async function handleGetMemberPostStatistics(fetch, request, response) {
+    const { accessToken, ugcPostUrn, queryType, aggregation, dateRange } = request.body.payload;
+
+    if (!accessToken || !ugcPostUrn || !queryType || !aggregation || !dateRange) {
+        return response.status(400).json({ error: 'Missing required parameters for member post statistics.' });
+    }
+
+    // Docs: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/members/post-statistics?view=li-lms-2025-07
+    const url = `https://api.linkedin.com/rest/memberCreatorPostAnalytics?q=entity&entity=(ugc:${encodeURIComponent(ugcPostUrn)})&queryType=${queryType}&aggregation=${aggregation}&dateRange=(start:(day:${dateRange.start.day},month:${dateRange.start.month},year:${dateRange.start.year}),end:(day:${dateRange.end.day},month:${dateRange.end.month},year:${dateRange.end.year}))`;
+
+    try {
+        const linkedinResponse = await fetchWithRetry(fetch, url, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'X-Restli-Protocol-Version': '2.0.0',
+                'LinkedIn-Version': LINKEDIN_API_VERSION
+            },
+        });
+
+        const data = await linkedinResponse.json();
+
+        if (linkedinResponse.ok) {
+            return response.status(200).json(data);
+        } else {
+            console.error(`[ERROR] LinkedIn Member Post Stats API responded with status ${linkedinResponse.status} for post ${ugcPostUrn}:`, data);
+            return response.status(linkedinResponse.status).json(data);
+        }
+    } catch (error) {
+        console.error(`[FATAL] Error during GET to ${url}:`, error.message, error.stack);
+        return response.status(500).json({
+            error: `Internal Server Error during GET to ${url}`,
+            details: error.message,
+        });
+    }
+}
+
 const mainHandler = async (request, response) => {
   const fetch = (await import('node-fetch')).default;
   const { action } = request.body;
@@ -392,6 +429,7 @@ const mainHandler = async (request, response) => {
     case 'createPost': return handleCreatePost(fetch, request, response);
     case 'getProfiles': return handleGetProfiles(fetch, request, response);
     case 'getShareStatistics': return handleGetShareStatistics(fetch, request, response);
+    case 'getMemberPostStatistics': return handleGetMemberPostStatistics(fetch, request, response);
     case 'initializeVideoUpload': return handleGenericPost(fetch, request, response, 'https://api.linkedin.com/rest/videos?action=initializeUpload');
     case 'uploadVideo': return handleUploadVideo(fetch, request, response);
     case 'finalizeVideoUpload': return handleGenericPost(fetch, request, response, 'https://api.linkedin.com/rest/videos?action=finalizeUpload');

--- a/src/components/Monitor.jsx
+++ b/src/components/Monitor.jsx
@@ -20,7 +20,7 @@ import {
 import { BarChart, Refresh, Info, Link as LinkIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
 import { getCampaignPublications } from '../utils/campaignState';
-import { getLinkedInShareStatistics } from '../utils/linkedinAPI';
+import { getLinkedInShareStatistics, getLinkedInMemberPostStatistics } from '../utils/linkedinAPI';
 import { useSettings } from '../context/SettingsContext';
 
 const StatCard = ({ title, value, icon }) => (
@@ -78,7 +78,6 @@ const Monitor = ({ currentCampaign }) => {
       return;
     }
 
-    // Group publications by their author_urn to make separate API calls if needed.
     const pubsByAuthor = publications.reduce((acc, pub) => {
       const authorUrn = pub.author_urn;
       if (authorUrn && pub.urn) {
@@ -91,34 +90,60 @@ const Monitor = ({ currentCampaign }) => {
     }, {});
 
     if (Object.keys(pubsByAuthor).length === 0) {
-        toast.info("Nenhuma publicação com autor válido encontrada para buscar estatísticas.");
-        return;
+      toast.info("Nenhuma publicação com autor válido encontrada para buscar estatísticas.");
+      return;
     }
 
     setIsLoading(true);
     setError('');
     try {
-        let allStats = {};
-        const fetchPromises = Object.entries(pubsByAuthor).map(async ([authorUrn, urns]) => {
-            const results = await getLinkedInShareStatistics(settings.linkedin, authorUrn, urns);
-            (results.elements || []).forEach(stat => {
-                const urn = stat.share || stat.ugcPost || stat.carousel || stat.post;
-                if (urn && stat.totalShareStatistics) {
-                    allStats[urn] = stat.totalShareStatistics;
-                }
-            });
-        });
+      let allStats = {};
+      const fetchPromises = Object.entries(pubsByAuthor).map(async ([authorUrn, urns]) => {
+        if (authorUrn.includes(':organization:')) {
+          const results = await getLinkedInShareStatistics(settings.linkedin, authorUrn, urns);
+          (results.elements || []).forEach(stat => {
+            const urn = stat.share || stat.ugcPost || stat.carousel || stat.post;
+            if (urn && stat.totalShareStatistics) {
+              allStats[urn] = stat.totalShareStatistics;
+            }
+          });
+        } else {
+          // For personal authors, call the new endpoint for each post.
+          const personalPostPromises = urns.map(async (urn) => {
+            try {
+              const result = await getLinkedInMemberPostStatistics(settings.linkedin, urn);
+              // The response structure for member stats is different. We need to transform it.
+              // This transformation is a best guess based on the API docs.
+              if (result && result.elements && result.elements.length > 0) {
+                const statsData = result.elements[0];
+                allStats[result.urn] = {
+                  impressionCount: statsData.totalImpressions?.count || 0,
+                  likeCount: statsData.reactionSummaries?.LIKE || 0,
+                  commentCount: statsData.totalComments?.count || 0,
+                  shareCount: statsData.totalReshares?.count || 0,
+                  clickCount: statsData.totalClicks?.count || 0,
+                  engagement: statsData.engagementRate?.rate || 0,
+                };
+              }
+            } catch (postError) {
+                console.error(`Failed to fetch stats for personal post ${urn}:`, postError);
+                toast.error(`Falha ao buscar estatísticas para o post ${urn.split(':').pop()}`);
+            }
+          });
+          await Promise.all(personalPostPromises);
+        }
+      });
 
-        await Promise.all(fetchPromises);
+      await Promise.all(fetchPromises);
 
-        setStats(allStats);
-        toast.success("Estatísticas atualizadas com sucesso!");
+      setStats(allStats);
+      toast.success("Estatísticas atualizadas com sucesso!");
 
     } catch (err) {
-        toast.error(`Falha ao buscar estatísticas: ${err.message}`);
-        setError(err.message);
+      toast.error(`Falha ao buscar estatísticas: ${err.message}`);
+      setError(err.message);
     } finally {
-        setIsLoading(false);
+      setIsLoading(false);
     }
   };
 

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -181,21 +181,51 @@ export const uploadImagesForLinkedIn = async (linkedinConfig, imageBlobs, author
   return assetUrns;
 };
 
-export const getLinkedInShareStatistics = async (linkedinConfig, organizationUrn, shareUrns) => {
+export const getLinkedInShareStatistics = async (linkedinConfig, authorUrn, shareUrns) => {
   if (!linkedinConfig || !linkedinConfig.accessToken) {
     throw new Error('LinkedIn configuration or Access Token not found.');
   }
-  if (!organizationUrn || !shareUrns || shareUrns.length === 0) {
-    throw new Error('Organization URN and at least one Share URN are required.');
+  if (!authorUrn || !shareUrns || shareUrns.length === 0) {
+    throw new Error('Author URN and at least one Share URN are required.');
   }
 
   const api = new LinkedInAPI(linkedinConfig.accessToken);
   const result = await api._proxyFetch('getShareStatistics', {
-    organizationUrn,
-    shareUrns,
+    payload: {
+        authorUrn,
+        shareUrns,
+    }
   });
 
   return result;
+};
+
+export const getLinkedInMemberPostStatistics = async (linkedinConfig, ugcPostUrn) => {
+    if (!linkedinConfig || !linkedinConfig.accessToken) {
+        throw new Error('LinkedIn configuration or Access Token not found.');
+    }
+    if (!ugcPostUrn) {
+        throw new Error('Post URN is required.');
+    }
+
+    const api = new LinkedInAPI(linkedinConfig.accessToken);
+
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(endDate.getDate() - 90);
+
+    const payload = {
+        ugcPostUrn,
+        queryType: 'TOTAL',
+        aggregation: 'TOTAL',
+        dateRange: {
+            start: { day: startDate.getUTCDate(), month: startDate.getUTCMonth() + 1, year: startDate.getUTCFullYear() },
+            end: { day: endDate.getUTCDate(), month: endDate.getUTCMonth() + 1, year: endDate.getUTCFullYear() }
+        }
+    };
+
+    const result = await api._proxyFetch('getMemberPostStatistics', { payload });
+    return { ...result, urn: ugcPostUrn }; // Add urn to result for easy mapping
 };
 
 


### PR DESCRIPTION
This commit implements the correct method for fetching statistics for LinkedIn posts made by personal profiles, based on the official LinkedIn API documentation for the `memberCreatorPostAnalytics` endpoint.

This resolves a series of errors that occurred when trying to use the organizational statistics endpoint for personal posts.

Changes:
- A new handler `handleGetMemberPostStatistics` is added to `api/linkedin-proxy.js` to call the `memberCreatorPostAnalytics` endpoint.
- The frontend component `src/components/Monitor.jsx` now differentiates between personal and organizational authors, calling the appropriate API for each.
- For personal profiles, statistics are fetched for each post individually.
- A new client function `getLinkedInMemberPostStatistics` is added to `src/utils/linkedinAPI.js`.