### PR TITLE
feat: Improve persona view experience

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -81,7 +81,7 @@ const MainAppBar = ({
           </IconButton>
         )}
         <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-          Midiator
+          {currentView === 'personas' ? 'Personas' : 'Midiator'}
         </Typography>
 
         <Tooltip title="Salvar Campanha">


### PR DESCRIPTION
This commit introduces two improvements to the persona management view:

1. The side panel (persona drawer) is now automatically expanded when the user enters the persona view without a specific persona selected. This ensures the user is immediately presented with the list of personas to choose from. The drawer is also forced to stay open in this state, as per the requirement.

2. The main application header title now dynamically changes to 'Personas' when the user is in the persona management view. It reverts to the default 'Midiator' title in all other views.