### PR TITLE
feat: Improve campaign editing UI

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -25,7 +25,6 @@ import {
   Tabs,
   Tab,
 } from '@mui/material';
-import { toast } from 'sonner';
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { getCampaignPrompt } from '../utils/campaignPrompt';
 import { useSettings } from '../context/SettingsContext';
@@ -183,7 +182,7 @@ const Campaign = ({
     setCampaignContent,
     onEditFollowup,
 }) => {
-    const { settings } = useSettings();
+    useSettings();
     const [activeTab, setActiveTab] = useState(0);
     const [isHintModalOpen, setHintModalOpen] = React.useState(false);
     const [isSolucaoHintModalOpen, setSolucaoHintModalOpen] = React.useState(false);
@@ -352,7 +351,7 @@ const Campaign = ({
                 </Typography>
 
                 <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                    <Tabs value={activeTab} onChange={handleTabChange} aria-label="abas da campanha">
+                    <Tabs value={activeTab} onChange={handleTabChange} aria-label="abas da campanha" variant="scrollable" scrollButtons="auto">
                         <Tab label="Problema e Solução" />
                         <Tab label="Conteúdo Principal" disabled={!campaignContent} />
                         <Tab label="Imagem" disabled={!campaignContent} />
@@ -581,7 +580,7 @@ const Campaign = ({
                                             </Button>
                                         </Box>
                                     </Box>
-                                    <img src={generatedImageUrl} alt="Imagem gerada pela IA" style={{ maxWidth: '100%', borderRadius: '8px', mt: 2 }} />
+                                    <img src={generatedImageUrl} alt="Imagem gerada pela IA" style={{ maxWidth: '100%', maxHeight: '70vh', objectFit: 'contain', borderRadius: '8px', marginTop: 2 }} />
                                 </Box>
                             )}
                             {isGeneratingImage && (

--- a/src/components/TextEditor.jsx
+++ b/src/components/TextEditor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdvancedEditor from './AdvancedEditor';
 import InlineEditor from './InlineEditor';
-import { TextField } from '@mui/material';
+import { TextField, Box, Typography } from '@mui/material';
 
 const TextEditor = ({ value, onChange, html = false, variant = 'full', ...props }) => {
   if (html) {
@@ -11,16 +11,35 @@ const TextEditor = ({ value, onChange, html = false, variant = 'full', ...props 
     return <AdvancedEditor value={value} onChange={onChange} html={html} {...props} />;
   }
 
+  const characterCount = value ? value.length : 0;
+
   return (
-    <TextField
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      multiline
-      rows={10}
-      fullWidth
-      variant="outlined"
-      {...props}
-    />
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <TextField
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        multiline
+        fullWidth
+        variant="outlined"
+        {...props}
+        sx={{
+          flexGrow: 1,
+          '& .MuiInputBase-root': {
+            height: '100%',
+            alignItems: 'flex-start',
+          },
+          '& .MuiInputBase-input': {
+            height: '100% !important',
+            overflowY: 'auto !important',
+          }
+        }}
+      />
+      <Box sx={{ textAlign: 'right', py: 0.5, px: 1.5 }}>
+        <Typography variant="caption" color="textSecondary">
+          {characterCount} caracteres
+        </Typography>
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION
This commit addresses several UI improvements in the campaign editing interface.

- **Text Editor:** The text editor now expands to use the full available vertical space, and a character counter has been added to provide feedback on content length.
- **Image Display:** The campaign image's height is now limited to 70% of the viewport height, preventing it from causing the main screen to scroll. The aspect ratio is preserved.
- **Tabs:** The tab bar in the campaign editor is now scrollable, ensuring all tabs are accessible even when they overflow the screen width.