### PR TITLE
Debug: Add console logging to editor components

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -97,10 +97,16 @@ const GeneratedImageEditor = ({
   };
 
   useEffect(() => {
+    console.log('[Editor] useEffect triggered. Open:', open);
     if (open && imageData && initialFieldPositions && initialFieldStyles) {
+      console.log('[Editor] Props received:', { initialFieldPositions, initialFieldStyles });
+
       const brands = JSON.parse(JSON.stringify(imageData.customBrandElements || brandElements || []));
 
       const positions = JSON.parse(JSON.stringify(initialFieldPositions));
+
+      console.log('[Editor] Positions to be used:', positions);
+
       // Defensively add filters to brand elements
       brands.forEach(el => {
         if (!el.filters) {
@@ -147,6 +153,8 @@ const GeneratedImageEditor = ({
           ...(initialFieldStyles?.[field] || {}),
         };
       });
+      console.log('[Editor] Styles to be used (after merging with default):', newEditedStyles);
+
       setEditedStyles(newEditedStyles);
       setStylesAreInitialized(true);
 

--- a/src/components/MemoizedGeneratedImageEditor.jsx
+++ b/src/components/MemoizedGeneratedImageEditor.jsx
@@ -20,9 +20,16 @@ const MemoizedGeneratedImageEditor = ({
     return generatedImages.find(img => img.index === editingGeneratedImageIndex);
   }, [generatedImages, editingGeneratedImageIndex]);
 
+  console.log('--- DEBUGGING START ---');
+  console.log('[Memoized] Image to Edit:', imageToEdit);
+
   const memoizedPositions = useMemo(() => {
+    console.log('[Memoized] Preparing POSITIONS...');
     const basePositions = JSON.parse(JSON.stringify(fieldPositions || {}));
     const customPositions = imageToEdit?.customFieldPositions || {};
+
+    console.log('[Memoized] Base Positions (Template):', basePositions);
+    console.log('[Memoized] Custom Positions (from Image):', customPositions);
 
     Object.keys(customPositions).forEach(field => {
       basePositions[field] = {
@@ -31,12 +38,17 @@ const MemoizedGeneratedImageEditor = ({
       };
     });
 
+    console.log('[Memoized] FINAL Merged Positions:', basePositions);
     return basePositions;
   }, [imageToEdit, fieldPositions]);
 
   const memoizedStyles = useMemo(() => {
+    console.log('[Memoized] Preparing STYLES...');
     const baseStyles = JSON.parse(JSON.stringify(fieldStyles || {}));
     const customStyles = imageToEdit?.customFieldStyles || {};
+
+    console.log('[Memoized] Base Styles (Template):', baseStyles);
+    console.log('[Memoized] Custom Styles (from Image):', customStyles);
 
     Object.keys(customStyles).forEach(field => {
       baseStyles[field] = {
@@ -45,6 +57,7 @@ const MemoizedGeneratedImageEditor = ({
       };
     });
 
+    console.log('[Memoized] FINAL Merged Styles:', baseStyles);
     return baseStyles;
   }, [imageToEdit, fieldStyles]);
 


### PR DESCRIPTION
This commit adds extensive console.log statements to `MemoizedGeneratedImageEditor.jsx` and `GeneratedImageEditor.jsx`.

This is a temporary debugging step to diagnose an issue where the editor preview does not correctly reflect the saved state of an image. The logs will provide insight into the props and state at the time the editor is initialized.

This commit is not intended to be a final solution and will be reverted once the root cause of the bug is identified.