### PR TITLE
This commit fixes a `ReferenceError: FolderOpenIcon is not defined` c…

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -23,6 +23,7 @@ import {
   Save as SaveIcon,
   People as PeopleIcon,
   Home as HomeIcon,
+  FolderOpen as FolderOpenIcon,
 } from '@mui/icons-material';
 import { useUserAuth } from '../context/UserAuthContext';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
…rash by adding the missing `FolderOpenIcon` import to `MainAppBar.jsx`.

This was another missing import from the restored legacy file.