### PR TITLE
fix: Comprehensive fixes for Persona view UI and state

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -90,17 +90,20 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
   const isNextDisabled = () => (activeStep === 1 && !(personaData.nome || '').trim());
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <Box sx={{ mb: 2 }}>
         <Typography variant="caption" color="text.secondary">Etapa {activeStep + 1} de {steps.length}: {steps[activeStep]}</Typography>
         <LinearProgress variant="determinate" value={((activeStep + 1) / steps.length) * 100} sx={{ mt: 1 }} />
       </Box>
-      <Box sx={{ mt: 4, mb: 4, minHeight: '30vh' }}>{getStepContent(activeStep)}</Box>
+      <Box sx={{ flexGrow: 1, overflowY: 'auto', p: 1 }}>
+        {getStepContent(activeStep)}
+      </Box>
       <DialogActions
         sx={{
           p: 2,
           flexDirection: { xs: 'column', sm: 'row' },
           justifyContent: 'space-between',
+          borderTop: (theme) => `1px solid ${theme.palette.divider}`,
         }}
       >
         <Button

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1108,8 +1108,12 @@ function HomePage() {
             currentView={currentView}
             onPersonaMenuClick={() => setPersonaDrawerOpen(!personaDrawerOpen)}
         />
-        <Sidebar sidebarOpen={sidebarOpen} darkMode={darkMode} steps={steps} activeStep={activeStep} setActiveStep={setActiveStep} csvData={csvData} backgroundImage={backgroundImage} visibleFields={visibleFields} totalFields={totalFields} styledFields={styledFields} variant={isMobile ? 'temporary' : 'persistent'} onClose={() => setSidebarOpen(false)} onStepClick={handleSidebarStepClick} />
-        {currentView === 'campaigns' && !isMobile && <Fab size="small" onClick={() => setSidebarOpen(!sidebarOpen)} aria-label={sidebarOpen ? 'Fechar barra lateral' : 'Abrir barra lateral'} sx={{ position: 'fixed', top: '50%', left: sidebarOpen ? 320 - 20 : 0, transform: 'translateY(-50%)', zIndex: (theme) => theme.zIndex.drawer + 1, transition: 'left 0.2s ease-in-out', backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', '&:hover': { backgroundColor: 'background.default' } }} >{sidebarOpen ? <ChevronLeft /> : <ChevronRight />}</Fab>}
+        {currentView === 'campaigns' && (
+          <>
+            <Sidebar sidebarOpen={sidebarOpen} darkMode={darkMode} steps={steps} activeStep={activeStep} setActiveStep={setActiveStep} csvData={csvData} backgroundImage={backgroundImage} visibleFields={visibleFields} totalFields={totalFields} styledFields={styledFields} variant={isMobile ? 'temporary' : 'persistent'} onClose={() => setSidebarOpen(false)} onStepClick={handleSidebarStepClick} />
+            {!isMobile && <Fab size="small" onClick={() => setSidebarOpen(!sidebarOpen)} aria-label={sidebarOpen ? 'Fechar barra lateral' : 'Abrir barra lateral'} sx={{ position: 'fixed', top: '50%', left: sidebarOpen ? 320 - 20 : 0, transform: 'translateY(-50%)', zIndex: (theme) => theme.zIndex.drawer + 1, transition: 'left 0.2s ease-in-out', backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', '&:hover': { backgroundColor: 'background.default' } }} >{sidebarOpen ? <ChevronLeft /> : <ChevronRight />}</Fab>}
+          </>
+        )}
         <Box component="main" sx={{ flexGrow: 1, p: { xs: 1, sm: 2, md: 3 }, transition: theme.transitions.create('margin', { easing: theme.transitions.easing.sharp, duration: theme.transitions.duration.leavingScreen }) }} >
           <Toolbar />
             {currentView === 'campaigns' && (
@@ -1237,26 +1241,43 @@ function HomePage() {
                   >
                       <Toolbar />
                       <Box>
-                          {selectedPersona ? (
-                              <PersonaWizard
-                                  key={selectedPersona.id || 'new'}
-                                  open={Boolean(selectedPersona)}
-                                  onClose={() => handleNavigation(() => setSelectedPersona(null))}
-                                  onSave={handleSavePersona}
-                                  onReset={handleNewPersona}
-                                  personaData={personaFormData}
-                                  onPersonaDataChange={setPersonaFormData}
-                                  onGenerate={handleGeneratePersonaWithAI}
-                                  isGeneratingPersona={isGeneratingPersona}
-                                  initialStep={initialWizardStep}
-                              />
+                        {selectedPersona ? (
+                          isMobile ? (
+                            <PersonaWizard
+                              key={selectedPersona.id || 'new'}
+                              open={Boolean(selectedPersona)}
+                              onClose={() => handleNavigation(() => { setCurrentView('personas'); setSelectedPersona(null); })}
+                              onSave={handleSavePersona}
+                              onReset={handleNewPersona}
+                              personaData={personaFormData}
+                              onPersonaDataChange={setPersonaFormData}
+                              onGenerate={handleGeneratePersonaWithAI}
+                              isGeneratingPersona={isGeneratingPersona}
+                              initialStep={initialWizardStep}
+                            />
                           ) : (
-                              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}>
-                                  <Typography variant="h6" color="text.secondary">
-                                      Selecione uma persona para editar ou crie uma nova.
-                                  </Typography>
-                              </Box>
-                          )}
+                            <Paper elevation={2} sx={{ p: 3 }}>
+                              <PersonaWizard
+                                key={selectedPersona.id || 'new'}
+                                open={Boolean(selectedPersona)}
+                                onClose={() => handleNavigation(() => { setCurrentView('personas'); setSelectedPersona(null); })}
+                                onSave={handleSavePersona}
+                                onReset={handleNewPersona}
+                                personaData={personaFormData}
+                                onPersonaDataChange={setPersonaFormData}
+                                onGenerate={handleGeneratePersonaWithAI}
+                                isGeneratingPersona={isGeneratingPersona}
+                                initialStep={initialWizardStep}
+                              />
+                            </Paper>
+                          )
+                        ) : (
+                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}>
+                            <Typography variant="h6" color="text.secondary">
+                              Selecione uma persona para editar ou crie uma nova.
+                            </Typography>
+                          </Box>
+                        )}
                       </Box>
                   </Box>
               </Box>


### PR DESCRIPTION
This commit addresses several UI and state management issues in the Persona view based on user feedback.

The following issues have been resolved:
1.  **Campaign Sidebar Hidden**: The campaign steps sidebar is now correctly hidden when the user is in the Persona view.
2.  **Desktop Layout Restored**: The Persona wizard is now correctly wrapped in a `Paper` container on desktop to provide proper margins and layout, while remaining full-width on mobile.
3.  **Sticky Action Buttons**: The action buttons in the Persona wizard are now sticky at the bottom of the view on both desktop and mobile, with a scrollable content area.
4.  **View Switching on Close**: The application now correctly returns to the persona list view after a user finishes editing a persona.