### PR TITLE
Fix: Correctly layer styles in the image editor

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -100,8 +100,6 @@ const GeneratedImageEditor = ({
     if (open && imageData && initialFieldPositions && initialFieldStyles) {
       const positions = JSON.parse(JSON.stringify(imageData.customFieldPositions || initialFieldPositions));
       const brands = JSON.parse(JSON.stringify(imageData.customBrandElements || brandElements || []));
-      const stylesToUse = imageData.customFieldStyles || initialFieldStyles;
-
       // Defensively add filters to brand elements
       brands.forEach(el => {
         if (!el.filters) {
@@ -140,11 +138,15 @@ const GeneratedImageEditor = ({
       setEditedBrandElements(brands);
       setEditedRecord(JSON.parse(JSON.stringify(imageData.record)));
 
+      // Reworked style initialization to correctly layer styles
       const newEditedStyles = {};
       globalCsvHeaders.forEach(field => {
+        const templateStyle = initialFieldStyles?.[field] || {};
+        const customStyle = imageData.customFieldStyles?.[field] || {};
         newEditedStyles[field] = {
           ...COMPLETE_DEFAULT_STYLE,
-          ...(stylesToUse?.[field] || {}),
+          ...templateStyle,
+          ...customStyle,
         };
       });
       setEditedStyles(newEditedStyles);


### PR DESCRIPTION
This commit resolves a bug where the image editor's preview would not correctly display saved styles for properties like padding, opacity, and background color. The issue stemmed from an incorrect style initialization logic that did not properly layer the default, template, and custom styles.

The fix refactors the style initialization in `GeneratedImageEditor.jsx` to ensure the correct order of precedence. The styles are now merged in the following order:
1.  A hardcoded default style (`COMPLETE_DEFAULT_STYLE`).
2.  The campaign's template styles (`initialFieldStyles`).
3.  The image's specific saved styles (`imageData.customFieldStyles`).

This ensures that any custom style applied to an image correctly overrides the template and default styles, and that any property not in the custom style will correctly fall back to the template's style. This resolves the visual discrepancy between the saved image and the editor's preview.