### PR TITLE
fix(persona): Restore automatic opening of side panel

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-UYU9aqCR.js"></script>
+  <script type="module" crossorigin src="/assets/index-RJTBC6M-.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DBiS__Si.css">
 </head>
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1078,7 +1078,7 @@ function HomePage() {
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} ><Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button><Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box><Button onClick={handleNext} disabled={isGenerating || activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1)} variant="contained" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Próximo</Button></Box>
               </>
             )}
-            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} />}
+            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} />}
         </Box>
       </Box>
       <UnsavedChangesDialog

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -22,7 +22,7 @@ import geminiAPI from '../utils/geminiAPI';
  * where the `PersonaWizard` is displayed. The component is self-contained and handles
  * all its state and API interactions.
  */
-const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen }) => {
+const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -54,6 +54,13 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen }) => {
   useEffect(() => {
       fetchPersonas();
   }, []);
+
+  // Effect to automatically open the drawer if no persona is selected
+  useEffect(() => {
+    if (!selectedPersona && onNoPersonaSelected) {
+      onNoPersonaSelected();
+    }
+  }, [selectedPersona, onNoPersonaSelected]);
 
   /**
    * Fetches the list of personas from the API and updates the state.


### PR DESCRIPTION
This commit fixes a regression where the persona side panel would no longer open automatically when no persona was selected.

This was corrected by re-introducing the `useEffect` hook in `PersonasPage.jsx` that checks for a selected persona. Instead of directly controlling the drawer state, it now calls a new prop, `onNoPersonaSelected`, which is passed down from `HomePage.jsx`. This allows the parent component to control the drawer's state while the child component signals the event, restoring the original behavior in a more robust way.