### PR TITLE
fix(api): Ensure persona_data is returned from all persona endpoints

### DIFF
--- a/api/personas/[id].js
+++ b/api/personas/[id].js
@@ -38,7 +38,7 @@ const handler = async (req, res) => {
         return res.status(400).json({ error: 'Persona name and data are required.' });
       }
       const { rows } = await query(
-        'UPDATE personas SET name = $1, persona_data = $2, updated_at = NOW() WHERE id = $3 AND user_id = $4 RETURNING id, name, updated_at',
+        'UPDATE personas SET name = $1, persona_data = $2, updated_at = NOW() WHERE id = $3 AND user_id = $4 RETURNING id, name, persona_data, updated_at',
         [name, persona_data, id, userId]
       );
       if (rows.length === 0) {

--- a/api/personas/index.js
+++ b/api/personas/index.js
@@ -19,7 +19,7 @@ const handler = async (req, res) => {
   if (req.method === 'GET') {
     try {
       const { rows } = await query(
-        'SELECT id, name, updated_at FROM personas WHERE user_id = $1 ORDER BY updated_at DESC',
+        'SELECT id, name, persona_data, updated_at FROM personas WHERE user_id = $1 ORDER BY updated_at DESC',
         [userId]
       );
       return res.status(200).json(rows);
@@ -34,7 +34,7 @@ const handler = async (req, res) => {
         return res.status(400).json({ error: 'Persona name and data are required.' });
       }
       const { rows } = await query(
-        'INSERT INTO personas (user_id, name, persona_data) VALUES ($1, $2, $3) RETURNING id, name, updated_at',
+        'INSERT INTO personas (user_id, name, persona_data) VALUES ($1, $2, $3) RETURNING id, name, persona_data, updated_at',
         [userId, name, persona_data]
       );
       return res.status(201).json(rows[0]);


### PR DESCRIPTION
This commit fixes a critical bug where the persona API was not returning the `persona_data` field in several key endpoints, causing the frontend to receive incomplete data. This was the root cause of the issue where the edit screen for a persona would appear empty.

The following changes have been made:
1.  In `api/personas/index.js` (GET /api/personas): Added `persona_data` to the `SELECT` statement to ensure the full persona object is returned when listing all personas.
2.  In `api/personas/index.js` (POST /api/personas): Added `persona_data` to the `RETURNING` clause to ensure the newly created persona object is returned in its entirety.
3.  In `api/personas/[id].js` (PUT /api/personas/:id): Added `persona_data` to the `RETURNING` clause to ensure the updated persona object is returned in its entirety.

These changes ensure data consistency across the API and resolve the bug reported by the user.