### PR TITLE
Fix(api): Correct header access to prevent TypeError

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -343,7 +343,9 @@ const mainHandler = async (request, response) => {
     // Cron job endpoint (GET) - uses Vercel's built-in cron secret
     if (request.method === 'GET') {
         const vercelCronSecret = process.env.VERCEL_CRON_SECRET;
-        const secretFromHeader = request.headers.get('x-vercel-cron-secret');
+        const secretFromHeader = typeof request.headers.get === 'function'
+            ? request.headers.get('x-vercel-cron-secret')
+            : request.headers['x-vercel-cron-secret'];
 
         // It's critical that the VERCEL_CRON_SECRET is available.
         // Vercel automatically injects this for projects with cron jobs.


### PR DESCRIPTION
This commit fixes a `TypeError: request.headers.get is not a function` in the `/api/schedule` endpoint. The previous change incorrectly assumed the existence of the `.get()` method on the `request.headers` object, which is not guaranteed across all Node.js runtimes.

The code is now updated to check if `request.headers.get` is a function before calling it, falling back to direct property access (`request.headers['...']`) if it is not. This makes the header access more robust and ensures compatibility with Vercel's serverless environment.

This is a correction for the previous commit that aimed to fix the cron job authentication.