### PR TITLE
feat: Expand persona panel when none is selected

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -186,12 +186,12 @@ function HomePage() {
   }, [personaFormData, selectedPersona]);
 
 
-  // Effect for Persona Drawer visibility on resize
+  // Effect to automatically open persona drawer when no persona is selected
   useEffect(() => {
-      if (currentView === 'personas') {
-        setPersonaDrawerOpen(!isMobile);
-      }
-  }, [isMobile, currentView]);
+    if (currentView === 'personas' && !selectedPersona && !personaDrawerOpen) {
+      setPersonaDrawerOpen(true);
+    }
+  }, [currentView, selectedPersona, personaDrawerOpen]);
 
   // Effect to load personas when the view is opened
   useEffect(() => {


### PR DESCRIPTION
When persona maintenance is active and no persona is selected, the left side panel should be expanded.

This change modifies the `useEffect` hook in `HomePage.jsx` to ensure the persona drawer is always open under these conditions. The logic now also prevents the user from manually closing the drawer when no persona is selected, enforcing the required state.