### PR TITLE
feat: Improve campaign editing UI

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -568,7 +568,7 @@ const Campaign = ({
                             </Grid>
                             {imageTabError && <Grid item xs={12}><Alert severity="error">{imageTabError}</Alert></Grid>}
                             {generatedImageUrl && !isGeneratingImage && (
-                                <Box>
+                                <Box sx={{ maxWidth: '600px', margin: 'auto' }}>
                                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 2, flexWrap: 'wrap', gap: 1 }}>
                                         <Typography variant="h6" gutterBottom>Imagem Gerada</Typography>
                                         <Box>


### PR DESCRIPTION
This commit addresses several UI improvements in the campaign editing interface.

- **Text Editor:** The text editor now expands to use the full available vertical space, and a character counter has been added to provide feedback on content length.
- **Image Display:** The campaign image's height is now limited to 70% of the viewport height, and its container is constrained to a maximum width of 600px to prevent it from becoming too large on wide screens. The aspect ratio is preserved.
- **Tabs:** The tab bar in the campaign editor is now scrollable, ensuring all tabs are accessible even when they overflow the screen width.

This also includes a fix to constrain the image container width to better control its size on large screens.