### PR TITLE
fix(proxy): Correct accessToken destructuring in stats handlers

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -337,7 +337,8 @@ async function handleRefreshToken(fetch, request, response) {
 }
 
 async function handleGetShareStatistics(fetch, request, response) {
-    const { accessToken, authorUrn, shareUrns } = request.body.payload;
+    const { accessToken, payload } = request.body;
+    const { authorUrn, shareUrns } = payload;
 
     if (!accessToken || !authorUrn || !shareUrns || !Array.isArray(shareUrns)) {
         return response.status(400).json({ error: 'Missing accessToken, authorUrn, or shareUrns in payload.' });
@@ -380,7 +381,8 @@ async function handleGetShareStatistics(fetch, request, response) {
 }
 
 async function handleGetMemberPostStatistics(fetch, request, response) {
-    const { accessToken, ugcPostUrn, queryType, aggregation, dateRange } = request.body.payload;
+    const { accessToken, payload } = request.body;
+    const { ugcPostUrn, queryType, aggregation, dateRange } = payload;
 
     if (!accessToken || !ugcPostUrn || !queryType || !aggregation || !dateRange) {
         return response.status(400).json({ error: 'Missing required parameters for member post statistics.' });


### PR DESCRIPTION
This commit fixes a bug in `api/linkedin-proxy.js` that caused a `400 Bad Request` error when fetching statistics.

The `handleGetShareStatistics` and `handleGetMemberPostStatistics` functions were incorrectly trying to destructure the `accessToken` from the nested `payload` object instead of the root of the request body. This caused the `accessToken` to be undefined, leading to a parameter validation failure before the request was sent to LinkedIn.

This change corrects the destructuring to read `accessToken` from `request.body` and the other parameters from `request.body.payload`, ensuring the proxy can correctly process the request.