### PR TITLE
feat(persona): Implement safe deletion for personas

### DIFF
--- a/api/personas/[id].js
+++ b/api/personas/[id].js
@@ -62,16 +62,32 @@ const handler = async (req, res) => {
       return res.status(500).json({ error: 'Internal Server Error' });
     }
     // Handles DELETE /api/personas/:id
-    // Deletes a persona.
+    // Deletes a persona, but only if it's not associated with any campaigns.
   } else if (req.method === 'DELETE') {
     try {
+      // First, check if the persona is used in any campaigns for this user.
+      const campaignCheck = await query(
+        "SELECT COUNT(*) FROM campaigns WHERE user_id = $1 AND campaign_data->'persona'->>'id' = $2",
+        [userId, id]
+      );
+
+      if (parseInt(campaignCheck.rows[0].count, 10) > 0) {
+        return res.status(409).json({
+          error: 'This persona cannot be deleted because it is associated with one or more campaigns.',
+        });
+      }
+
+      // If not used, proceed with deletion.
       const { rowCount } = await query(
         'DELETE FROM personas WHERE id = $1 AND user_id = $2',
         [id, userId]
       );
+
       if (rowCount === 0) {
+        // This case would be rare if the campaign check passes, but it's good practice.
         return res.status(404).json({ error: 'Persona not found or access denied.' });
       }
+
       return res.status(200).json({ message: 'Persona deleted successfully.' });
     } catch (error) {
       console.error(`[DELETE /api/personas/${id}] Error for user ${userId}:`, error);

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BysT9Lwy.js"></script>
+  <script type="module" crossorigin src="/assets/index-UYU9aqCR.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DBiS__Si.css">
 </head>
 

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -2,13 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {
-  Paper, Typography, Box, Button, Alert, IconButton, Toolbar, Divider, Drawer, List, ListItemButton, ListItemText, CircularProgress,
+  Paper, Typography, Box, Button, Alert, IconButton, Toolbar, Divider, Drawer, List, ListItem, ListItemButton, ListItemText, CircularProgress,
 } from '@mui/material';
-import { ChevronLeft, Add } from '@mui/icons-material';
+import { ChevronLeft, Add, Delete as DeleteIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
 import isEqual from 'lodash.isequal';
 
-import { getPersonas, savePersona, updatePersona } from '../utils/personaState';
+import { getPersonas, savePersona, updatePersona, deletePersona } from '../utils/personaState';
 import PersonaWizard, { emptyPersonaWizardData } from '../components/PersonaWizard';
 import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
 import { getGeminiApiKey } from '../utils/geminiCredentials';
@@ -193,6 +193,26 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen }) => {
         setNavigationTarget(null);
     };
 
+  const handleConfirmDelete = async (personaId) => {
+    try {
+      await deletePersona(personaId);
+      toast.success('Persona excluída com sucesso!');
+      fetchPersonas(); // Refresh list
+      setSelectedPersona(null); // Deselect if the deleted one was selected
+    } catch (error) {
+      // Error toast is handled inside deletePersona, but you could add more here if needed
+      console.error(error);
+    }
+  };
+
+  const handleDeleteClick = (persona) => {
+    // Stop propagation to prevent the ListItemButton's onClick from firing
+    // event.stopPropagation();
+    if (window.confirm(`Tem certeza que deseja excluir a persona "${persona.name}"? Esta ação não pode ser desfeita.`)) {
+      handleConfirmDelete(persona.id);
+    }
+  };
+
   const personaDrawerContent = (
     <Box sx={{p: 2, width: 320}}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
@@ -205,9 +225,19 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen }) => {
         {!personasLoading && !personasError && (
             <List>
                 {personaList.map((p) => (
-                    <ListItemButton key={p.id} selected={selectedPersona?.id === p.id} onClick={() => handleNavigation(() => handleSelectPersona(p))}>
+                  <ListItem
+                    key={p.id}
+                    disablePadding
+                    secondaryAction={
+                      <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteClick(p)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    }
+                  >
+                    <ListItemButton selected={selectedPersona?.id === p.id} onClick={() => handleNavigation(() => handleSelectPersona(p))}>
                         <ListItemText primary={p.name} />
                     </ListItemButton>
+                  </ListItem>
                 ))}
             </List>
         )}

--- a/src/utils/personaState.js
+++ b/src/utils/personaState.js
@@ -107,12 +107,20 @@ export const deletePersona = async (id) => {
     const res = await fetchWithAuth(`/api/personas/${id}`, { method: 'DELETE' });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
+      // Handle the specific 409 conflict error
+      if (res.status === 409) {
+        toast.error(err.error || 'This persona is in use and cannot be deleted.');
+      } else {
+        toast.error(err.error || 'Failed to delete persona.');
+      }
       throw new Error(err.error || 'Failed to delete persona.');
     }
-    toast.success('Persona deleted successfully!');
+    // The success toast is now handled in the component to avoid duplication
+    // toast.success('Persona deleted successfully!');
     return res.json();
   } catch (error) {
-    toast.error(`Delete failed: ${error.message}`);
+    // The toast is already shown for !res.ok cases, so we just re-throw
+    // for the component to catch and handle loading states etc.
     throw error;
   }
 };


### PR DESCRIPTION
This commit introduces a new feature to allow users to delete personas, with a safeguard to prevent deletion if the persona is in use by any campaigns.

Key changes:
- **UI:** A delete icon button has been added next to each persona in the list. Clicking this button triggers a confirmation dialog to prevent accidental deletion.
- **Backend:** The `DELETE /api/personas/:id` endpoint has been updated to check for associated campaigns before deleting a persona. If the persona is in use, the API returns a 409 Conflict error.
- **Frontend:** The client-side logic has been updated to handle the new deletion flow, including showing the confirmation dialog and displaying an appropriate error message if the persona cannot be deleted.