### PR TITLE
chore: Add console logs to debug persona edit flow

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -54,8 +54,13 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
 
   // This effect synchronizes the internal state with the props passed from the parent
   useEffect(() => {
-    setPersonaData(persona || emptyPersonaWizardData);
+    console.log("DEBUG: [Wizard] useEffect triggered.");
+    console.log("DEBUG: [Wizard] Received persona prop:", persona);
+    console.log("DEBUG: [Wizard] Received initialStep prop:", initialStep);
+    const newPersonaData = persona || emptyPersonaWizardData;
+    setPersonaData(newPersonaData);
     setActiveStep(initialStep || 0);
+    console.log("DEBUG: [Wizard] State updated. personaData:", newPersonaData, "activeStep:", initialStep || 0);
   }, [persona, initialStep]);
 
   const handleNext = () => {

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -46,10 +46,13 @@ const PersonasPage = () => {
   };
 
   const handleOpenModal = (persona = null) => {
+    console.log("DEBUG: [PersonasPage] handleOpenModal called.");
     if (persona) {
+      console.log("DEBUG: [PersonasPage] Editing existing persona. Data:", persona);
       setCurrentPersona({ ...persona });
       setInitialWizardStep(1);
     } else {
+      console.log("DEBUG: [PersonasPage] Creating new persona.");
       setCurrentPersona({ name: '', persona_data: { ...emptyPersonaWizardData } });
       setInitialWizardStep(0);
     }
@@ -153,22 +156,28 @@ const PersonasPage = () => {
         </List>
       )}
 
-      {isModalOpen && (
-        <PersonaWizard
-            open={isModalOpen}
-            onClose={handleCloseModal}
-            onSave={handleSave}
-            persona={currentPersona?.persona_data}
-            onGenerate={handleGeneratePersonaWithAI}
-            isGeneratingPersona={isGeneratingPersona}
-            initialStep={initialWizardStep}
-            onReset={() => {
-                // This resets the wizard to a new persona state within the existing modal
-                setCurrentPersona({ name: '', persona_data: { ...emptyPersonaWizardData } });
-                setInitialWizardStep(0);
-            }}
-        />
-      )}
+      {isModalOpen && (() => {
+        console.log("DEBUG: [PersonasPage] Rendering PersonaWizard with props:", {
+            persona: currentPersona?.persona_data,
+            initialStep: initialWizardStep,
+        });
+        return (
+            <PersonaWizard
+                open={isModalOpen}
+                onClose={handleCloseModal}
+                onSave={handleSave}
+                persona={currentPersona?.persona_data}
+                onGenerate={handleGeneratePersonaWithAI}
+                isGeneratingPersona={isGeneratingPersona}
+                initialStep={initialWizardStep}
+                onReset={() => {
+                    console.log("DEBUG: [PersonasPage] onReset called.");
+                    setCurrentPersona({ name: '', persona_data: { ...emptyPersonaWizardData } });
+                    setInitialWizardStep(0);
+                }}
+            />
+        );
+      })()}
     </Container>
   );
 };


### PR DESCRIPTION
This commit adds extensive `console.log` statements to `PersonasPage.jsx` and `PersonaWizard.jsx` to diagnose a persistent bug where data is not correctly populating the wizard during an edit session.

Logs have been added to trace:
- The data passed when the edit modal is opened (`handleOpenModal`).
- The props being passed to the `PersonaWizard` component upon render.
- The props received by the `PersonaWizard` component inside its `useEffect` hook.
- The state being set within the wizard after receiving props.

This is a temporary debugging measure to gather information from the user's environment to identify the root cause of the data flow issue.