### PR TITLE
This commit fixes two UI issues related to the re-integrated Persona …

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -40,6 +40,8 @@ const MainAppBar = ({
   isMobile,
   onSaveCampaign,
   onLoadCampaign,
+  currentView,
+  onPersonaMenuClick,
 }) => {
   const { user, logout } = useUserAuth();
   const navigate = useNavigate();
@@ -72,8 +74,8 @@ const MainAppBar = ({
             color="inherit"
             aria-label="open drawer"
             edge="start"
-            onClick={onMenuClick}
-            sx={{ mr: 2 }}
+            onClick={currentView === 'personas' && isMobile ? onPersonaMenuClick : onMenuClick}
+            sx={{ mr: 2, display: { md: 'none' } }} // Only show on mobile
           >
             <MenuIcon />
           </IconButton>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1070,6 +1070,8 @@ function HomePage() {
             onLoadCampaign={() => setShowLoadModal(true)}
             onShowPersonas={() => setCurrentView('personas')}
             onShowCampaigns={() => setCurrentView('campaigns')}
+            currentView={currentView}
+            onPersonaMenuClick={() => setPersonaDrawerOpen(!personaDrawerOpen)}
         />
         <Sidebar sidebarOpen={sidebarOpen} darkMode={darkMode} steps={steps} activeStep={activeStep} setActiveStep={setActiveStep} csvData={csvData} backgroundImage={backgroundImage} visibleFields={visibleFields} totalFields={totalFields} styledFields={styledFields} variant={isMobile ? 'temporary' : 'persistent'} onClose={() => setSidebarOpen(false)} onStepClick={handleSidebarStepClick} />
         {!isMobile && <Fab size="small" onClick={() => setSidebarOpen(!sidebarOpen)} aria-label={sidebarOpen ? 'Fechar barra lateral' : 'Abrir barra lateral'} sx={{ position: 'fixed', top: '50%', left: sidebarOpen ? 320 - 20 : 0, transform: 'translateY(-50%)', zIndex: (theme) => theme.zIndex.drawer + 1, transition: 'left 0.2s ease-in-out', backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', '&:hover': { backgroundColor: 'background.default' } }} >{sidebarOpen ? <ChevronLeft /> : <ChevronRight />}</Fab>}
@@ -1198,18 +1200,6 @@ function HomePage() {
                       sx={{
                           flexGrow: 1,
                           p: 3,
-                          transition: theme.transitions.create('margin', {
-                              easing: theme.transitions.easing.sharp,
-                              duration: theme.transitions.duration.leavingScreen,
-                          }),
-                          marginLeft: `-${320}px`,
-                          ...((personaDrawerOpen && !isMobile) && {
-                              transition: theme.transitions.create('margin', {
-                                  easing: theme.transitions.easing.easeOut,
-                                  duration: theme.transitions.duration.enteringScreen,
-                              }),
-                              marginLeft: 0,
-                          }),
                       }}
                   >
                       <Toolbar /> {/* Spacer for AppBar */}


### PR DESCRIPTION
…management view.

1.  **Desktop Layout:** The main content area of the persona view was misaligned due to incorrect margin logic. This has been fixed by removing the negative margin and allowing the flexbox container to manage the layout.
2.  **Mobile Drawer:** The persona list drawer was not appearing on mobile because the app bar's menu button was toggling the wrong state. This has been fixed by making the button's onClick handler conditional based on the current view (`campaigns` or `personas`), ensuring it toggles the correct drawer.