### PR TITLE
fix: Correct z-index of temporary drawer in Persona modal

### DIFF
--- a/src/components/PersonaManagementModal.jsx
+++ b/src/components/PersonaManagementModal.jsx
@@ -156,7 +156,15 @@ const PersonaManagementModal = ({ open, onClose }) => {
               sx={{
                 width: drawerWidth,
                 flexShrink: 0,
-                '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box', ...(isMobile ? {} : { position: 'relative', height: '100%' }) },
+                // When temporary on mobile, it needs a higher z-index to appear over the modal
+                zIndex: isMobile ? theme.zIndex.modal + 1 : 'auto',
+                '& .MuiDrawer-paper': {
+                  width: drawerWidth,
+                  boxSizing: 'border-box',
+                  // When permanent on desktop, it needs to be part of the layout
+                  position: isMobile ? 'fixed' : 'relative',
+                  height: '100%'
+                },
               }}
             >
               {drawerContent}


### PR DESCRIPTION
This commit fixes a persistent layout bug where the temporary (mobile) Drawer in the PersonaManagementModal was rendering underneath the main modal content, making it inaccessible.

The root cause was a z-index conflict, where the Drawer's default z-index (1200) is lower than the Modal's (1300).

The fix applies a conditional z-index to the Drawer's sx prop:
- When `isMobile` is true, the `zIndex` is set to `theme.zIndex.modal + 1`, ensuring it appears on top of the modal content.
- When `isMobile` is false, the `zIndex` is set to `auto` to not interfere with the permanent drawer's layout.

The `position` attribute is also now explicitly managed to ensure the correct behavior for both temporary and permanent variants. This robustly resolves the UI bug.