### PR TITLE
fix: Isolate Divider import to resolve build error

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,7 +3,8 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { Box, Toolbar, Paper, Typography, Button, List, ListItemButton, ListItemText, Drawer, CircularProgress, Alert, IconButton, Divider } from '@mui/material';
+import { Box, Toolbar, Paper, Typography, Button, List, ListItemButton, ListItemText, Drawer, CircularProgress, Alert, IconButton } from '@mui/material';
+import Divider from '@mui/material/Divider';
 import { Add, ChevronLeft } from '@mui/icons-material';
 import { toast } from 'sonner';
 


### PR DESCRIPTION
This commit addresses a persistent `ReferenceError: Divider is not defined` build error.

Despite the component appearing to be correctly imported in the main MUI import line, the build process was failing. This hotfix attempts to resolve a potential caching or bundling issue by moving the `Divider` import to its own separate line.

This is a targeted attempt to force the build environment to correctly resolve the component.