### PR TITLE
Fix: Resolve persona wizard issues

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -19,6 +19,7 @@ const steps = ['Início Rápido com IA', 'Revisão Básica', 'Responsabilidades'
 
 export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, personaData, onPersonaDataChange, initialStep = 0 }) => {
   const [activeStep, setActiveStep] = useState(initialStep);
+  const isMobile = useIsMobile();
 
   const handleNext = () => setActiveStep((prevActiveStep) => prevActiveStep < steps.length - 1 ? prevActiveStep + 1 : prevActiveStep);
   const handleBack = () => setActiveStep((prevActiveStep) => prevActiveStep > 0 ? prevActiveStep - 1 : prevActiveStep);
@@ -28,7 +29,7 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     onSwipedLeft: () => !isNextDisabled() && handleNext(),
     onSwipedRight: handleBack,
     preventDefaultTouchmoveEvent: true,
-    trackMouse: true,
+    trackMouse: isMobile,
   });
 
   useEffect(() => {

--- a/src/utils/personaState.js
+++ b/src/utils/personaState.js
@@ -35,7 +35,6 @@ export const savePersona = async (name, personaData) => {
     }
 
     const result = await createRes.json();
-    toast.success('Persona saved successfully!');
     return result;
   } catch (error) {
     toast.error(`Save failed: ${error.message}`);
@@ -59,7 +58,6 @@ export const updatePersona = async (id, name, personaData) => {
         }
 
         const result = await res.json();
-        toast.success('Persona updated successfully!');
         return result;
     } catch (error) {
         toast.error(`Update failed: ${error.message}`);


### PR DESCRIPTION
This commit addresses two issues in the persona wizard:

1.  **Duplicate success messages:** Removes the redundant English success message that appeared alongside the Portuguese one when saving a persona. This was caused by `toast.success` calls in both the `HomePage` component and the `personaState` utility. The calls in `personaState` have been removed, leaving only the one in `HomePage`.
2.  **Text selection conflict:** Disables the swipe-to-navigate functionality on desktop to prevent it from interfering with text selection. The `useSwipeable` hook's `trackMouse` option is now conditionally set based on whether the user is on a mobile device.