### PR TITLE
The "Reset Style" button in the property panel now correctly reverts …

### DIFF
--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -8,6 +8,7 @@ const FormattingDrawer = ({
   onClose,
   selectedField,
   fieldStyles,
+  initialFieldStyles,
   setFieldStyles,
   fieldPositions,
   setFieldPositions,
@@ -34,6 +35,7 @@ const FormattingDrawer = ({
         <FormattingPanel
           selectedField={selectedField}
           fieldStyles={fieldStyles}
+          initialFieldStyles={initialFieldStyles}
           setFieldStyles={setFieldStyles}
           fieldPositions={fieldPositions}
           setFieldPositions={setFieldPositions}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -55,6 +55,7 @@ import BrandElementManager from './BrandElementManager';
 const FormattingPanel = ({
   selectedField,
   fieldStyles,
+  initialFieldStyles,
   setFieldStyles,
   fieldPositions,
   setFieldPositions,
@@ -101,19 +102,30 @@ const FormattingPanel = ({
   };
 
   const resetFieldStyle = (field) => {
-    const defaultStyle = {
-      fontFamily: 'Arial', fontSize: 24, fontWeight: 'normal', fontStyle: 'normal', textDecoration: 'none',
-      color: '#000000', textStroke: false, strokeColor: '#ffffff', strokeWidth: 2, textShadow: false,
-      shadowColor: '#000000', shadowBlur: 4, shadowOffsetX: 2, shadowOffsetY: 2,
-      textAlign: 'left', verticalAlign: 'top',
-      backgroundColor: 'rgba(0,0,0,0)',
-      borderColor: '#000000',
-      borderWidth: 0,
-      borderRadius: 0,
-      padding: 5,
-      backgroundOpacity: 1,
-    };
-    setFieldStyles(prev => ({ ...prev, [field]: defaultStyle }));
+    // Busca o estilo inicial para este campo específico
+    const initialStyle = initialFieldStyles?.[field];
+
+    if (initialStyle) {
+      // Se encontrou, aplica o estilo inicial
+      setFieldStyles(prev => ({ ...prev, [field]: initialStyle }));
+    } else {
+      // Fallback para o caso de não encontrar o estilo inicial (não deve acontecer)
+      console.warn(`[FormattingPanel] Estilo inicial para o campo "${field}" não encontrado. O reset pode não funcionar como esperado.`);
+      // Opcionalmente, pode-se manter o reset para um default genérico aqui
+      const defaultStyle = {
+        fontFamily: 'Arial', fontSize: 24, fontWeight: 'normal', fontStyle: 'normal', textDecoration: 'none',
+        color: '#000000', textStroke: false, strokeColor: '#ffffff', strokeWidth: 2, textShadow: false,
+        shadowColor: '#000000', shadowBlur: 4, shadowOffsetX: 2, shadowOffsetY: 2,
+        textAlign: 'left', verticalAlign: 'top',
+        backgroundColor: 'rgba(0,0,0,0)',
+        borderColor: '#000000',
+        borderWidth: 0,
+        borderRadius: 0,
+        padding: 5,
+        backgroundOpacity: 1,
+      };
+      setFieldStyles(prev => ({ ...prev, [field]: defaultStyle }));
+    }
   };
 
   const updateBrandElementFilter = (elementId, filterProperty, value) => {

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -32,6 +32,7 @@ const ImageStep = ({
   fieldPositions,
   setFieldPositions,
   fieldStyles,
+  initialFieldStyles,
   setFieldStyles,
   csvData,
   onImageDisplayedSizeChange,
@@ -179,6 +180,7 @@ const ImageStep = ({
             <FormattingPanel
               selectedField={selectedField}
               fieldStyles={fieldStyles}
+              initialFieldStyles={initialFieldStyles}
               setFieldStyles={setFieldStyles}
               fieldPositions={fieldPositions}
               setFieldPositions={setFieldPositions}
@@ -202,6 +204,7 @@ const ImageStep = ({
               onClose={() => setIsDrawerOpen(false)}
               selectedField={selectedField}
               fieldStyles={fieldStyles}
+              initialFieldStyles={initialFieldStyles}
               setFieldStyles={setFieldStyles}
               fieldPositions={fieldPositions}
               setFieldPositions={setFieldPositions}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -120,6 +120,7 @@ function HomePage() {
   const [isFetchingCampaigns, setIsFetchingCampaigns] = useState(true);
   const [fieldPositions, setFieldPositions] = useState({});
   const [fieldStyles, setFieldStyles] = useState({});
+  const [initialFieldStyles, setInitialFieldStyles] = useState({});
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
   const [originalImageSize, setOriginalImageSize] = useState({ width: 0, height: 0 });
   const [generatedImagesData, setGeneratedImagesData] = useState([]);
@@ -220,6 +221,7 @@ function HomePage() {
       });
     }
     setFieldStyles(completeStyles);
+    setInitialFieldStyles(completeStyles); // Salvar o estado inicial
 
     setDisplayedImageSize(state.displayedImageSize ?? { width: 0, height: 0 });
     setOriginalImageSize(state.originalImageSize ?? { width: 0, height: 0 });
@@ -477,6 +479,7 @@ function HomePage() {
 
         setFieldPositions(newPositions);
         setFieldStyles(newStyles);
+        setInitialFieldStyles(newStyles); // Salvar o estado inicial
         setInputMethod('manual');
       }
     } catch (error) {
@@ -622,6 +625,7 @@ function HomePage() {
     });
     setFieldPositions(updatedFieldPositions);
     setFieldStyles(updatedFieldStyles);
+    setInitialFieldStyles(updatedFieldStyles);
 
     // When rebuilding the generatedImagesData array due to a change in the number of records,
     // we must check if a specific background image already exists for that index in the *previous*
@@ -847,6 +851,7 @@ function HomePage() {
       setCsvHeaders(csvHeadersResult);
       setFieldPositions(updatedFieldPositions);
       setFieldStyles(updatedFieldStyles);
+      setInitialFieldStyles(updatedFieldStyles); // Salvar o estado inicial
       setGeneratedImagesData(newGeneratedImagesData);
       setInputMethod('manual');
 
@@ -952,6 +957,7 @@ function HomePage() {
               fieldPositions={fieldPositions}
               setFieldPositions={setFieldPositions}
               fieldStyles={fieldStyles}
+              initialFieldStyles={initialFieldStyles}
               setFieldStyles={setFieldStyles}
               csvData={csvData}
               onImageDisplayedSizeChange={setDisplayedImageSize}


### PR DESCRIPTION
…a field's style to its initial state from the template, rather than a hardcoded default. This is achieved by storing the initial styles when a template is loaded and using them for the reset operation.