### PR TITLE
fix(ui): correct campaign stepper and mobile persona drawer

### DIFF
--- a/src/components/CampaignWorkflow.jsx
+++ b/src/components/CampaignWorkflow.jsx
@@ -22,7 +22,6 @@ import PaletteWizard from './PaletteWizard';
 import LoadCampaignModal from './LoadCampaignModal';
 import SaveCampaignModal from './SaveCampaignModal';
 import TextEditorDialog from './TextEditorDialog';
-import MyCampaignsStep from './MyCampaignsStep';
 
 // Other imports
 import { lightTheme, darkTheme } from '../theme.js';
@@ -51,7 +50,7 @@ function CampaignWorkflow() {
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
     // Campaign state
-    const [activeStep, setActiveStep] = useState(0);
+    const [activeStep, setActiveStep] = useState(1);
     const [problema, setProblema] = useState('');
     const [solucao, setSolucao] = useState('');
     const [campaignContent, setCampaignContent] = useState(null);
@@ -117,7 +116,7 @@ function CampaignWorkflow() {
     const handleNext = () => setActiveStep((prevActiveStep) => prevActiveStep + 1);
     const handleBack = () => setActiveStep((prevActiveStep) => prevActiveStep - 1);
     const handleReset = () => {
-        setActiveStep(0);
+        setActiveStep(1);
         setProblema('');
         setSolucao('');
         setCampaignContent(null);
@@ -244,24 +243,22 @@ function CampaignWorkflow() {
     return (
         <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
             <Toolbar />
-            {activeStep === 0 ? <MyCampaignsStep onLoadCampaign={() => {}} onEditCampaign={() => {}} onCreateNew={() => setActiveStep(1)} /> : (
-                <>
-                    <Stepper activeStep={activeStep - 1} alternativeLabel sx={{ mb: 4 }}>
-                        {steps.map((step) => (
-                            <Step key={step.label}>
-                                <StepLabel>{step.label}</StepLabel>
-                            </Step>
-                        ))}
-                    </Stepper>
-                    {steps[activeStep - 1].component}
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 4 }}>
-                        <Button disabled={activeStep === 1} onClick={handleBack}>Voltar</Button>
-                        <Button variant="contained" onClick={handleNext} disabled={activeStep === steps.length}>
-                            {activeStep === steps.length ? 'Finalizado' : 'Próximo'}
-                        </Button>
-                    </Box>
-                </>
-            )}
+            <>
+                <Stepper activeStep={activeStep - 1} alternativeLabel sx={{ mb: 4 }}>
+                    {steps.map((step) => (
+                        <Step key={step.label}>
+                            <StepLabel>{step.label}</StepLabel>
+                        </Step>
+                    ))}
+                </Stepper>
+                {steps[activeStep - 1].component}
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 4 }}>
+                    <Button disabled={activeStep === 1} onClick={handleBack}>Voltar</Button>
+                    <Button variant="contained" onClick={handleNext} disabled={activeStep === steps.length}>
+                        {activeStep === steps.length ? 'Finalizado' : 'Próximo'}
+                    </Button>
+                </Box>
+            </>
         </Box>
     );
 }

--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -30,9 +30,11 @@ import { useNavigate } from 'react-router-dom';
 const MainAppBar = ({
   darkMode,
   setDarkMode,
-  onShowPersonas, // New prop
-  onShowCampaigns, // New prop
-  // ... other props
+  onShowPersonas,
+  onShowCampaigns,
+  isMobile,
+  currentView,
+  onTogglePersonaDrawer,
 }) => {
   const { user, logout } = useUserAuth();
   const navigate = useNavigate();
@@ -62,6 +64,17 @@ const MainAppBar = ({
       }}
     >
       <Toolbar>
+        {isMobile && currentView === 'personas' && (
+            <IconButton
+                color="inherit"
+                aria-label="open drawer"
+                edge="start"
+                onClick={onTogglePersonaDrawer}
+                sx={{ mr: 2 }}
+            >
+                <MenuIcon />
+            </IconButton>
+        )}
         <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
             Midiator
         </Typography>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -164,7 +164,9 @@ function HomePage() {
                     setDarkMode={setDarkMode}
                     onShowPersonas={() => setCurrentView('personas')}
                     onShowCampaigns={() => setCurrentView('campaign')}
-                    // Pass other necessary props...
+                    isMobile={isMobile}
+                    currentView={currentView}
+                    onTogglePersonaDrawer={() => setPersonaDrawerOpen(!personaDrawerOpen)}
                 />
 
                 {currentView === 'campaign' && (


### PR DESCRIPTION
This commit addresses two UI bugs reported by the user.

1. **Missing Campaign Stepper:**
   - The `CampaignWorkflow` component was incorrectly attempting to render an obsolete `MyCampaignsStep` component, which prevented the actual campaign creation stepper from appearing.
   - This has been fixed by refactoring `CampaignWorkflow.jsx` to remove the old logic and start the user directly on the first step of the campaign creation process.

2. **Missing Persona Panel Toggle on Mobile:**
   - The button to open the persona selection drawer was not visible on mobile devices.
   - This has been fixed by adding a conditionally rendered `MenuIcon` button to the `MainAppBar`. This button is only visible on mobile screens when the "Personas" view is active and correctly toggles the drawer.