### PR TITLE
Fix: Add missing Divider import to MainAppBar

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -8,6 +8,7 @@ import {
   Menu,
   MenuItem,
   Typography,
+  Divider,
 } from '@mui/material';
 import {
   Settings,


### PR DESCRIPTION
Resolves a `ReferenceError: Divider is not defined` that occurred on application load.

The `Divider` component from Material-UI was being used in `src/components/MainAppBar.jsx` without being imported. This change adds `Divider` to the import statement from `@mui/material` in that file, resolving the error.