### PR TITLE
Fix: Ensure image editor preview matches generated image

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -191,7 +191,11 @@ const ImageGeneratorFrontendOnly = ({
       })
       .then(imageData => {
         setProgress(p => p + 1);
-        return imageData;
+        // Persist the styles used for generation with the image data
+        return {
+          ...imageData,
+          customFieldStyles: fieldStyles,
+        };
       })
       .catch(error => {
         console.error(`Erro ao gerar imagem para o registro ${i}:`, error);
@@ -358,7 +362,7 @@ const ImageGeneratorFrontendOnly = ({
               ...img,
               ...newImageData,
               customFieldPositions: positionsToUse,
-              customFieldStyles: stylesToUse,
+              customFieldStyles: stylesToUse, // Persist the styles used for regeneration
               customBrandElements: elementsToUse,
               customOriginalImageSize: customSize,
               backgroundImage: currentBackgroundImage, // Explicitly preserve the background used for regeneration


### PR DESCRIPTION
This commit resolves an issue where the preview in the image editor did not accurately reflect the saved image. The discrepancy was caused by the editor incorrectly falling back to the campaign's template styles instead of using the specific styles with which the image was originally generated.

The fix involves two main changes:

1.  **Persist Styles on Generation:** The styles used to create an image (both during initial bulk generation and single-image regeneration) are now saved to the `customFieldStyles` property of that image's data object. This ensures that every image has an explicit record of its styles.

2.  **Correct Style Loading in Editor:** The existing logic in the editor, which prioritizes `customFieldStyles` and falls back to the template's `initialFieldStyles`, will now function as intended. For all newly generated images, it will use the correct persisted styles. For legacy data (images generated before this fix), it will maintain the previous behavior of using the template styles, preventing regressions.