### PR TITLE
fix: Correct Drawer position for mobile view in Persona Modal

### DIFF
--- a/src/components/PersonaManagementModal.jsx
+++ b/src/components/PersonaManagementModal.jsx
@@ -225,7 +225,12 @@ const PersonaManagementModal = ({ open, onClose }) => {
               sx={{
                 width: drawerWidth,
                 flexShrink: 0,
-                '& .MuiDrawer-paper': { width: drawerWidth, boxSizing: 'border-box', position: 'relative', height: '100%' },
+                '& .MuiDrawer-paper': {
+                  width: drawerWidth,
+                  boxSizing: 'border-box',
+                  position: isMobile ? 'fixed' : 'relative',
+                  height: '100%'
+                },
               }}
             >
               {drawerContent}


### PR DESCRIPTION
This commit provides a definitive fix for the persistent bug where the side panel (Drawer) in the PersonaManagementModal was not visible on mobile viewports.

The root cause was an incorrect `sx` prop on the `MuiDrawer-paper` element that was unconditionally setting `position: 'relative'`. This broke the behavior of the `temporary` drawer variant on mobile, which requires `position: 'fixed'` to function as an overlay.

The fix makes the `position` property conditional:
- It is set to `'fixed'` when `isMobile` is true, allowing the temporary drawer to function correctly.
- It is set to `'relative'` when `isMobile` is false, allowing the permanent drawer to integrate correctly into the flexbox layout on desktop.

This change ensures the drawer is correctly displayed and accessible across all screen sizes, finally resolving the UI regression.