### PR TITLE
Fix: Implement robust state initialization in image editor

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -100,17 +100,7 @@ const GeneratedImageEditor = ({
     if (open && imageData && initialFieldPositions && initialFieldStyles) {
       const brands = JSON.parse(JSON.stringify(imageData.customBrandElements || brandElements || []));
 
-      // Deep merge positions
-      const basePositions = JSON.parse(JSON.stringify(initialFieldPositions));
-      const customPositions = imageData.customFieldPositions || {};
-      Object.keys(customPositions).forEach(field => {
-        basePositions[field] = {
-          ...(basePositions[field] || {}),
-          ...customPositions[field],
-        };
-      });
-      const positions = basePositions;
-
+      const positions = JSON.parse(JSON.stringify(initialFieldPositions));
       // Defensively add filters to brand elements
       brands.forEach(el => {
         if (!el.filters) {
@@ -149,15 +139,12 @@ const GeneratedImageEditor = ({
       setEditedBrandElements(brands);
       setEditedRecord(JSON.parse(JSON.stringify(imageData.record)));
 
-      // Reworked style initialization to correctly layer styles
+      // Simplified style initialization, as props are now pre-merged
       const newEditedStyles = {};
       globalCsvHeaders.forEach(field => {
-        const templateStyle = initialFieldStyles?.[field] || {};
-        const customStyle = imageData.customFieldStyles?.[field] || {};
         newEditedStyles[field] = {
           ...COMPLETE_DEFAULT_STYLE,
-          ...templateStyle,
-          ...customStyle,
+          ...(initialFieldStyles?.[field] || {}),
         };
       });
       setEditedStyles(newEditedStyles);

--- a/src/components/MemoizedGeneratedImageEditor.jsx
+++ b/src/components/MemoizedGeneratedImageEditor.jsx
@@ -21,17 +21,31 @@ const MemoizedGeneratedImageEditor = ({
   }, [generatedImages, editingGeneratedImageIndex]);
 
   const memoizedPositions = useMemo(() => {
-    const positionsSource = imageToEdit?.customFieldPositions !== undefined
-      ? imageToEdit.customFieldPositions
-      : fieldPositions;
-    return JSON.parse(JSON.stringify(positionsSource || {}));
+    const basePositions = JSON.parse(JSON.stringify(fieldPositions || {}));
+    const customPositions = imageToEdit?.customFieldPositions || {};
+
+    Object.keys(customPositions).forEach(field => {
+      basePositions[field] = {
+        ...(basePositions[field] || {}),
+        ...customPositions[field],
+      };
+    });
+
+    return basePositions;
   }, [imageToEdit, fieldPositions]);
 
   const memoizedStyles = useMemo(() => {
-    const stylesSource = imageToEdit?.customFieldStyles !== undefined
-      ? imageToEdit.customFieldStyles
-      : fieldStyles;
-    return JSON.parse(JSON.stringify(stylesSource || {}));
+    const baseStyles = JSON.parse(JSON.stringify(fieldStyles || {}));
+    const customStyles = imageToEdit?.customFieldStyles || {};
+
+    Object.keys(customStyles).forEach(field => {
+      baseStyles[field] = {
+        ...(baseStyles[field] || {}),
+        ...customStyles[field],
+      };
+    });
+
+    return baseStyles;
   }, [imageToEdit, fieldStyles]);
 
   const memoizedBrandElements = useMemo(() => {


### PR DESCRIPTION
This commit provides a definitive fix for a recurring bug where the image editor's preview did not accurately reflect an image's saved custom properties (including styles and positions).

The root cause was identified in the `MemoizedGeneratedImageEditor` component, which was performing a shallow, incorrect merge of template and custom properties before passing them to the editor. This resulted in custom properties being lost or overridden.

The fix refactors the logic in `MemoizedGeneratedImageEditor.jsx`:
1.  The `useMemo` hooks for styles and positions now perform a proper deep merge. They iterate over the custom properties for the specific image and layer them on top of the base template properties.
2.  This ensures that the `GeneratedImageEditor` component receives a single, correctly pre-merged set of props for both `initialFieldStyles` and `initialFieldPositions`.

As a result, the `GeneratedImageEditor.jsx` component has been simplified, as it no longer needs to handle complex merging logic. This change centralizes the responsibility for data preparation, making the code cleaner and resolving the entire class of preview discrepancy bugs.