### PR TITLE
fix: Unify scaling and precision in preview and final render

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -214,10 +214,10 @@ export const composeSingleImage = async ({
 
         ctx.save();
         const posPx = {
-            x: Math.round((position.x / 100) * finalCanvas.width),
-            y: Math.round((position.y / 100) * finalCanvas.height),
-            width: Math.round((position.width / 100) * finalCanvas.width),
-            height: Math.round((position.height / 100) * finalCanvas.height)
+            x: (position.x / 100) * finalCanvas.width,
+            y: (position.y / 100) * finalCanvas.height,
+            width: (position.width / 100) * finalCanvas.width,
+            height: (position.height / 100) * finalCanvas.height
         };
 
         if (position.rotation) {


### PR DESCRIPTION
This commit addresses a series of visual discrepancies between the editor preview and the final rendered image, ensuring a consistent, what-you-see-is-what-you-get (WYSIWYG) experience.

The following issues have been resolved:

1.  **Inconsistent Scaling:** The preview renderer (`DraggableElement.jsx`) now scales all pixel-based style properties (`padding`, `borderRadius`, `borderWidth`, `textShadow`, `strokeWidth`) by the `fontScale` factor. This makes them visually proportional to the scaled `fontSize`.

2.  **Incorrect Final Render Logic:** The final renderer (`imageComposer.js`) was using incorrect logic that divided these same style properties by `fontScale`. This logic has been removed. The renderer now correctly uses the direct, unscaled values from the style objects for all properties, including `fontSize`, `padding`, etc.

3.  **Rounding Discrepancies:** The final renderer was rounding position and dimension calculations to the nearest pixel (`Math.round()`), while the CSS preview used more precise sub-pixel rendering. This could cause a slight mismatch in appearance. The `Math.round()` calls have been removed to allow for more precise floating-point calculations in the final render, bringing it into closer alignment with the preview.