### PR TITLE
Fix: Prevent flickering in image generation screen

### DIFF
--- a/src/components/GeneratedImageEditor.jsx
+++ b/src/components/GeneratedImageEditor.jsx
@@ -161,15 +161,26 @@ const GeneratedImageEditor = ({
   }
 
   const handleSave = () => {
-    onSave({
-      ...imageData, // Keeps original data like index
-      record: editedRecord, // Passes the updated record
-      backgroundImage: currentBackgroundImageForEditor, // Explicitly pass back the background being used
+    // Construct a new object explicitly to avoid propagating stale props from imageData
+    const savedData = {
+      // Core identifiers from the original imageData that should not change
+      index: imageData.index,
+      blob: imageData.blob,
+      url: imageData.url,
+      filename: imageData.filename,
+
+      // The state that was actually edited in this component
+      record: editedRecord,
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
+      imageFilters: editedImageFilters, // Pass back the edited filters
       fontScale: fontScale,
-    });
+
+      // Explicitly set the background image that was used for editing
+      backgroundImage: currentBackgroundImageForEditor,
+    };
+    onSave(savedData);
     onClose();
   };
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -653,7 +653,8 @@ function HomePage() {
             }
 
             // If no image exists for this index (e.g., a new row was added),
-            // create a new image data object using the global background.
+            // create a new, complete image data object using the global background
+            // and default values to prevent state instability and flickering.
             return {
                 index,
                 record,
@@ -661,6 +662,12 @@ function HomePage() {
                 url: null,
                 filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
                 backgroundImage: backgroundImage, // Use global background for new rows
+                // Initialize all custom properties to null to ensure a consistent object shape
+                customFieldPositions: null,
+                customFieldStyles: null,
+                customBrandElements: null,
+                customImageFilters: null,
+                fontScale: 1,
             };
         });
         return newGeneratedImages;
@@ -805,7 +812,6 @@ function HomePage() {
     setGeneratedImageUrl(null);
     setConteudoMedio('');
     setConteudoPequeno('');
-    setConteudoFormatado('');
     setFollowupPosts([]);
     setFollowupPostsQuantity(5);
   };
@@ -836,6 +842,7 @@ function HomePage() {
       });
 
       // Create a fresh image data array, discarding any previous state.
+      // Initialize with a complete, stable object shape to prevent flickering.
       const newGeneratedImagesData = csvDataResult.map((record, index) => ({
         index,
         record,
@@ -843,6 +850,12 @@ function HomePage() {
         url: null,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
         backgroundImage: backgroundImage, // Always use the global background for new items
+        // Initialize all custom properties to null to ensure a consistent object shape
+        customFieldPositions: null,
+        customFieldStyles: null,
+        customBrandElements: null,
+        customImageFilters: null,
+        fontScale: 1,
       }));
 
       // Set all states together


### PR DESCRIPTION
This commit addresses a flickering issue that occurred in the 'Generate Images' step.

The root cause was that when a user generated short posts without AI images, the corresponding `generatedImagesData` objects were created with an incomplete set of properties. When the `ImageGeneratorFrontendOnly` component received this incomplete data, it would get caught in a re-rendering loop while trying to generate thumbnails, causing the UI to flicker.

The fix ensures that when `generatedImagesData` objects are created in `HomePage.jsx` (in both `handleDadosAlterados` and `handleGenerateIAContent`), they are initialized with a complete and stable set of default properties (e.g., `customFieldStyles: null`). This prevents the unstable state and eliminates the flickering.

Additionally, the `handleSave` function in `GeneratedImageEditor.jsx` was refactored to be more explicit and robust, preventing potential future bugs related to stale data. A minor linting error (`setConteudoFormatado` was not defined) was also fixed in `HomePage.jsx`.