### PR TITLE
fix: Ensure consistent font scaling in generated image editor

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -60,7 +60,8 @@ const GeneratedImageEditor = ({
   globalBackgroundImage, // Imagem de fundo global, como fallback
   originalImageSize,
   imageFilters, // Adicionado
-  brandElements
+  brandElements,
+  fontScale: propFontScale = 1
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
   const [editedStyles, setEditedStyles] = useState({});
@@ -151,11 +152,11 @@ const GeneratedImageEditor = ({
       setStylesAreInitialized(true);
 
       setEditedImageFilters(imageFilters || defaultFilters);
-      setFontScale(imageData.fontScale || 1); // Initialize font scale from imageData
+      setFontScale(propFontScale); // Initialize font scale from the prop
     } else {
       setStylesAreInitialized(false);
     }
-  }, [open, imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, brandElements]);
+  }, [open, imageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, brandElements, propFontScale]);
 
   if (!imageData) {
     return null;

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -66,6 +66,8 @@ const ImageGeneratorFrontendOnly = ({
   const [selectedPreview, setSelectedPreview] = useState(null);
   const [editingGeneratedImageIndex, setEditingGeneratedImageIndex] = useState(null);
   const [showGeneratedImageEditor, setShowGeneratedImageEditor] = useState(false);
+  const editingImage = generatedImages.find(img => img.index === editingGeneratedImageIndex);
+  const fontScaleForEditor = editingImage?.fontScale || fontScale;
   const { googleAccessToken } = useUserAuth();
   const isGoogleDriveConnected = !!googleAccessToken;
   const [projectName, setProjectName] = useState('');
@@ -743,6 +745,7 @@ const ImageGeneratorFrontendOnly = ({
         backgroundImage={backgroundImage}
         originalImageSize={originalImageSize}
         imageFilters={imageFilters}
+        fontScale={fontScaleForEditor}
       />
 
       <input


### PR DESCRIPTION
The previous implementation caused a visual distortion where text fields would appear proportionally larger in the editor view compared to the thumbnail view, especially on mobile. This was because the editor would recalculate its own font scale based on the dimensions of the dialog, which often differed from the scale used to generate the original thumbnail.

This commit fixes the issue by ensuring the editor is initialized with the correct font scale. The logic now prioritizes the specific `fontScale` saved on the individual image data and falls back to the global `fontScale` if a specific one is not present. This value is then passed as a prop to the editor, ensuring a consistent rendering between the thumbnail and the editor view, and preventing the distorted scale from being saved.