### PR TITLE
feat: Add swipe navigation to persona wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "react-dom": "^18.2.0",
         "react-draggable": "^4.5.0",
         "react-router-dom": "^7.8.1",
+        "react-swipeable": "^7.0.2",
         "sonner": "^1.1.2",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2"
@@ -8179,6 +8180,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.5.0",
     "react-router-dom": "^7.8.1",
+    "react-swipeable": "^7.0.2",
     "sonner": "^1.1.2",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2"

--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useSwipeable } from 'react-swipeable';
 import { useIsMobile } from '../hooks/use-mobile';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions, Button, LinearProgress, Box, TextField, Typography, Grid, FormControl, InputLabel, Select, MenuItem, Chip, Checkbox, ListItemText, Accordion, AccordionSummary, AccordionDetails, FormGroup, FormControlLabel, CircularProgress, Tooltip, IconButton, Link as MuiLink,
@@ -28,12 +29,34 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     setActiveStep(initialStep || 0);
   }, [initialStep]);
 
+  const isNextDisabled = () => {
+    if (!personaData) return true;
+    return (activeStep === 1 && !(personaData.nome || '').trim());
+  };
+
+  const handleNext = () => {
+    if (activeStep < steps.length - 1 && !isNextDisabled()) {
+      setActiveStep(activeStep + 1);
+    }
+  };
+
+  const handleBack = () => {
+    if (activeStep > 0) {
+      setActiveStep(activeStep - 1);
+    }
+  };
+
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => handleNext(),
+    onSwipedRight: () => handleBack(),
+    preventScrollOnSwipe: true,
+    trackMouse: true,
+  });
+
   if (!personaData) {
     return <CircularProgress />;
   }
 
-  const handleNext = () => setActiveStep((prevActiveStep) => prevActiveStep + 1);
-  const handleBack = () => setActiveStep((prevActiveStep) => prevActiveStep - 1);
   const handleChange = (event) => onPersonaDataChange(prev => ({ ...prev, [event.target.name]: event.target.value }));
   const handleMultiSelectChange = (event) => onPersonaDataChange(prev => ({ ...prev, [event.target.name]: typeof event.target.value === 'string' ? event.target.value.split(',') : event.target.value }));
   const handleCheckboxChange = (category, field) => (event) => { const { checked } = event.target; onPersonaDataChange(prev => { const currentValues = prev[category] || []; const newValues = checked ? [...currentValues, field] : currentValues.filter(item => item !== field); return { ...prev, [category]: newValues }; }); };
@@ -87,15 +110,13 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     }
   };
 
-  const isNextDisabled = () => (activeStep === 1 && !(personaData.nome || '').trim());
-
   return (
     <Box>
       <Box sx={{ mb: 2 }}>
         <Typography variant="caption" color="text.secondary">Etapa {activeStep + 1} de {steps.length}: {steps[activeStep]}</Typography>
         <LinearProgress variant="determinate" value={((activeStep + 1) / steps.length) * 100} sx={{ mt: 1 }} />
       </Box>
-      <Box sx={{ mt: 4, mb: 4, minHeight: '30vh' }}>{getStepContent(activeStep)}</Box>
+      <Box {...swipeHandlers} sx={{ mt: 4, mb: 4, minHeight: '30vh', cursor: 'grab' }}>{getStepContent(activeStep)}</Box>
       <DialogActions sx={{ p: 2, justifyContent: 'space-between' }}>
         <Button onClick={onClose} color="secondary">Cancelar</Button>
         <Box>


### PR DESCRIPTION
This change introduces swipe-based navigation to the persona creation wizard. Users can now swipe left and right on the wizard's content area to move to the next and previous steps, respectively.

This was implemented by:
- Adding the `react-swipeable` library.
- Using the `useSwipeable` hook in the `PersonaWizard.jsx` component.
- Creating safe navigation handlers with boundary checks to prevent going out of bounds.
- Applying the swipe handlers to the main content area of the wizard.