### PR TITLE
feat: Improve content and style reset logic

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -835,25 +835,15 @@ function HomePage() {
         standardsColors,
       });
 
-      // Create the new image data array, preserving backgrounds from the previous state
-      const newGeneratedImagesData = csvDataResult.map((record, index) => {
-        const existingImage = generatedImagesData.find(img => img.index === index);
-        if (existingImage) {
-          return {
-            ...existingImage,
-            record: record, // Update the record with new text
-          };
-        }
-        // For new records, fall back to the global background
-        return {
-          index,
-          record,
-          blob: null,
-          url: null,
-          filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
-          backgroundImage: backgroundImage,
-        };
-      });
+      // Create a fresh image data array, discarding any previous state.
+      const newGeneratedImagesData = csvDataResult.map((record, index) => ({
+        index,
+        record,
+        blob: null,
+        url: null,
+        filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
+        backgroundImage: backgroundImage, // Always use the global background for new items
+      }));
 
       // Set all states together
       setCsvData(csvDataResult);


### PR DESCRIPTION
This commit introduces two main improvements to the content and style reset functionalities based on user feedback.

1.  The "Reset Style" button is now context-aware. It resets to the initial loaded styles when editing the template (Step 3) and resets to the finalized template styles in subsequent steps.

2.  Generating new content with AI in the "Short Posts" step now completely discards all previous posts and their associated data, ensuring a clean slate with the new content.