### PR TITLE
fix: Add missing MenuItem import to HomePage

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {
-  Container, Paper, Typography, Box, Button, Grid, Card, CardContent, Alert, Stepper, Step, StepLabel, StepContent, Chip, IconButton, Tooltip, ToggleButton, ToggleButtonGroup, TextField, Link as MuiLink, Fab, FormControl, InputLabel, Select, Accordion, AccordionSummary, AccordionDetails, Toolbar,
+  Container, Paper, Typography, Box, Button, Grid, Card, CardContent, Alert, Stepper, Step, StepLabel, StepContent, Chip, IconButton, Tooltip, ToggleButton, ToggleButtonGroup, TextField, Link as MuiLink, Fab, FormControl, InputLabel, Select, Accordion, AccordionSummary, AccordionDetails, Toolbar, MenuItem,
 } from '@mui/material';
 import {
   CloudUpload, ExpandMore as ExpandMoreIcon, FileUpload, Settings, Image as ImageIcon, Movie, Audiotrack, Palette, ArrowBackIosNew, ArrowForwardIos, MoreVert, Brightness4, Brightness7, Edit, Download as DownloadIcon, CloudQueue, ChevronRight, ChevronLeft, Check, Add, InsertDriveFileOutlined, FormatBold, Visibility, Grid3x3, Campaign as CampaignIcon, AspectRatio, Language, Publish, SaveAlt as SaveAltIcon, FileUpload as FileUploadIcon, FolderOpen as FolderOpenIcon, BarChart


### PR DESCRIPTION
This commit fixes a runtime ReferenceError caused by using the MenuItem component in the new persona selector without importing it from @mui/material.

feat: Refactor persona management to database

Moves persona data from `localStorage` to a dedicated `personas` table in the database.

- Creates a new API for CRUD operations on personas.
- Introduces a new page for managing personas, including creation, editing, and deletion.
- Updates the campaign creation workflow to allow associating a campaign with a persona.
- Campaigns now store a `persona_id` instead of duplicating persona data.
- Content generation prompts are now conditionally updated with persona information if a persona is associated with the campaign.
- The application now warns the user if a campaign does not have an associated persona but does not block content creation.