### PR TITLE
feat: Replace Stepper with Progress Bar in Persona Wizard

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -6,9 +6,7 @@ import {
   DialogContent,
   DialogActions,
   Button,
-  Stepper,
-  Step,
-  StepLabel,
+  LinearProgress,
   Box,
   TextField,
   Typography,
@@ -110,12 +108,21 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
 
   return (
     <Box>
-      <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>{steps.map((label) => <Step key={label}><StepLabel>{label}</StepLabel></Step>)}</Stepper>
-      {getStepContent(activeStep)}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="caption" color="text.secondary">
+            Etapa {activeStep + 1} de {steps.length}: {steps[activeStep]}
+        </Typography>
+        <LinearProgress variant="determinate" value={((activeStep + 1) / steps.length) * 100} sx={{ mt: 1 }} />
+      </Box>
+
+      <Box sx={{ mt: 4, mb: 4, minHeight: '30vh' }}>
+        {getStepContent(activeStep)}
+      </Box>
+
       <DialogActions sx={{ p: 3, justifyContent: 'space-between', mt: 2, flexWrap: 'wrap' }}>
         <Box>
           <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSave} color="secondary">Salvar</Button>
+          <Button onClick={handleSave} color="secondary">Salvar e Fechar</Button>
           {initialStep > 0 && <Button onClick={handleReset} color="error" startIcon={<ReplayIcon />}>Recomeçar</Button>}
         </Box>
         <Box sx={{ display: 'flex', mt: { xs: 2, sm: 0 } }}>


### PR DESCRIPTION
This commit refactors the UI of the `PersonaWizard` component based on user feedback to improve usability and save screen space, especially on mobile devices.

The key changes are:
1.  The `Stepper` component at the top of the wizard has been completely removed.
2.  It has been replaced with a more subtle and space-efficient progress indicator, consisting of an MUI `LinearProgress` bar and a `Typography` component that displays the current step (e.g., "Etapa 2 de 6").
3.  To reduce confusion around save actions, the "Salvar" button in the wizard's footer, which saves the current progress and closes the wizard, has been renamed to "Salvar e Fechar" (Save and Close) to make its function more explicit.

This addresses the user's feedback about the confusing navigation and the large amount of vertical space consumed by the original stepper.