### PR TITLE
fix: Add missing ListItem import in PersonaManagementModal

### DIFF
--- a/src/components/PersonaManagementModal.jsx
+++ b/src/components/PersonaManagementModal.jsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Button,
   List,
+  ListItem,
   ListItemText,
   ListItemButton,
   CircularProgress,


### PR DESCRIPTION
This commit fixes a runtime error (`ReferenceError: ListItem is not defined`) that occurred in the new PersonaManagementModal component.

The error was caused by using the `ListItem` component from MUI without importing it. This commit adds the missing `ListItem` to the import list from `@mui/material`, resolving the crash.