### PR TITLE
feat: Implement context-aware style reset for fields

### DIFF
--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -22,6 +22,8 @@ const FormattingDrawer = ({
   onOpenHtmlEditor,
   isHtmlField,
   standardsColors,
+  templateFieldStyles,
+  activeStep,
 }) => {
   return (
     <Drawer anchor="right" open={open} onClose={onClose} sx={{ zIndex: 1400 }}>
@@ -49,6 +51,8 @@ const FormattingDrawer = ({
           onOpenHtmlEditor={onOpenHtmlEditor}
           isHtmlField={isHtmlField}
           standardsColors={standardsColors}
+          templateFieldStyles={templateFieldStyles}
+          activeStep={activeStep}
         />
       </Box>
     </Drawer>

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -68,6 +68,8 @@ const FormattingPanel = ({
   onDeselectField,
   onOpenHtmlEditor,
   standardsColors,
+  templateFieldStyles,
+  activeStep,
 }) => {
   const fonts = [
     // Sans-serif
@@ -102,29 +104,27 @@ const FormattingPanel = ({
   };
 
   const resetFieldStyle = (field) => {
-    // Busca o estilo inicial para este campo específico
-    const initialStyle = initialFieldStyles?.[field];
+    let styleToApply = null;
 
-    if (initialStyle) {
-      // Se encontrou, aplica o estilo inicial
-      setFieldStyles(prev => ({ ...prev, [field]: initialStyle }));
+    // Se estamos em um passo posterior à formatação (step 3), usamos o template salvo.
+    if (activeStep > 3 && templateFieldStyles && Object.keys(templateFieldStyles).length > 0) {
+      styleToApply = templateFieldStyles[field];
+      if (!styleToApply) {
+        console.warn(`[FormattingPanel] Estilo de template para o campo "${field}" não encontrado. Usando fallback para estilo inicial.`);
+      }
+    }
+
+    // Se não aplicamos o estilo do template (ou se falhou), usamos o estilo inicial.
+    // Isso cobre o caso de estarmos no passo 3, ou o fallback do passo > 3.
+    if (!styleToApply) {
+      styleToApply = initialFieldStyles?.[field];
+    }
+
+    if (styleToApply) {
+      setFieldStyles(prev => ({ ...prev, [field]: styleToApply }));
     } else {
-      // Fallback para o caso de não encontrar o estilo inicial (não deve acontecer)
-      console.warn(`[FormattingPanel] Estilo inicial para o campo "${field}" não encontrado. O reset pode não funcionar como esperado.`);
-      // Opcionalmente, pode-se manter o reset para um default genérico aqui
-      const defaultStyle = {
-        fontFamily: 'Arial', fontSize: 24, fontWeight: 'normal', fontStyle: 'normal', textDecoration: 'none',
-        color: '#000000', textStroke: false, strokeColor: '#ffffff', strokeWidth: 2, textShadow: false,
-        shadowColor: '#000000', shadowBlur: 4, shadowOffsetX: 2, shadowOffsetY: 2,
-        textAlign: 'left', verticalAlign: 'top',
-        backgroundColor: 'rgba(0,0,0,0)',
-        borderColor: '#000000',
-        borderWidth: 0,
-        borderRadius: 0,
-        padding: 5,
-        backgroundOpacity: 1,
-      };
-      setFieldStyles(prev => ({ ...prev, [field]: defaultStyle }));
+      // Se nenhum estilo foi encontrado, loga um erro.
+      console.error(`[FormattingPanel] Nenhum estilo (inicial ou de template) encontrado para o campo "${field}". O reset não pode ser executado.`);
     }
   };
 

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -53,6 +53,8 @@ const ImageStep = ({
   isHtmlField,
   currentPreviewIndex,
   setCurrentPreviewIndex,
+  templateFieldStyles,
+  activeStep,
 }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [fontScale, setFontScale] = useState(1);
@@ -194,6 +196,8 @@ const ImageStep = ({
               onOpenHtmlEditor={onOpenHtmlEditor}
               standardsColors={standardsColors}
               fontScale={fontScale}
+              templateFieldStyles={templateFieldStyles}
+              activeStep={activeStep}
             />
           </Grid>
         ) : (
@@ -218,6 +222,8 @@ const ImageStep = ({
               onOpenHtmlEditor={onOpenHtmlEditor}
               standardsColors={standardsColors}
               fontScale={fontScale}
+              templateFieldStyles={templateFieldStyles}
+              activeStep={activeStep}
             />
           </>
         )}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -121,6 +121,7 @@ function HomePage() {
   const [fieldPositions, setFieldPositions] = useState({});
   const [fieldStyles, setFieldStyles] = useState({});
   const [initialFieldStyles, setInitialFieldStyles] = useState({});
+  const [templateFieldStyles, setTemplateFieldStyles] = useState({});
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
   const [originalImageSize, setOriginalImageSize] = useState({ width: 0, height: 0 });
   const [generatedImagesData, setGeneratedImagesData] = useState([]);
@@ -199,6 +200,7 @@ function HomePage() {
     setPromptNumRecords(state.promptNumRecords ?? 10);
     setPromptText(state.promptText ?? '');
     setFieldPositions(state.fieldPositions ?? {});
+    setTemplateFieldStyles(state.templateFieldStyles ?? {});
 
     // Ensure loaded fieldStyles are complete with all default values.
     const loadedStyles = state.fieldStyles ?? {};
@@ -257,6 +259,7 @@ function HomePage() {
       followupPostsQuantity,
       fieldPositions,
       fieldStyles,
+      templateFieldStyles,
       imageFilters,
       brandElements,
       backgroundImage,
@@ -572,7 +575,13 @@ function HomePage() {
   const handleImageDragOver = (event) => { event.preventDefault(); event.stopPropagation(); };
   const handleImageDragEnter = (event) => { event.preventDefault(); event.stopPropagation(); setIsDraggingOverImage(true); };
   const handleImageDragLeave = (event) => { event.preventDefault(); event.stopPropagation(); setIsDraggingOverImage(false); };
-  const handleNext = () => { setActiveStep((prevActiveStep) => prevActiveStep + 1); };
+  const handleNext = () => {
+    if (activeStep === 3) {
+      console.log("[HomePage] Snapshotting styles from step 3 to templateFieldStyles");
+      setTemplateFieldStyles(fieldStyles);
+    }
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
+  };
   const handleBack = () => { setActiveStep((prevActiveStep) => prevActiveStep - 1); };
   const canProceedToStep = (step) => {
     switch (step) {
@@ -982,6 +991,8 @@ function HomePage() {
               currentPreviewIndex={currentPreviewIndex}
               setCurrentPreviewIndex={setCurrentPreviewIndex}
               onFontScaleChange={setFontScale}
+              templateFieldStyles={templateFieldStyles}
+              activeStep={activeStep}
             />
           </div>
           <div hidden={activeStep !== 4}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} standardsColors={standardsColors} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} fontScale={fontScale} /></div>


### PR DESCRIPTION
The "Reset Style" button now behaves differently based on the user's current step in the campaign creation process.

- When editing the template (Step 3), resetting a field reverts its style to the state it was in when the step was first loaded.
- In subsequent steps (e.g., generating images), resetting a field reverts its style to the final configuration that was saved upon completing Step 3.

This is achieved by introducing two state variables: `initialFieldStyles` to capture the initial state for Step 3, and `templateFieldStyles` to snapshot the styles upon leaving Step 3.