### PR TITLE
feat: Improve persona and main navigation UX

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -69,13 +69,13 @@ const MainAppBar = ({
       }}
     >
       <Toolbar>
-        {isMobile && (
+        {(currentView === 'personas' || (currentView === 'campaigns' && isMobile)) && (
           <IconButton
             color="inherit"
             aria-label="open drawer"
             edge="start"
-            onClick={currentView === 'personas' && isMobile ? onPersonaMenuClick : onMenuClick}
-            sx={{ mr: 2, display: { md: 'none' } }} // Only show on mobile
+            onClick={currentView === 'personas' ? onPersonaMenuClick : onMenuClick}
+            sx={{ mr: 2 }}
           >
             <MenuIcon />
           </IconButton>


### PR DESCRIPTION
This commit addresses several UX issues in the persona wizard and main application navigation:

1.  **Duplicate success messages:** Removes the redundant English success message that appeared alongside the Portuguese one when saving a persona.
2.  **Text selection conflict:** Disables swipe-to-navigate functionality on desktop within the persona wizard to prevent it from interfering with text selection.
3.  **Missing navigation control:** Adds a hamburger menu to the 'Personas' view on all screen sizes to ensure the side panel can always be reopened. This replaces the previous inconsistent behavior where no control was visible on desktop or mobile in this view.