### PR TITLE
fix(campaign): resolve persistent TypeError crash

### DIFF
--- a/src/components/CampaignWorkflow.jsx
+++ b/src/components/CampaignWorkflow.jsx
@@ -21,18 +21,18 @@ function CampaignWorkflow({ campaignToEdit, onExitWorkflow }) {
     const [activeStep, setActiveStep] = useState(1);
     const [problema, setProblema] = useState('');
     const [solucao, setSolucao] = useState('');
-    const [campaignContent, setCampaignContent] = useState({});
+    const [campaignContent, setCampaignContent] = useState({ hashtags: [] });
     const [generatedImagesData, setGeneratedImagesData] = useState([]);
     const [generatedAudioData, setGeneratedAudioData] = useState([]);
     const [generatedVideosData, setGeneratedVideosData] = useState([]);
-    const [currentCampaign, setCurrentCampaign] = useState({});
+    const [currentCampaign, setCurrentCampaign] = useState(null);
 
     useEffect(() => {
         if (campaignToEdit && campaignToEdit.campaign_data) {
             const data = campaignToEdit.campaign_data;
             setProblema(data.problema || '');
             setSolucao(data.solucao || '');
-            setCampaignContent(data.campaignContent || {});
+            setCampaignContent(data.campaignContent || { hashtags: [] });
             setGeneratedImagesData(data.generatedImagesData || []);
             setGeneratedAudioData(data.generatedAudioData || []);
             setGeneratedVideosData(data.generatedVideosData || []);
@@ -42,11 +42,11 @@ function CampaignWorkflow({ campaignToEdit, onExitWorkflow }) {
             // Reset state if creating a new campaign
             setProblema('');
             setSolucao('');
-            setCampaignContent({});
+            setCampaignContent({ hashtags: [] });
             setGeneratedImagesData([]);
             setGeneratedAudioData([]);
             setGeneratedVideosData([]);
-            setCurrentCampaign({});
+            setCurrentCampaign(null);
             setActiveStep(1);
         }
     }, [campaignToEdit]);


### PR DESCRIPTION
This commit fixes a persistent `TypeError: Cannot read properties of undefined (reading 'map')` that occurred throughout the campaign workflow.

The root cause was improper state initialization for the `campaignContent` object. It was sometimes `null` or an empty object `{}`, causing crashes in child components when they tried to access nested properties like `campaignContent.hashtags`.

The fix ensures that the `campaignContent` state in `CampaignWorkflow.jsx` is always initialized with a default structure, including an empty `hashtags` array. This prevents the crash and makes the component more robust.