### PR TITLE
fix(persona): Correct drawer toggle functionality and refine UI

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-OLp1YD3z.js"></script>
+  <script type="module" crossorigin src="/assets/index-BysT9Lwy.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DBiS__Si.css">
 </head>
 

--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -16,6 +16,7 @@ import {
   Brightness7,
   Edit,
   Menu as MenuIcon,
+  Close as CloseIcon,
   Article as ArticleIcon,
   Logout,
   AdminPanelSettings,
@@ -42,6 +43,7 @@ const MainAppBar = ({
   onLoadCampaign,
   currentView,
   onPersonaMenuClick,
+  isDrawerOpen,
 }) => {
   const { user, logout } = useUserAuth();
   const navigate = useNavigate();
@@ -77,7 +79,7 @@ const MainAppBar = ({
             onClick={currentView === 'personas' ? onPersonaMenuClick : onMenuClick}
             sx={{ mr: 2 }}
           >
-            <MenuIcon />
+            {isDrawerOpen ? <CloseIcon /> : <MenuIcon />}
           </IconButton>
         )}
         <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -82,6 +82,7 @@ function HomePage() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile);
+  const [personaDrawerOpen, setPersonaDrawerOpen] = useState(!isMobile);
   const [csvData, setCsvData] = useState([]);
   const [csvHeaders, setCsvHeaders] = useState([]);
   const [backgroundImage, setBackgroundImage] = useState(null);
@@ -969,7 +970,8 @@ function HomePage() {
             onShowPersonas={() => handleNavigation(() => setCurrentView('personas'))}
             onShowCampaigns={() => handleNavigation(() => setCurrentView('campaigns'))}
             currentView={currentView}
-            onPersonaMenuClick={() => { /* This is now handled by PersonasPage */ }}
+            onPersonaMenuClick={() => setPersonaDrawerOpen(!personaDrawerOpen)}
+            isDrawerOpen={currentView === 'personas' ? personaDrawerOpen : sidebarOpen}
         />
         {currentView === 'campaigns' && (
           <>
@@ -1076,7 +1078,7 @@ function HomePage() {
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} ><Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button><Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box><Button onClick={handleNext} disabled={isGenerating || activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1)} variant="contained" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Próximo</Button></Box>
               </>
             )}
-            {currentView === 'personas' && <PersonasPage />}
+            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} />}
         </Box>
       </Box>
       <UnsavedChangesDialog

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -22,14 +22,13 @@ import geminiAPI from '../utils/geminiAPI';
  * where the `PersonaWizard` is displayed. The component is self-contained and handles
  * all its state and API interactions.
  */
-const PersonasPage = () => {
+const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   // State for Persona View
   const [personaList, setPersonaList] = useState([]);
   const [selectedPersona, setSelectedPersona] = useState(null);
-  const [personaDrawerOpen, setPersonaDrawerOpen] = useState(!isMobile);
   const [personasLoading, setPersonasLoading] = useState(true);
   const [personasError, setPersonasError] = useState(null);
   const [isGeneratingPersona, setIsGeneratingPersona] = useState(false);
@@ -50,13 +49,6 @@ const PersonasPage = () => {
         setIsPersonaDirty(false);
     }
   }, [personaFormData, selectedPersona]);
-
-  // Effect to ensure persona drawer opens when no persona is selected
-  useEffect(() => {
-      if (!selectedPersona) {
-          setPersonaDrawerOpen(true);
-      }
-  }, [selectedPersona]);
 
   // Effect to load personas when the component mounts
   useEffect(() => {
@@ -205,7 +197,6 @@ const PersonasPage = () => {
     <Box sx={{p: 2, width: 320}}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
             <Typography variant="h6">Personas</Typography>
-            {!isMobile && <IconButton onClick={() => setPersonaDrawerOpen(false)}><ChevronLeft /></IconButton>}
         </Box>
         <Button variant="contained" startIcon={<Add />} onClick={handleNewPersona} fullWidth>Nova Persona</Button>
         <Divider sx={{my: 2}} />


### PR DESCRIPTION
This commit addresses issues with the persona management UI following the recent refactoring.

Key changes:
- **Fixed Drawer Toggle:** The state for the persona side panel (`personaDrawerOpen`) has been lifted from `PersonasPage.jsx` to `HomePage.jsx`. This reconnects the hamburger menu button in the `MainAppBar` to correctly open and close the persona panel.
- **Refined Icons:**
    - The hamburger menu icon now correctly transitions to a close ('X') icon when the side panel is open, providing better user feedback.
    - The redundant back arrow ('<') icon inside the persona panel has been removed to avoid UI clutter.