### PR TITLE
fix: Correct state handling for wizard reset flow

### DIFF
--- a/src/components/PersonaManagementModal.jsx
+++ b/src/components/PersonaManagementModal.jsx
@@ -114,6 +114,12 @@ const PersonaManagementModal = ({ open, onClose }) => {
 
   const handleCloseWizard = () => setSelectedPersona(null);
 
+  const handleWizardReset = () => {
+    // This function is called from the wizard's "Recomeçar" button
+    // It re-uses the new persona logic to completely reset the state
+    handleNewPersona();
+  };
+
   const drawerContent = (
     <Box sx={{ p: 2, height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
@@ -183,6 +189,7 @@ const PersonaManagementModal = ({ open, onClose }) => {
               onGenerate={handleGeneratePersonaWithAI}
               isGeneratingPersona={isGeneratingPersona}
               initialStep={initialWizardStep}
+              onReset={handleWizardReset}
             />
           ) : (
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>

--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -48,12 +48,13 @@ export const emptyPersonaWizardData = { description: '', nome: '', posicaoCargo:
 
 const steps = ['Início Rápido com IA', 'Revisão Básica', 'Responsabilidades', 'Dores e Desafios', 'Gatilhos e Barreiras', 'Mentalidade e Cultura'];
 
-export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, persona, initialStep = 0 }) => {
+export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, persona, initialStep = 0, onReset }) => {
   const [activeStep, setActiveStep] = useState(initialStep);
   const [personaData, setPersonaData] = useState(persona || emptyPersonaWizardData);
   const [otherItemInputs, setOtherItemInputs] = useState({});
   const [editingChip, setEditingChip] = useState(null);
 
+  // This effect synchronizes the internal state with the props passed from the parent
   useEffect(() => {
     setPersonaData(persona || emptyPersonaWizardData);
     setActiveStep(initialStep || 0);
@@ -85,10 +86,11 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
   const handleUpdateChipValue = () => { if (!editingChip) return; const { key, value, newValue } = editingChip; const trimmedNewValue = newValue.trim(); if (!trimmedNewValue) { toast.error("O valor não pode ser vazio."); setEditingChip(null); return; } if (value.toLowerCase() === trimmedNewValue.toLowerCase()) { setEditingChip(null); return; } if ((personaData[key] || []).map(item => item.toLowerCase()).includes(trimmedNewValue.toLowerCase())) { toast.warning('Este item já foi adicionado.'); setEditingChip(null); return; } setPersonaData(prev => ({ ...prev, [key]: (prev[key] || []).map(item => (item === value ? trimmedNewValue : item)) })); setEditingChip(null); };
 
   const handleReset = () => {
-    if (window.confirm("Tem certeza que deseja recomeçar? Todos os dados não salvos nesta persona serão perdidos.")) {
-        setPersonaData(emptyPersonaWizardData);
-        setActiveStep(0);
-        toast.info("Formulário resetado. Você pode começar a gerar uma nova persona com a IA.");
+    if (window.confirm("Tem certeza que deseja recomeçar? Todos os dados não salvos nesta persona serão perdidos e o processo de criação iniciará do zero.")) {
+      if (onReset) {
+        onReset();
+      }
+      toast.info("Formulário resetado. Você pode começar a gerar uma nova persona com a IA.");
     }
   };
 
@@ -107,7 +109,7 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
         <Box>
           <Button onClick={onClose}>Cancelar</Button>
           <Button onClick={handleSave} color="secondary">Salvar</Button>
-          {initialStep > 0 && activeStep > 0 && <Button onClick={handleReset} color="error" startIcon={<ReplayIcon />}>Recomeçar</Button>}
+          {initialStep > 0 && <Button onClick={handleReset} color="error" startIcon={<ReplayIcon />}>Recomeçar</Button>}
         </Box>
         <Box sx={{ display: 'flex', mt: { xs: 2, sm: 0 } }}>
           <Button onClick={handleBack} disabled={activeStep === 0}>Voltar</Button>


### PR DESCRIPTION
This commit fixes a bug where using the 'Recomeçar' (Start Over) button in the Persona Wizard during an edit session did not correctly reset the state, causing subsequent actions like AI generation and saving to fail or behave incorrectly.

The fix involves refactoring the state management for the reset action:
1.  **In `PersonaWizard.jsx`:** The `handleReset` function no longer modifies its internal state directly. Instead, it now calls a new `onReset` prop function, delegating the state management responsibility to the parent component.
2.  **In `PersonaManagementModal.jsx`:** A new `handleWizardReset` function has been added. This function is passed to the wizard as the `onReset` prop. It calls the existing `handleNewPersona` function, which correctly resets the `selectedPersona` state to a fresh, empty object with no ID, and sets the wizard's initial step back to 0.

This change ensures that when a user resets the wizard, the application state is properly cleared, allowing the flow to behave like a new persona creation, which resolves the reported bug.