### PR TITLE
refactor: Change Personas page to a master-detail UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
+import { toast } from 'sonner';
 
 // Pages
 import HomePage from './pages/HomePage';
@@ -12,7 +13,49 @@ import PersonasPage from './pages/PersonasPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 
+// Utils
+import { savePersona } from './utils/personaState';
+
 function App() {
+  useEffect(() => {
+    const migrateOldPersona = async () => {
+      const MIGRATION_KEY = 'persona_migration_v2_done';
+      if (localStorage.getItem(MIGRATION_KEY)) {
+        return;
+      }
+
+      const storedData = localStorage.getItem('campaignPrompt');
+      if (storedData) {
+        try {
+          const parsedData = JSON.parse(storedData);
+          // Check for a valid persona object to migrate
+          if (parsedData && parsedData.persona && parsedData.persona.nome) {
+            console.log("Found old persona data. Attempting to migrate...");
+
+            // The persona data is nested inside the 'persona' key
+            const personaToMigrate = parsedData.persona;
+
+            // Use the 'nome' from inside the persona object as the top-level name
+            await savePersona(personaToMigrate.nome, personaToMigrate);
+
+            toast.success("Sua persona antiga foi migrada para o novo sistema com sucesso!");
+            console.log("Persona migration successful.");
+          }
+        } catch (e) {
+          console.error("Could not parse old campaign prompt for migration, or migration failed.", e);
+        } finally {
+          // Set the flag regardless of success to prevent retrying on corrupted data or failed saves.
+          localStorage.setItem(MIGRATION_KEY, 'true');
+        }
+      } else {
+        // No old data found, so we can set the flag and not check again.
+        localStorage.setItem(MIGRATION_KEY, 'true');
+      }
+    };
+
+    migrateOldPersona();
+  }, []); // Empty dependency array ensures this runs only once on mount
+
   return (
     <Routes>
       {/* Public Routes */}

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -6,25 +6,26 @@ import {
   List,
   ListItem,
   ListItemText,
+  ListItemButton,
   IconButton,
   CircularProgress,
   Alert,
   Box,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
+  Grid,
+  Paper,
+  Divider,
+  Stack
 } from '@mui/material';
-import { Edit, Delete, Add } from '@mui/icons-material';
+import { Delete, Add } from '@mui/icons-material';
 import { getPersonas, savePersona, updatePersona, deletePersona } from '../utils/personaState';
 import PersonaForm, { emptyPersonaData } from '../components/PersonaForm';
+import { toast } from 'sonner';
 
 const PersonasPage = () => {
   const [personas, setPersonas] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [currentPersona, setCurrentPersona] = useState(null);
+  const [selectedPersona, setSelectedPersona] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
@@ -44,45 +45,39 @@ const PersonasPage = () => {
     }
   };
 
-  const handleOpenModal = (persona = null) => {
-    if (persona) {
-      setCurrentPersona({ ...persona });
-    } else {
-      // For a new persona, we create the structure the DB expects,
-      // with the actual detailed data inside `persona_data`.
-      setCurrentPersona({ name: '', persona_data: { ...emptyPersonaData } });
-    }
-    setIsModalOpen(true);
+  const handleSelectPersona = (persona) => {
+    setSelectedPersona(persona);
   };
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-    setCurrentPersona(null);
+  const handleNewPersona = () => {
+    setSelectedPersona({ name: '', persona_data: { ...emptyPersonaData } });
   };
 
-  const handlePersonaFormChange = (newPersonaData) => {
-    setCurrentPersona(prev => ({
-        ...prev,
-        // The name of the persona record is synced with the 'nome' field in the data
-        name: newPersonaData.nome,
-        persona_data: newPersonaData,
+  const handleFormChange = (newPersonaData) => {
+    setSelectedPersona(prev => ({
+      ...prev,
+      name: newPersonaData.nome,
+      persona_data: newPersonaData,
     }));
   };
 
   const handleSave = async () => {
-    if (!currentPersona?.name) {
-      alert('O nome da persona é obrigatório.');
+    if (!selectedPersona?.name) {
+      toast.error('O nome da persona é obrigatório.');
       return;
     }
     setIsSaving(true);
     try {
-      if (currentPersona.id) {
-        await updatePersona(currentPersona.id, currentPersona.name, currentPersona.persona_data);
+      let savedPersona;
+      if (selectedPersona.id) {
+        savedPersona = await updatePersona(selectedPersona.id, selectedPersona.name, selectedPersona.persona_data);
       } else {
-        await savePersona(currentPersona.name, currentPersona.persona_data);
+        savedPersona = await savePersona(selectedPersona.name, selectedPersona.persona_data);
       }
       await fetchPersonas();
-      handleCloseModal();
+      // After saving, update the selected persona to the one returned from the API
+      // This ensures we have the correct ID for new personas and any other server-side updates
+      setSelectedPersona(savedPersona);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -90,11 +85,16 @@ const PersonasPage = () => {
     }
   };
 
-  const handleDelete = async (id) => {
-    if (window.confirm('Tem certeza que deseja deletar esta persona?')) {
+  const handleDelete = async () => {
+    if (!selectedPersona || !selectedPersona.id) {
+        toast.warning("Nenhuma persona selecionada para deletar.");
+        return;
+    }
+    if (window.confirm(`Tem certeza que deseja deletar a persona "${selectedPersona.name}"?`)) {
       try {
-        await deletePersona(id);
+        await deletePersona(selectedPersona.id);
         await fetchPersonas();
+        setSelectedPersona(null); // Clear the form
       } catch (err) {
         setError(err.message);
       }
@@ -104,76 +104,85 @@ const PersonasPage = () => {
   const getSecondaryText = (persona) => {
     if (!persona.persona_data) return '...';
     const { posicaoCargo, segmentoEmpresa } = persona.persona_data;
-    let text = [];
-    if (posicaoCargo && posicaoCargo.length > 0) {
-      text.push(posicaoCargo.join(', '));
-    }
-    if (segmentoEmpresa && segmentoEmpresa.length > 0) {
-      text.push(segmentoEmpresa.join(', '));
-    }
+    const text = [
+        ...(posicaoCargo && posicaoCargo.length > 0 ? [posicaoCargo.join(', ')] : []),
+        ...(segmentoEmpresa && segmentoEmpresa.length > 0 ? [segmentoEmpresa.join(', ')] : [])
+    ];
     if (text.length === 0) return 'Sem detalhes adicionais.';
-
     const fullText = text.join(' | ');
-    return fullText.length > 100 ? fullText.substring(0, 100) + '...' : fullText;
-  }
+    return fullText.length > 80 ? fullText.substring(0, 80) + '...' : fullText;
+  };
 
   return (
-    <Container maxWidth="md" sx={{ mt: 4 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h4" component="h1">
-          Personas
-        </Typography>
-        <Button variant="contained" startIcon={<Add />} onClick={() => handleOpenModal()}>
-          Nova Persona
-        </Button>
-      </Box>
+    <Container maxWidth="xl" sx={{ mt: 4 }}>
+      <Grid container spacing={3}>
+        {/* Left Column: Persona List */}
+        <Grid item xs={12} md={4}>
+          <Paper elevation={2} sx={{ p: 2, height: '100%' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+              <Typography variant="h6" component="h2">
+                Personas
+              </Typography>
+              <Button variant="contained" size="small" startIcon={<Add />} onClick={handleNewPersona}>
+                Nova
+              </Button>
+            </Box>
+            <Divider />
+            {loading && <CircularProgress />}
+            {error && <Alert severity="error">{error}</Alert>}
+            {!loading && !error && (
+              <List>
+                {personas.map((persona) => (
+                  <ListItemButton
+                    key={persona.id}
+                    selected={selectedPersona?.id === persona.id}
+                    onClick={() => handleSelectPersona(persona)}
+                  >
+                    <ListItemText
+                      primary={persona.name}
+                      secondary={getSecondaryText(persona)}
+                    />
+                  </ListItemButton>
+                ))}
+              </List>
+            )}
+          </Paper>
+        </Grid>
 
-      {loading && <CircularProgress />}
-      {error && <Alert severity="error">{error}</Alert>}
-
-      {!loading && !error && (
-        <List>
-          {personas.map((persona) => (
-            <ListItem
-              key={persona.id}
-              secondaryAction={
-                <>
-                  <IconButton edge="end" aria-label="edit" onClick={() => handleOpenModal(persona)}>
-                    <Edit />
-                  </IconButton>
-                  <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(persona.id)}>
-                    <Delete />
-                  </IconButton>
-                </>
-              }
-            >
-              <ListItemText
-                primary={persona.name}
-                secondary={getSecondaryText(persona)}
-              />
-            </ListItem>
-          ))}
-        </List>
-      )}
-
-      {isModalOpen && (
-        <Dialog open={isModalOpen} onClose={handleCloseModal} fullWidth maxWidth="md">
-          <DialogTitle>{currentPersona?.id ? 'Editar Persona' : 'Nova Persona'}</DialogTitle>
-          <DialogContent>
-            <PersonaForm
-              persona={currentPersona?.persona_data}
-              onChange={handlePersonaFormChange}
-              isSaving={isSaving}
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={handleCloseModal}>Cancelar</Button>
-            <Button onClick={handleSave} variant="contained" disabled={isSaving}>
-              {isSaving ? <CircularProgress size={24} /> : 'Salvar'}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
+        {/* Right Column: Persona Form */}
+        <Grid item xs={12} md={8}>
+          <Paper elevation={2} sx={{ p: 3, height: '100%' }}>
+            {selectedPersona ? (
+              <>
+                <Typography variant="h6" component="h2" gutterBottom>
+                  {selectedPersona.id ? 'Editar Persona' : 'Nova Persona'}
+                </Typography>
+                <PersonaForm
+                  persona={selectedPersona.persona_data}
+                  onChange={handleFormChange}
+                  isSaving={isSaving}
+                />
+                <Stack direction="row" spacing={2} sx={{ mt: 3 }}>
+                    <Button onClick={handleSave} variant="contained" disabled={isSaving}>
+                        {isSaving ? <CircularProgress size={24} /> : 'Salvar Persona'}
+                    </Button>
+                    {selectedPersona.id && (
+                        <Button onClick={handleDelete} variant="outlined" color="error" startIcon={<Delete />}>
+                            Deletar
+                        </Button>
+                    )}
+                </Stack>
+              </>
+            ) : (
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                <Typography variant="h6" color="text.secondary">
+                  Selecione uma persona para editar ou crie uma nova.
+                </Typography>
+              </Box>
+            )}
+          </Paper>
+        </Grid>
+      </Grid>
     </Container>
   );
 };


### PR DESCRIPTION
This commit refactors the `PersonasPage` from a list-based view that opens a modal to a master-detail interface, addressing user feedback that the previous UI was not in line with the original request for an integrated editing experience.

The new layout features:
- A two-column view using MUI's Grid component.
- The left column displays a list of all personas.
- The right column displays the full `PersonaForm` for creating or editing a persona.
- Clicking a persona in the list populates the form on the right.
- Clicking 'New Persona' clears the form for a new entry.
- The modal dialog has been completely removed in favor of this integrated view, which mirrors the UX of the original persona editor in the Campaign Standards tab.

This change provides a more fluid user experience and directly implements the UI design requested by the user.