### PR TITLE
Refactor Field Editor panel and fix UI issues

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -467,10 +467,10 @@ const FormattingPanel = ({
                       {/* Opacidade e Cor de Fundo */}
                       <Grid item xs={12}>
                         <Grid container spacing={1} alignItems="center">
-                          <Grid item xs={9}>
+                          <Grid item sx={{ minWidth: '90px' }}>
                             <Typography variant="body2">Opacidade</Typography>
                           </Grid>
-                          <Grid item xs={3}>
+                          <Grid item>
                             <TextField
                               type="color"
                               value={currentElement.style.backgroundColor || '#000000'}
@@ -479,7 +479,9 @@ const FormattingPanel = ({
                               sx={{ minWidth: '40px' }}
                             />
                           </Grid>
-                          <Grid item xs={9}>
+                        </Grid>
+                        <Grid container spacing={2} alignItems="center">
+                          <Grid item xs>
                             <Slider
                               value={currentElement.style.backgroundOpacity || 1}
                               onChange={(e, value) => updateFieldStyle(selectedField, 'backgroundOpacity', value)}
@@ -489,7 +491,7 @@ const FormattingPanel = ({
                               size="small"
                             />
                           </Grid>
-                          <Grid item xs={3}>
+                          <Grid item>
                             <TextField
                               type="number"
                               value={Math.round((currentElement.style.backgroundOpacity || 1) * 100)}
@@ -513,10 +515,10 @@ const FormattingPanel = ({
                       {/* Espessura e Cor da Borda */}
                       <Grid item xs={12}>
                         <Grid container spacing={1} alignItems="center">
-                          <Grid item xs={9}>
+                          <Grid item sx={{ minWidth: '90px' }}>
                             <Typography variant="body2">Espessura</Typography>
                           </Grid>
-                          <Grid item xs={3}>
+                          <Grid item>
                             <TextField
                               type="color"
                               value={currentElement.style.borderColor || '#000000'}
@@ -525,7 +527,9 @@ const FormattingPanel = ({
                               sx={{ minWidth: '40px' }}
                             />
                           </Grid>
-                          <Grid item xs={9}>
+                        </Grid>
+                        <Grid container spacing={2} alignItems="center">
+                          <Grid item xs>
                             <Slider
                               value={currentElement.style.borderWidth || 0}
                               onChange={(e, value) => updateFieldStyle(selectedField, 'borderWidth', value)}
@@ -534,7 +538,7 @@ const FormattingPanel = ({
                               size="small"
                             />
                           </Grid>
-                          <Grid item xs={3}>
+                          <Grid item>
                             <TextField
                               type="number"
                               value={currentElement.style.borderWidth || 0}


### PR DESCRIPTION
This commit refactors the Field Editor panel to improve the user experience, including renaming labels, rearranging controls, and fixing the display of the campaign color palette. It also resolves a double scrollbar issue in the image editor dialog.

Based on user feedback, this commit also:
- Implements a two-row layout for the Opacity and Thickness controls to improve usability.
- Adds line spacing presets.
- Removes the 'Apply to All' button.
- Renames 'Largura da Borda' to 'Espessura' and 'Raio da Borda' to 'Curva'.