### PR TITLE
Refactor author data maintenance to use database API

### DIFF
--- a/add_autores_table.sql
+++ b/add_autores_table.sql
@@ -1,0 +1,28 @@
+-- Autores Table
+CREATE TABLE IF NOT EXISTS autores (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    autor_data JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index on user_id for faster lookups of a user's autores
+CREATE INDEX IF NOT EXISTS idx_autores_user_id ON autores(user_id);
+
+-- Trigger for autores table
+DROP TRIGGER IF EXISTS set_timestamp ON autores;
+CREATE TRIGGER set_timestamp
+BEFORE UPDATE ON autores
+FOR EACH ROW
+EXECUTE PROCEDURE trigger_set_timestamp();
+
+-- Add a comment to verify execution
+COMMENT ON TABLE autores IS 'Autores table created successfully';
+
+-- Add autor_id to campaigns table
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS autor_id INTEGER REFERENCES autores(id) ON DELETE SET NULL;
+
+-- Index on autor_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_campaigns_autor_id ON campaigns(autor_id);

--- a/api/autores/[id].js
+++ b/api/autores/[id].js
@@ -1,0 +1,102 @@
+import { withAuth } from '../middleware/auth.js';
+import { query } from '../db.js';
+
+const parseBody = async (req) => {
+  let body = '';
+  for await (const chunk of req) {
+    body += new TextDecoder().decode(chunk);
+  }
+  try {
+    return JSON.parse(body);
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * API handler for individual autor operations (GET, PUT, DELETE).
+ * All routes in this handler are protected and require authentication.
+ * The user can only operate on autores they own.
+ *
+ * @param {object} req - The incoming request object.
+ * @param {object} res - The outgoing response object.
+ */
+const handler = async (req, res) => {
+  const userId = req.user.sub;
+  const { id } = req.query; // Autor ID from the URL path
+
+  // Handles GET /api/autores/:id
+  // Fetches a single autor by its ID.
+  if (req.method === 'GET') {
+    try {
+      const { rows } = await query(
+        'SELECT id, name, autor_data, updated_at FROM autores WHERE id = $1 AND user_id = $2',
+        [id, userId]
+      );
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Autor not found or access denied.' });
+      }
+      return res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error(`[GET /api/autores/${id}] Error for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+    // Handles PUT /api/autores/:id
+    // Updates an existing autor.
+  } else if (req.method === 'PUT') {
+    try {
+      const { name, autor_data } = await parseBody(req);
+      if (!name || !autor_data) {
+        return res.status(400).json({ error: 'Autor name and data are required.' });
+      }
+      const { rows } = await query(
+        'UPDATE autores SET name = $1, autor_data = $2, updated_at = NOW() WHERE id = $3 AND user_id = $4 RETURNING id, name, autor_data, updated_at',
+        [name, autor_data, id, userId]
+      );
+      if (rows.length === 0) {
+        return res.status(404).json({ error: 'Autor not found or access denied.' });
+      }
+      return res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error(`[PUT /api/autores/${id}] Error for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+    // Handles DELETE /api/autores/:id
+    // Deletes an autor, but only if it's not associated with any campaigns.
+  } else if (req.method === 'DELETE') {
+    try {
+      // First, check if the autor is used in any campaigns for this user.
+      const campaignCheck = await query(
+        "SELECT COUNT(*) FROM campaigns WHERE user_id = $1 AND autor_id = $2",
+        [userId, id]
+      );
+
+      if (parseInt(campaignCheck.rows[0].count, 10) > 0) {
+        return res.status(409).json({
+          error: 'This autor cannot be deleted because it is associated with one or more campaigns.',
+        });
+      }
+
+      // If not used, proceed with deletion.
+      const { rowCount } = await query(
+        'DELETE FROM autores WHERE id = $1 AND user_id = $2',
+        [id, userId]
+      );
+
+      if (rowCount === 0) {
+        // This case would be rare if the campaign check passes, but it's good practice.
+        return res.status(404).json({ error: 'Autor not found or access denied.' });
+      }
+
+      return res.status(200).json({ message: 'Autor deleted successfully.' });
+    } catch (error) {
+      console.error(`[DELETE /api/autores/${id}] Error for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+};
+
+export default withAuth(handler);

--- a/api/autores/index.js
+++ b/api/autores/index.js
@@ -1,0 +1,63 @@
+import { withAuth } from '../middleware/auth.js';
+import { query } from '../db.js';
+
+const parseBody = async (req) => {
+  let body = '';
+  for await (const chunk of req) {
+    body += new TextDecoder().decode(chunk);
+  }
+  try {
+    return JSON.parse(body);
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * API handler for autor collection operations.
+ * All routes in this handler are protected and require authentication.
+ *
+ * @param {object} req - The incoming request object.
+ * @param {object} res - The outgoing response object.
+ */
+const handler = async (req, res) => {
+  // The user ID is extracted from the authenticated request.
+  const userId = req.user.sub;
+
+  // Handles GET requests to /api/autores
+  // Fetches all autores belonging to the authenticated user.
+  if (req.method === 'GET') {
+    try {
+      const { rows } = await query(
+        'SELECT id, name, autor_data, updated_at FROM autores WHERE user_id = $1 ORDER BY updated_at DESC',
+        [userId]
+      );
+      return res.status(200).json(rows);
+    } catch (error) {
+      console.error(`[GET /api/autores] Error for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  // Handles POST requests to /api/autores
+  // Creates a new autor for the authenticated user.
+  } else if (req.method === 'POST') {
+    try {
+      const { name, autor_data } = await parseBody(req);
+      if (!name || !autor_data) {
+        return res.status(400).json({ error: 'Autor name and data are required.' });
+      }
+      const { rows } = await query(
+        'INSERT INTO autores (user_id, name, autor_data) VALUES ($1, $2, $3) RETURNING id, name, autor_data, updated_at',
+        [userId, name, autor_data]
+      );
+      return res.status(201).json(rows[0]);
+    } catch (error) {
+      console.error(`[POST /api/autores] Error for user ${userId}:`, error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+};
+
+export default withAuth(handler);

--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -1,304 +1,192 @@
 import React, { useState, useEffect } from 'react';
 import { useIsMobile } from '../hooks/use-mobile';
+import { useSwipeable } from 'react-swipeable';
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Stepper,
-  Step,
-  StepLabel,
-  Box,
-  TextField,
-  Typography,
-  Grid,
-  CircularProgress,
-  Alert,
-  MenuItem,
-  Tooltip,
-  IconButton,
+  Dialog, DialogTitle, DialogContent, Button, LinearProgress, Box, TextField, Typography, Grid, FormControl, InputLabel, Select, MenuItem, CircularProgress, Tooltip, IconButton,
 } from '@mui/material';
-import { InfoOutlined as InfoOutlinedIcon } from '@mui/icons-material';
+import { ArrowBack, ArrowForward, AutoAwesome as AutoAwesomeIcon } from '@mui/icons-material';
 import TextEditor from './TextEditor';
 
-const steps = [
-  'Início Rápido com IA',
-  'Revisão Detalhada',
-];
-
+// Constants
 export const TIPO_ORGANIZACAO_OPTIONS = ['Braço de tecnologia', 'Agência de marketing', 'Consultoria', 'Startup', 'Empresa de Software (SaaS)', 'E-commerce', 'Outro'];
+export const emptyAutorWizardData = {
+    descricaoGeral: '',
+    dominioReferencia: '',
+    siteExclusao: '',
+    identidade: '',
+    descricao: '',
+    tipo: '',
+    tipoOrganizacaoOutro: '',
+    objetivoEstrategico: '',
+    objetivoEngajamento: '',
+};
 
-const InfoTooltip = ({ title }) => (
-    <Tooltip title={<Typography variant="body2" sx={{ p: 1 }}>{title}</Typography>}>
-      <IconButton>
-        <InfoOutlinedIcon sx={{ color: 'text.secondary', fontSize: '1rem' }} />
-      </IconButton>
-    </Tooltip>
-);
+const steps = ['Início Rápido com IA', 'Revisão Detalhada'];
 
-export const AutorWizardContent = ({ onClose, onSave, onGenerate, isGeneratingAutor, autor, initialStep = 0 }) => {
+/**
+ * @component AutorWizardContent
+ * @description The core UI of the autor creation/editing wizard.
+ */
+export const AutorWizardContent = ({ onSave, onClose, onGenerate, isGeneratingAutor, autorData, onAutorDataChange, initialStep = 0 }) => {
   const [activeStep, setActiveStep] = useState(initialStep);
-  const [autorData, setAutorData] = useState(autor || {});
+  const isMobile = useIsMobile();
+
+  const handleNext = () => setActiveStep((prevActiveStep) => prevActiveStep < steps.length - 1 ? prevActiveStep + 1 : prevActiveStep);
+  const handleBack = () => setActiveStep((prevActiveStep) => prevActiveStep > 0 ? prevActiveStep - 1 : prevActiveStep);
+  const isNextDisabled = () => (activeStep === 1 && !(autorData.identidade || '').trim());
+
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => !isNextDisabled() && handleNext(),
+    onSwipedRight: handleBack,
+    preventDefaultTouchmoveEvent: true,
+    trackMouse: isMobile,
+  });
 
   useEffect(() => {
-    // Unlike the modal version, we don't reset the step when 'open' changes here.
-    // The parent component will control the mounting/unmounting.
-    // We do want to initialize the data when the component mounts or the initial 'autor' prop changes.
-    setAutorData(autor || {
-      descricaoGeral: '',
-      dominioReferencia: '',
-      siteExclusao: '',
-      identidade: '',
-      descricao: '',
-      tipo: '',
-      tipoOrganizacaoOutro: '',
-      objetivoEstrategico: '',
-      objetivoEngajamento: '',
-    });
-  }, [autor]);
+    setActiveStep(initialStep || 0);
+  }, [initialStep]);
 
-  const handleNext = () => {
-    if (activeStep === 0) { // Step "Início Rápido com IA"
-      onGenerate(
-        autorData.descricaoGeral,
-        autorData.dominioReferencia,
-        autorData.siteExclusao,
-        (generatedAutor) => {
-          setAutorData(prev => ({ ...prev, ...generatedAutor }));
-          setActiveStep(1);
+  if (!autorData) {
+    return <CircularProgress />;
+  }
+
+  // Generic change handlers that propagate updates to the parent component.
+  const handleChange = (event) => onAutorDataChange(prev => ({ ...prev, [event.target.name]: event.target.value }));
+  const handleRichTextChange = (name, value) => onAutorDataChange(prev => ({ ...prev, [name]: value }));
+
+  /**
+   * Handles the AI generation click.
+   */
+  const handleGenerateClick = () => {
+    const hasExistingData = autorData && autorData.identidade;
+    const proceed = () => {
+        onGenerate(autorData.descricaoGeral, (generatedAutor) => {
+            onAutorDataChange(prev => ({ ...prev, ...generatedAutor }));
+            setActiveStep(1);
+        });
+    };
+
+    if (hasExistingData) {
+        if (window.confirm("Gerar um novo autor com IA irá sobrescrever os dados atuais. Deseja continuar?")) {
+            proceed();
         }
-      );
     } else {
-      handleSave();
+        proceed();
     }
-  };
-
-  const handleBack = () => {
-    setActiveStep((prevActiveStep) => prevActiveStep - 1);
-  };
-
-  const handleSave = () => {
-    onSave(autorData);
-  };
-
-  const handleChange = (event) => {
-    const { name, value } = event.target;
-    setAutorData(prev => {
-      const newState = { ...prev, [name]: value };
-      // Se o tipo de organização for alterado para algo diferente de "Outro",
-      // limpa o campo de texto `tipoOrganizacaoOutro`.
-      if (name === 'tipo' && value !== 'Outro') {
-        newState.tipoOrganizacaoOutro = '';
-      }
-      return newState;
-    });
-  };
-
-  const handleRichTextChange = (name, value) => {
-    setAutorData(prev => ({ ...prev, [name]: value }));
   };
 
   const getStepContent = (step) => {
-    const emptyLabelStyle = {
-        '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiFormLabel-filled)': {
-            fontFamily: 'Montserrat, sans-serif',
-            fontSize: '1.4rem',
-            // Ajustado para um campo de 6 linhas
-            transform: 'translate(14px, 60px) scale(1)',
-        },
-    };
-
     switch (step) {
-      case 0:
-        return (
-          <Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <TextField
-                  name="descricaoGeral"
-                  label="Descrição do Autor"
-                  multiline
-                  rows={6}
-                  fullWidth
-                  value={autorData.descricaoGeral || ''}
-                  onChange={handleChange}
-                  placeholder="Ex: 'Uma empresa de consultoria de marketing digital focada em startups de tecnologia...'"
-                  disabled={isGeneratingAutor}
-                  sx={!(autorData.descricaoGeral || '').trim() ? emptyLabelStyle : {}}
-                />
-                <InfoTooltip title="Forneça uma breve descrição do perfil do autor (a empresa ou marca). A IA irá usar essa informação para preencher os campos detalhados." />
-            </Box>
-            <Grid container spacing={2}>
-                <Grid item xs={12} md={6}>
-                    <TextField
-                      name="dominioReferencia"
-                      label="Domínio de Referência (Opcional)"
-                      fullWidth
-                      value={autorData.dominioReferencia || ''}
-                      onChange={handleChange}
-                      placeholder="Ex: 'empresa.com.br'"
-                      helperText="A IA usará este site como fonte de informação."
-                      disabled={isGeneratingAutor}
-                    />
-                </Grid>
-                <Grid item xs={12} md={6}>
-                    <TextField
-                      name="siteExclusao"
-                      label="Site para Excluir da Busca (Opcional)"
-                      fullWidth
-                      value={autorData.siteExclusao || ''}
-                      onChange={handleChange}
-                      placeholder="Ex: 'concorrente.com.br'"
-                      helperText="A IA evitará este site em sua busca."
-                      disabled={isGeneratingAutor}
-                    />
-                </Grid>
-            </Grid>
-          </Box>
-        );
-      case 1:
-        return (
-          <Box>
-            <Typography variant="h6" gutterBottom>Revisão e Detalhamento do Autor</Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              A IA preencheu os campos abaixo com base na sua descrição. Revise e ajuste se necessário.
-            </Typography>
-            <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <TextField
-                  label="Identidade do Autor"
-                  name="identidade"
-                  value={autorData.identidade || ''}
-                  onChange={handleChange}
-                  fullWidth
-                  required
-                  variant="outlined"
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <Typography variant="subtitle1" gutterBottom>Descrição da Empresa</Typography>
-                <TextEditor
-                    value={autorData.descricao || ''}
-                    onChange={(value) => handleRichTextChange('descricao', value)}
-                    html={true}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  select
-                  label="Tipo de Organização"
-                  name="tipo"
-                  value={autorData.tipo || ''}
-                  onChange={handleChange}
-                  fullWidth
-                  required
-                  variant="outlined"
-                >
-                    {TIPO_ORGANIZACAO_OPTIONS.map(option => <MenuItem key={option} value={option}>{option}</MenuItem>)}
-                </TextField>
-              </Grid>
-              {autorData.tipo === 'Outro' && (
-                <Grid item xs={12}>
-                  <TextField
-                    name="tipoOrganizacaoOutro"
-                    label="Qual?"
-                    fullWidth
-                    value={autorData.tipoOrganizacaoOutro || ''}
-                    onChange={handleChange}
-                    placeholder="Especifique o tipo de organização"
-                    required
-                  />
-                </Grid>
-              )}
-              <Grid item xs={12}>
-                <Typography variant="subtitle1" gutterBottom>Objetivo Estratégico</Typography>
-                <TextEditor
-                    value={autorData.objetivoEstrategico || ''}
-                    onChange={(value) => handleRichTextChange('objetivoEstrategico', value)}
-                    html={true}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <Typography variant="subtitle1" gutterBottom>Objetivo de Engajamento</Typography>
-                <TextEditor
-                    value={autorData.objetivoEngajamento || ''}
-                    onChange={(value) => handleRichTextChange('objetivoEngajamento', value)}
-                    html={true}
-                />
-              </Grid>
-            </Grid>
-          </Box>
-        );
-      default:
-        return 'Unknown step';
+      case 0: return (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <TextField name="descricaoGeral" label="Descrição do Autor" multiline rows={6} fullWidth value={autorData.descricaoGeral || ''} onChange={handleChange} placeholder="Ex: 'Uma empresa de consultoria...'" disabled={isGeneratingAutor} />
+            <Tooltip title="Gerar autor com IA">
+                <IconButton onClick={handleGenerateClick} disabled={isGeneratingAutor || !autorData.descricaoGeral?.trim()} color="primary">
+                    {isGeneratingAutor ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
+                </IconButton>
+            </Tooltip>
+        </Box>
+      );
+      case 1: return <Box><Typography variant="h6" gutterBottom>Revisão e Detalhamento</Typography><Grid container spacing={3}><Grid item xs={12}><TextField label="Nome do Autor" name="identidade" value={autorData.identidade || ''} onChange={handleChange} fullWidth required /></Grid><Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Descrição da Empresa</Typography><TextEditor value={autorData.descricao || ''} onChange={(v) => handleRichTextChange('descricao', v)} html={true} /></Grid><Grid item xs={12}><FormControl fullWidth><InputLabel>Tipo de Organização</InputLabel><Select name="tipo" value={autorData.tipo || ''} onChange={handleChange} label="Tipo de Organização">{TIPO_ORGANIZACAO_OPTIONS.map((o) => (<MenuItem key={o} value={o}>{o}</MenuItem>))}</Select></FormControl></Grid>{autorData.tipo === 'Outro' && <Grid item xs={12}><TextField label="Especifique o Tipo" name="tipoOrganizacaoOutro" value={autorData.tipoOrganizacaoOutro || ''} onChange={handleChange} fullWidth /></Grid>}<Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Objetivo Estratégico</Typography><TextEditor value={autorData.objetivoEstrategico || ''} onChange={(v) => handleRichTextChange('objetivoEstrategico', v)} html={true} /></Grid><Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Objetivo de Engajamento</Typography><TextEditor value={autorData.objetivoEngajamento || ''} onChange={(v) => handleRichTextChange('objetivoEngajamento', v)} html={true} /></Grid></Grid></Box>;
+      default: return 'Unknown step';
     }
-  };
-
-  const isNextDisabled = () => {
-    if (activeStep === 0 && !(autorData.descricaoGeral || '').trim()) {
-      return true;
-    }
-    if (activeStep === 1 && !(autorData.identidade || '').trim()) {
-      return true;
-    }
-    return isGeneratingAutor;
   };
 
   return (
-    <Box>
-      <Stepper activeStep={activeStep} sx={{ mb: 4 }}>
-        {steps.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
-      </Stepper>
-      {getStepContent(activeStep)}
-      <DialogActions sx={{ p: 3, justifyContent: 'space-between', mt: 2, flexWrap: 'wrap' }}>
-        <Box>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSave} color="secondary">Salvar</Button>
-        </Box>
-        <Box sx={{ display: 'flex', mt: { xs: 2, sm: 0 } }}>
-          <Button onClick={handleBack} disabled={activeStep === 0}>
-            Voltar
+    <Box {...swipeHandlers} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="caption" color="text.secondary">Etapa {activeStep + 1} de {steps.length}: {steps[activeStep]}</Typography>
+        <LinearProgress variant="determinate" value={((activeStep + 1) / steps.length) * 100} sx={{ mt: 1 }} />
+      </Box>
+      <Box sx={{ flexGrow: 1, overflowY: 'auto', p: 1 }}>
+        {getStepContent(activeStep)}
+      </Box>
+      <Box
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          p: 2,
+          bgcolor: 'background.paper',
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          zIndex: 1,
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          justifyContent: 'space-between',
+        }}
+      >
+        <Button
+          onClick={onClose}
+          color="secondary"
+          sx={{ width: { xs: '100%', sm: 'auto' }, mb: { xs: 1, sm: 0 } }}
+        >
+          Cancelar
+        </Button>
+        <Box sx={{ display: 'flex', width: { xs: '100%', sm: 'auto' }, justifyContent: 'flex-end' }}>
+          <Button
+            onClick={handleBack}
+            disabled={activeStep === 0}
+            variant="outlined"
+            startIcon={<ArrowBack />}
+          >
+            Anterior
           </Button>
           <Button
-              onClick={handleNext}
-              variant="contained"
-              disabled={isNextDisabled()}
-              sx={{ ml: 1 }}
+            onClick={handleNext}
+            variant="outlined"
+            endIcon={<ArrowForward />}
+            disabled={isNextDisabled() || activeStep === steps.length - 1}
+            sx={{ ml: 1 }}
           >
-            {isGeneratingAutor && activeStep === 0 && <CircularProgress size={24} />}
-            {!isGeneratingAutor && (activeStep === 0 ? 'Gerar com IA' : 'Finalizar e Salvar')}
+            Próximo
+          </Button>
+          <Button
+            onClick={onSave}
+            variant="contained"
+            color="primary"
+            sx={{ ml: 2 }}
+          >
+            Salvar
           </Button>
         </Box>
-      </DialogActions>
+      </Box>
     </Box>
   );
 };
 
-
-const AutorWizard = ({ open, onClose, onSave, initialStep, ...props }) => {
+/**
+ * @component AutorWizard
+ * @description A wrapper component for the AutorWizardContent.
+ */
+const AutorWizard = ({ open, onClose, onSave, ...props }) => {
   const isMobile = useIsMobile();
 
+  if (!open) {
+    return null;
+  }
+
+  if (isMobile) {
+    return (
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen>
+        <DialogTitle>Assistente de Criação de Autor</DialogTitle>
+        <DialogContent sx={{ p: 0 }}>
+          <Box sx={{ p: 1, height: '100%' }}>
+            <AutorWizardContent onClose={onClose} onSave={onSave} {...props} />
+          </Box>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" fullScreen={isMobile}>
-      <DialogTitle>
+    <>
+      <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
         Assistente de Criação de Autor
-      </DialogTitle>
-      <DialogContent sx={{ minHeight: '50vh' }}>
-        <AutorWizardContent
-            onClose={onClose}
-            onSave={(data) => {
-                onSave(data);
-                onClose(); // In modal context, save also closes.
-            }}
-            initialStep={initialStep}
-            {...props}
-        />
-      </DialogContent>
-    </Dialog>
+      </Typography>
+      <AutorWizardContent onClose={onClose} onSave={onSave} {...props} />
+    </>
   );
 };
 

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -181,10 +181,10 @@ const Campaign = ({
     handleGenerateImage,
     setCampaignContent,
     onEditFollowup,
-    persona,
-    personaList,
-    selectedPersonaForCampaign,
-    setSelectedPersonaForCampaign,
+    autor,
+    autorList,
+    selectedAutorForCampaign,
+    setSelectedAutorForCampaign,
 }) => {
     useSettings();
     const [activeTab, setActiveTab] = useState(0);
@@ -232,34 +232,34 @@ const Campaign = ({
         setProblemsError(null);
         setCommonProblems([]);
         try {
-            if (!persona || Object.keys(persona).length === 0) {
-                throw new Error("Por favor, selecione uma persona para obter sugestões.");
+            if (!autor || Object.keys(autor).length === 0) {
+                throw new Error("Por favor, selecione uma autor para obter sugestões.");
             }
-            const problems = await generateCommonProblems({ persona });
+            const problems = await generateCommonProblems({ autor });
             setCommonProblems(problems);
         } catch (error) {
             setProblemsError(error.message);
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [commonProblems.length, persona]);
+    }, [commonProblems.length, autor]);
 
     const handleRegenerateProblems = useCallback(async () => {
         setIsLoadingProblems(true);
         setProblemsError(null);
         setCommonProblems([]);
         try {
-            if (!persona || Object.keys(persona).length === 0) {
-                throw new Error("Por favor, selecione uma persona para obter sugestões.");
+            if (!autor || Object.keys(autor).length === 0) {
+                throw new Error("Por favor, selecione uma autor para obter sugestões.");
             }
-            const problems = await generateCommonProblems({ persona });
+            const problems = await generateCommonProblems({ autor });
             setCommonProblems(problems);
         } catch (error) {
             setProblemsError(error.message);
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [persona]);
+    }, [autor]);
 
     useEffect(() => {
         if (isHintModalOpen) {
@@ -276,14 +276,14 @@ const Campaign = ({
             if (!problema.trim()) {
                 throw new Error("Descreva o problema primeiro.");
             }
-            const solutions = await generateCommonSolutions({ problema, persona });
+            const solutions = await generateCommonSolutions({ problema, autor });
             setCommonSolutions(solutions);
         } catch (error) {
             setSolutionsError(error.message);
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [commonSolutions.length, problema, persona]);
+    }, [commonSolutions.length, problema, autor]);
 
     const handleRegenerateSolutions = useCallback(async () => {
         setIsLoadingSolutions(true);
@@ -293,14 +293,14 @@ const Campaign = ({
             if (!problema.trim()) {
                 throw new Error("Descreva o problema primeiro.");
             }
-            const solutions = await generateCommonSolutions({ problema, persona });
+            const solutions = await generateCommonSolutions({ problema, autor });
             setCommonSolutions(solutions);
         } catch (error) {
             setSolutionsError(error.message);
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [problema, persona]);
+    }, [problema, autor]);
 
     useEffect(() => {
         if (isSolucaoHintModalOpen) {
@@ -365,17 +365,17 @@ const Campaign = ({
                     <Grid container spacing={3} sx={{ mt: 2 }}>
                         <Grid item xs={12}>
                             <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
-                                <InputLabel id="persona-select-label">Selecionar Persona</InputLabel>
+                                <InputLabel id="autor-select-label">Selecionar Autor</InputLabel>
                                 <Select
-                                    labelId="persona-select-label"
-                                    value={selectedPersonaForCampaign}
-                                    onChange={(e) => setSelectedPersonaForCampaign(e.target.value)}
-                                    label="Selecionar Persona"
+                                    labelId="autor-select-label"
+                                    value={selectedAutorForCampaign}
+                                    onChange={(e) => setSelectedAutorForCampaign(e.target.value)}
+                                    label="Selecionar Autor"
                                 >
                                     <MenuItem value="">
-                                        <em>Nenhuma (Usará Padrões)</em>
+                                        <em>Nenhum (Usará Padrões)</em>
                                     </MenuItem>
-                                    {personaList.map((p) => (
+                                    {autorList.map((p) => (
                                         <MenuItem key={p.id} value={p.id}>
                                             {p.name}
                                         </MenuItem>

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -45,7 +45,6 @@ import ColorThief from 'colorthief';
 
 import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
-import AutorWizard, { AutorWizardContent, TIPO_ORGANIZACAO_OPTIONS } from './AutorWizard';
 import PaletteWizard from './PaletteWizard';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
 import { getCampaignPrompt, saveCampaignPrompt } from '../utils/campaignPrompt';
@@ -79,7 +78,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemori
   const [value, setValue] = useState(0);
 
   // Other states
-  const [autor, setAutor] = useState({});
   const [instrucoes, setInstrucoes] = useState('');
   const [formato, setFormato] = useState('');
   const [colors, setColors] = useState([]);
@@ -88,66 +86,21 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemori
   const [initialState, setInitialState] = useState(null);
   const [isConfirmCloseOpen, setIsConfirmCloseOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
-  const [isAutorWizardVisible, setIsAutorWizardVisible] = useState(false);
-  const [initialAutorStep, setInitialAutorStep] = useState(0);
   const [showPaletteWizard, setShowPaletteWizard] = useState(false);
-
-  const handleGenerateAutorWithAI = async (descricaoGeral, dominioReferencia, siteExclusao, callback) => {
-    if (!geminiAPI.isInitialized) {
-      const apiKey = getGeminiApiKey();
-      if (!apiKey) {
-        toast.error('Chave de API do Gemini não configurada.');
-        return;
-      }
-      geminiAPI.initialize(apiKey);
-    }
-
-    setIsGeneratingAutor(true);
-    const prompt = `
-Com base na descrição do autor, preencha os campos do objeto JSON abaixo.
-**Descrição do Autor:** ${descricaoGeral}
-**Instruções Adicionais:**
-${dominioReferencia ? `- Use o site \`${dominioReferencia}\` como principal fonte de referência.` : ''}
-${siteExclusao ? `- NÃO use o site \`${siteExclusao}\` como referência.` : ''}
-**Campos para preencher (use exatamente estes nomes de chave):**
-- identidade: (string)
-- descricao: (string em HTML)
-- tipo: (string)
-- objetivoEstrategico: (string em HTML)
-- objetivoEngajamento: (string em HTML)
-Retorne apenas um único objeto JSON.`;
-
-    try {
-      const response = await geminiAPI.generateContent(prompt);
-      const cleanedResponse = response.replace(/```json/g, '').replace(/```/g, '').trim();
-      const generatedAutor = JSON.parse(cleanedResponse);
-      if (callback) callback(generatedAutor);
-    } catch (error) {
-      console.error("Erro ao gerar autor com IA:", error);
-      toast.error('Ocorreu um erro ao processar a resposta da IA.');
-    } finally {
-      setIsGeneratingAutor(false);
-    }
-  };
 
   useEffect(() => {
     if (open) {
       const apiKey = getGeminiApiKey();
       if (apiKey && !geminiAPI.isInitialized) geminiAPI.initialize(apiKey);
 
-      const { autor, instrucoes, formato, colors: loadedColors } = getCampaignPrompt();
+      const { instrucoes, formato, colors: loadedColors } = getCampaignPrompt();
 
-      setAutor(autor);
       setInstrucoes(instrucoes);
       setFormato(formato);
       const colorsAsObjects = (loadedColors || []).map(hex => ({ hex, name: `Cor (${hex})`, role: 'Salva', justification: '' }));
       setColors(colorsAsObjects);
 
-      setInitialState({ autor, instrucoes, formato, colors: colorsAsObjects });
-
-      if (!autor || !autor.identidade) setIsAutorWizardVisible(true);
-      else setIsAutorWizardVisible(false);
+      setInitialState({ instrucoes, formato, colors: colorsAsObjects });
     }
   }, [open]);
 
@@ -155,7 +108,7 @@ Retorne apenas um único objeto JSON.`;
 
   const handleSave = () => {
     const colorsToSave = colors.map(color => color.hex).filter(Boolean);
-    saveCampaignPrompt({ autor, instrucoes, formato, colors: colorsToSave });
+    saveCampaignPrompt({ instrucoes, formato, colors: colorsToSave });
     toast.success('Padrões de campanha salvos com sucesso!');
     onClose();
   };
@@ -169,28 +122,19 @@ Retorne apenas um único objeto JSON.`;
   const handleCloseEditor = () => setEditingField(null);
 
   const handleSaveEditor = (newContent) => {
-    if (editingField.startsWith('autor.')) {
-      const fieldName = editingField.split('.')[1];
-      setAutor(prev => ({ ...prev, [fieldName]: newContent }));
-    } else if (editingField === 'instrucoes') setInstrucoes(newContent);
+    if (editingField === 'instrucoes') setInstrucoes(newContent);
     else if (editingField === 'formato') setFormato(newContent);
     setEditingField(null);
   };
 
   const getCurrentContent = () => {
     if (!editingField) return '';
-    if (editingField.startsWith('autor.')) return autor[editingField.split('.')[1]] || '';
     if (editingField === 'instrucoes') return instrucoes;
     if (editingField === 'formato') return formato;
     return '';
   };
 
   const getEditorTitle = () => {
-    if (editingField === 'autor.descricao') return 'Editar Descrição da Empresa';
-    if (editingField === 'autor.tipo') return 'Editar Tipo de Organização';
-    if (editingField === 'autor.tipoOrganizacaoOutro') return 'Editar Tipo de Organização (Outro)';
-    if (editingField === 'autor.objetivoEstrategico') return 'Editar Objetivo Estratégico';
-    if (editingField === 'autor.objetivoEngajamento') return 'Editar Objetivo de Engajamento';
     if (editingField === 'instrucoes') return 'Editar Instruções';
     if (editingField === 'formato') return 'Editar Formato';
     return 'Editar';
@@ -232,22 +176,9 @@ Retorne apenas um único objeto JSON.`;
     }
   };
 
-  const handleAutorChange = (event) => {
-    const { name, value } = event.target;
-    setAutor(prev => ({ ...prev, [name]: value }));
-  };
-
-  const handleClearAutor = () => {
-    if (window.confirm('Tem certeza? Os dados do autor serão apagados.')) {
-      setAutor({});
-      setIsAutorWizardVisible(true);
-      toast.success('Dados do autor removidos.');
-    }
-  };
-
   const hasUnsavedChanges = () => {
     if (!initialState) return false;
-    const currentState = { autor, instrucoes, formato, colors };
+    const currentState = { instrucoes, formato, colors };
     // Custom comparison for colors as it's an array of objects
     const initialColorsHex = initialState.colors.map(c => c.hex);
     const currentColorsHex = currentState.colors.map(c => c.hex);
@@ -278,39 +209,19 @@ Retorne apenas um único objeto JSON.`;
         <DialogContent sx={{ p: 0, display: 'flex', flexDirection: 'column' }}>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tabs orientation="horizontal" variant="scrollable" value={value} onChange={handleChange}>
-              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Autor" {...a11yProps(0)} />
-              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Formato" {...a11yProps(1)} />
-              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Instruções" {...a11yProps(2)} />
-              <Tab icon={<PaletteIcon />} iconPosition="start" label="Cores" {...a11yProps(3)} />
+              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Formato" {...a11yProps(0)} />
+              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Instruções" {...a11yProps(1)} />
+              <Tab icon={<PaletteIcon />} iconPosition="start" label="Cores" {...a11yProps(2)} />
             </Tabs>
           </Box>
           <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
             <TabPanel value={value} index={0}>
-              {isAutorWizardVisible ? (
-                <AutorWizardContent autor={autor} onGenerate={handleGenerateAutorWithAI} isGeneratingAutor={isGeneratingAutor} onClose={() => setIsAutorWizardVisible(false)} onSave={(newAutor) => { setAutor(newAutor); setIsAutorWizardVisible(false); toast.success('Autor salvo com assistente!'); }} />
-              ) : (
-                <Stack spacing={2}>
-                  <Stack direction="row" spacing={1} sx={{ mb: 2, alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
-                    <Button variant="outlined" startIcon={<AutoAwesomeIcon />} onClick={() => { setInitialAutorStep(0); setIsAutorWizardVisible(true); }}>Gerar</Button>
-                    <Button variant="contained" startIcon={<Add />} onClick={() => { setInitialAutorStep(1); setIsAutorWizardVisible(true); }}>Assistente</Button>
-                    <Button variant="outlined" color="error" startIcon={<DeleteForeverIcon />} onClick={handleClearAutor} disabled={!autor || Object.keys(autor).length === 0}>Recomeçar</Button>
-                  </Stack>
-                  <TextField fullWidth label="Nome" name="identidade" value={autor?.identidade || ''} onChange={handleAutorChange} />
-                  <HtmlDisplayField title="Descrição da Empresa" htmlContent={autor?.descricao} onClick={() => handleOpenEditor('autor.descricao')} />
-                  <FormControl fullWidth><InputLabel>Tipo de Organização</InputLabel><Select name="tipo" value={autor?.tipo || ''} onChange={handleAutorChange} label="Tipo de Organização">{TIPO_ORGANIZACAO_OPTIONS.map((o) => (<MenuItem key={o} value={o}>{o}</MenuItem>))}</Select></FormControl>
-                  {autor?.tipo === 'Outro' && <TextField fullWidth label="Especifique o Tipo" name="tipoOrganizacaoOutro" value={autor?.tipoOrganizacaoOutro || ''} onChange={handleAutorChange} />}
-                  <HtmlDisplayField title="Objetivo Estratégico" htmlContent={autor?.objetivoEstrategico} onClick={() => handleOpenEditor('autor.objetivoEstrategico')} />
-                  <HtmlDisplayField title="Objetivo de Engajamento" htmlContent={autor?.objetivoEngajamento} onClick={() => handleOpenEditor('autor.objetivoEngajamento')} />
-                </Stack>
-              )}
-            </TabPanel>
-            <TabPanel value={value} index={1}>
               <HtmlDisplayField title="Formato" htmlContent={formato} onClick={() => handleOpenEditor('formato')} />
             </TabPanel>
-            <TabPanel value={value} index={2}>
+            <TabPanel value={value} index={1}>
               <HtmlDisplayField title="Instruções" htmlContent={instrucoes} onClick={() => handleOpenEditor('instruções')} />
             </TabPanel>
-            <TabPanel value={value} index={3}>
+            <TabPanel value={value} index={2}>
               <Stack spacing={2} sx={{ mb: 3 }}>
                 <Button variant="contained" startIcon={<AutoAwesomeIcon />} onClick={() => setShowPaletteWizard(true)} disabled={!onGeneratePalette} sx={{ alignSelf: 'flex-start' }}>Assistente de Paleta</Button>
               </Stack>
@@ -340,7 +251,6 @@ Retorne apenas um único objeto JSON.`;
         </DialogActions>
       </Dialog>
       <TextEditorDialog open={editingField !== null} title={getEditorTitle()} content={getCurrentContent()} onSave={handleSaveEditor} onClose={handleCloseEditor} html={true} />
-      <AutorWizard open={isAutorWizardVisible} onClose={() => { setIsAutorWizardVisible(false); setInitialAutorStep(0); }} autor={autor} initialStep={initialAutorStep} onSave={(newAutor) => { setAutor(newAutor); setIsAutorWizardVisible(false); setInitialAutorStep(0); toast.success('Autor salvo!'); }} onGenerate={handleGenerateAutorWithAI} isGeneratingAutor={isGeneratingAutor} />
       <PaletteWizard open={showPaletteWizard} onClose={() => setShowPaletteWizard(false)} onSave={(newPalette) => { setColors(newPalette); toast.success('Paleta de cores aplicada!'); }} onGenerate={async (briefing, callback) => { setIsGenerating(true); try { const result = await onGeneratePalette(briefing); callback(result); } catch (error) { toast.error('Erro ao gerar paleta.'); } finally { setIsGenerating(false); } }} isGenerating={isGenerating} />
       <Dialog open={isConfirmCloseOpen} onClose={() => setIsConfirmCloseOpen(false)}>
         <DialogTitle>Descartar Alterações?</DialogTitle>

--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -33,6 +33,7 @@ const MainAppBar = ({
   darkMode,
   setDarkMode,
   onShowPersonas,
+  onShowAutores,
   onShowCampaigns,
   setShowSetupModal,
   setShowCampaignStandardsModal,
@@ -43,6 +44,7 @@ const MainAppBar = ({
   onLoadCampaign,
   currentView,
   onPersonaMenuClick,
+  onAutorMenuClick,
   isDrawerOpen,
 }) => {
   const { user, logout } = useUserAuth();
@@ -63,6 +65,27 @@ const MainAppBar = ({
     navigate('/login');
   };
 
+  const handleMenuIconClick = () => {
+    if (currentView === 'personas') {
+      onPersonaMenuClick();
+    } else if (currentView === 'autores') {
+      onAutorMenuClick();
+    } else {
+      onMenuClick();
+    }
+  };
+
+  const getTitle = () => {
+    switch (currentView) {
+      case 'personas':
+        return 'Personas';
+      case 'autores':
+        return 'Autores';
+      default:
+        return 'Midiator';
+    }
+  };
+
   return (
     <AppBar
       position="fixed"
@@ -71,19 +94,19 @@ const MainAppBar = ({
       }}
     >
       <Toolbar>
-        {(currentView === 'personas' || (currentView === 'campaigns' && isMobile)) && (
+        {(currentView !== 'campaigns' || isMobile) && (
           <IconButton
             color="inherit"
             aria-label="open drawer"
             edge="start"
-            onClick={currentView === 'personas' ? onPersonaMenuClick : onMenuClick}
+            onClick={handleMenuIconClick}
             sx={{ mr: 2 }}
           >
             {isDrawerOpen ? <CloseIcon /> : <MenuIcon />}
           </IconButton>
         )}
         <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-          {currentView === 'personas' ? 'Personas' : 'Midiator'}
+          {getTitle()}
         </Typography>
 
         <Tooltip title="Salvar Campanha">
@@ -139,6 +162,10 @@ const MainAppBar = ({
           <MenuItem onClick={() => { handleUserMenuClose(); onShowPersonas(); }}>
             <PeopleIcon sx={{ mr: 1 }} />
             Personas
+          </MenuItem>
+          <MenuItem onClick={() => { handleUserMenuClose(); onShowAutores(); }}>
+            <AccountCircle sx={{ mr: 1 }} />
+            Autores
           </MenuItem>
           <Divider />
           <MenuItem onClick={() => { handleUserMenuClose(); setShowSetupModal(true); }}>

--- a/src/pages/AutoresPage.jsx
+++ b/src/pages/AutoresPage.jsx
@@ -1,0 +1,303 @@
+import React, { useState, useEffect } from 'react';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import {
+  Paper, Typography, Box, Button, Alert, IconButton, Toolbar, Divider, Drawer, List, ListItem, ListItemButton, ListItemText, CircularProgress,
+} from '@mui/material';
+import { ChevronLeft, Add, Delete as DeleteIcon } from '@mui/icons-material';
+import { toast } from 'sonner';
+import isEqual from 'lodash.isequal';
+
+import { getAutores, saveAutor, updateAutor, deleteAutor } from '../utils/autorState';
+import AutorWizard, { emptyAutorWizardData } from '../components/AutorWizard';
+import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
+import { getGeminiApiKey } from '../utils/geminiCredentials';
+import geminiAPI from '../utils/geminiAPI';
+
+const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected }) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const [autorList, setAutorList] = useState([]);
+  const [selectedAutor, setSelectedAutor] = useState(null);
+  const [autoresLoading, setAutoresLoading] = useState(true);
+  const [autoresError, setAutoresError] = useState(null);
+  const [isGeneratingAutor, setIsGeneratingAutor] = useState(false);
+  const [initialWizardStep, setInitialWizardStep] = useState(0);
+
+  const [autorFormData, setAutorFormData] = useState(null);
+  const [isAutorDirty, setIsAutorDirty] = useState(false);
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const [navigationTarget, setNavigationTarget] = useState(null);
+
+  useEffect(() => {
+    if (selectedAutor && autorFormData) {
+        const isDirty = !isEqual(selectedAutor.autor_data, autorFormData);
+        setIsAutorDirty(isDirty);
+    } else {
+        setIsAutorDirty(false);
+    }
+  }, [autorFormData, selectedAutor]);
+
+  useEffect(() => {
+      fetchAutores();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedAutor && onNoAutorSelected) {
+      onNoAutorSelected();
+    }
+  }, [selectedAutor, onNoAutorSelected]);
+
+  const fetchAutores = async () => {
+      setAutoresLoading(true);
+      try {
+          const data = await getAutores();
+          setAutorList(data);
+      } catch (err) {
+          setAutoresError(err.message);
+      } finally {
+          setAutoresLoading(false);
+      }
+  };
+
+  const handleSelectAutor = (p) => {
+      setSelectedAutor(p);
+      setAutorFormData(p.autor_data);
+      setIsAutorDirty(false);
+      setInitialWizardStep(1);
+      if (isMobile) setAutorDrawerOpen(false);
+  };
+
+  const handleNewAutor = () => {
+      const newEmptyAutor = { name: '', autor_data: { ...emptyAutorWizardData } };
+      setSelectedAutor(newEmptyAutor);
+      setAutorFormData(newEmptyAutor.autor_data);
+      setIsAutorDirty(false);
+      setInitialWizardStep(0);
+      if (isMobile) setAutorDrawerOpen(false);
+  };
+
+  const handleSaveAutor = async () => {
+    if (!autorFormData) {
+        toast.error('Não há dados de autor para salvar.');
+        return false;
+    }
+    const autorToSave = { ...selectedAutor, name: autorFormData.identidade, autor_data: autorFormData };
+    if (!autorToSave.name) {
+        toast.error('O nome do autor é obrigatório.');
+        return false;
+    }
+    try {
+        const saved = autorToSave.id
+            ? await updateAutor(autorToSave.id, autorToSave.name, autorToSave.autor_data)
+            : await saveAutor(autorToSave.name, autorToSave.autor_data);
+        toast.success("Autor salvo com sucesso!");
+        await fetchAutores();
+        setSelectedAutor(saved);
+        setAutorFormData(saved.autor_data);
+        setIsAutorDirty(false);
+        return true; // Indicate success
+    } catch (err) {
+        toast.error(`Falha ao salvar autor: ${err.message}`);
+        return false; // Indicate failure
+    }
+  };
+
+    const handleGenerateAutorWithAI = async (description, callback) => {
+        if (!geminiAPI.isInitialized) {
+            const apiKey = getGeminiApiKey();
+            if (!apiKey) {
+                toast.error('Chave de API do Gemini não configurada.');
+                return;
+            }
+            geminiAPI.initialize(apiKey);
+        }
+        setIsGeneratingAutor(true);
+        const prompt = `Crie um objeto JSON para um autor de marketing detalhado com base na seguinte descrição: '${description}'. O JSON deve ter as seguintes chaves: 'identidade' (string), 'descricao' (string), 'tipo' (string), 'tipoOrganizacaoOutro' (string), 'objetivoEstrategico' (string), e 'objetivoEngajamento' (string).`;
+        let cleanedResponse = '';
+        try {
+            const response = await geminiAPI.generateContent(prompt);
+            cleanedResponse = response.replace(/```json/g, '').replace(/```/g, '').trim();
+            if (callback) callback(JSON.parse(cleanedResponse));
+        } catch (error) {
+            console.error("Error generating or parsing autor from AI:", error);
+            console.error("AI Response Text:", cleanedResponse); // Log the raw text
+            toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console para detalhes.');
+        } finally {
+            setIsGeneratingAutor(false);
+        }
+    };
+
+    const handleNavigation = (targetAction) => {
+        if (isAutorDirty) {
+            setNavigationTarget(() => targetAction);
+            setShowUnsavedDialog(true);
+        } else {
+            targetAction();
+        }
+    };
+
+    const handleDialogClose = () => {
+        setShowUnsavedDialog(false);
+        setNavigationTarget(null);
+    };
+
+    const handleDialogDiscard = () => {
+        setShowUnsavedDialog(false);
+        setIsAutorDirty(false);
+        if (navigationTarget) {
+            navigationTarget();
+        }
+        setNavigationTarget(null);
+    };
+
+    const handleDialogSaveAndNavigate = async () => {
+        const success = await handleSaveAutor();
+        setShowUnsavedDialog(false);
+        if (success && navigationTarget) {
+            navigationTarget();
+        }
+        setNavigationTarget(null);
+    };
+
+  const handleConfirmDelete = async (autorId) => {
+    try {
+      await deleteAutor(autorId);
+      toast.success('Autor excluído com sucesso!');
+      fetchAutores(); // Refresh list
+      setSelectedAutor(null); // Deselect if the deleted one was selected
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleDeleteClick = (autor) => {
+    if (window.confirm(`Tem certeza que deseja excluir o autor "${autor.name}"? Esta ação não pode ser desfeita.`)) {
+      handleConfirmDelete(autor.id);
+    }
+  };
+
+  const autorDrawerContent = (
+    <Box sx={{p: 2, width: 320}}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+            <Typography variant="h6">Autores</Typography>
+        </Box>
+        <Button variant="contained" startIcon={<Add />} onClick={handleNewAutor} fullWidth>Novo Autor</Button>
+        <Divider sx={{my: 2}} />
+        {autoresLoading && <CircularProgress />}
+        {autoresError && <Alert severity="error">{autoresError}</Alert>}
+        {!autoresLoading && !autoresError && (
+            <List>
+                {autorList.map((p) => (
+                  <ListItem
+                    key={p.id}
+                    disablePadding
+                    secondaryAction={
+                      <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteClick(p)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    }
+                  >
+                    <ListItemButton selected={selectedAutor?.id === p.id} onClick={() => handleNavigation(() => handleSelectAutor(p))}>
+                        <ListItemText primary={p.name} />
+                    </ListItemButton>
+                  </ListItem>
+                ))}
+            </List>
+        )}
+    </Box>
+  );
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', width: '100%', height: '100%' }}>
+          <Drawer
+              variant={isMobile ? 'temporary' : 'persistent'}
+              anchor="left"
+              open={autorDrawerOpen}
+              onClose={() => handleNavigation(() => setAutorDrawerOpen(false))}
+              sx={{
+                  width: 320,
+                  flexShrink: 0,
+                  '& .MuiDrawer-paper': {
+                      width: 320,
+                      boxSizing: 'border-box',
+                      position: 'absolute', // Position relative to the parent Box
+                  },
+              }}
+          >
+              <Toolbar />
+              {autorDrawerContent}
+          </Drawer>
+          <Box
+              component="main"
+              sx={{
+                  flexGrow: 1,
+                  p: 3,
+                  transition: theme.transitions.create('margin', {
+                    easing: theme.transitions.easing.sharp,
+                    duration: theme.transitions.duration.leavingScreen,
+                  }),
+                  marginLeft: !isMobile ? `-${320}px` : 0,
+                  ...(!isMobile && autorDrawerOpen && {
+                    transition: theme.transitions.create('margin', {
+                        easing: theme.transitions.easing.easeOut,
+                        duration: theme.transitions.duration.enteringScreen,
+                    }),
+                    marginLeft: 0,
+                  }),
+              }}
+          >
+              <Box>
+                {selectedAutor ? (
+                  isMobile ? (
+                    <AutorWizard
+                      key={selectedAutor.id || 'new'}
+                      open={Boolean(selectedAutor)}
+                      onClose={() => handleNavigation(() => setSelectedAutor(null))}
+                      onSave={handleSaveAutor}
+                      onReset={handleNewAutor}
+                      autorData={autorFormData}
+                      onAutorDataChange={setAutorFormData}
+                      onGenerate={handleGenerateAutorWithAI}
+                      isGeneratingAutor={isGeneratingAutor}
+                      initialStep={initialWizardStep}
+                    />
+                  ) : (
+                    <Paper elevation={2} sx={{ p: 3 }}>
+                      <AutorWizard
+                        key={selectedAutor.id || 'new'}
+                        open={Boolean(selectedAutor)}
+                        onClose={() => handleNavigation(() => setSelectedAutor(null))}
+                        onSave={handleSaveAutor}
+                        onReset={handleNewAutor}
+                        autorData={autorFormData}
+                        onAutorDataChange={setAutorFormData}
+                        onGenerate={handleGenerateAutorWithAI}
+                        isGeneratingAutor={isGeneratingAutor}
+                        initialStep={initialWizardStep}
+                      />
+                    </Paper>
+                  )
+                ) : (
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '50vh' }}>
+                    <Typography variant="h6" color="text.secondary">
+                      Selecione um autor para editar ou crie um novo.
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
+          </Box>
+      </Box>
+      <UnsavedChangesDialog
+        open={showUnsavedDialog}
+        onClose={handleDialogClose}
+        onConfirmDiscard={handleDialogDiscard}
+        onConfirmSave={handleDialogSaveAndNavigate}
+      />
+    </>
+  );
+};
+
+export default AutoresPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -20,9 +20,11 @@ import { loadSettingsFromDb } from '../utils/credentialsManager';
 import { getCampaigns, saveCampaign, loadCampaign, updateCampaign } from '../utils/campaignState';
 import { checkAuthStatus } from '../utils/auth';
 import { getPersonas, savePersona, updatePersona } from '../utils/personaState';
+import { getAutores } from '../utils/autorState';
 
 import MyCampaignsStep from '../components/MyCampaignsStep';
 import PersonasPage from './PersonasPage';
+import AutoresPage from './AutoresPage';
 import MainAppBar from '../components/MainAppBar';
 import Sidebar from '../components/Sidebar';
 import FieldPositioner from '../components/FieldPositioner';
@@ -73,6 +75,7 @@ function HomePage() {
 
   // Component State
   const [personaList, setPersonaList] = useState([]);
+  const [autorList, setAutorList] = useState([]);
   const [currentView, setCurrentView] = useState('campaigns');
   const [activeStep, setActiveStep] = useState(null);
   const [darkMode, setDarkMode] = useState(() => {
@@ -83,6 +86,7 @@ function HomePage() {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile);
   const [personaDrawerOpen, setPersonaDrawerOpen] = useState(!isMobile);
+  const [autorDrawerOpen, setAutorDrawerOpen] = useState(!isMobile);
   const [csvData, setCsvData] = useState([]);
   const [csvHeaders, setCsvHeaders] = useState([]);
   const [backgroundImage, setBackgroundImage] = useState(null);
@@ -150,6 +154,7 @@ function HomePage() {
   const [fontScale, setFontScale] = useState(1);
 
   const [selectedPersonaForCampaign, setSelectedPersonaForCampaign] = useState('');
+  const [selectedAutorForCampaign, setSelectedAutorForCampaign] = useState('');
 
   // State for unsaved changes guard
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
@@ -385,6 +390,12 @@ function HomePage() {
         .catch(err => {
           console.error("Failed to fetch personas for campaign step:", err);
           toast.error('Could not load personas for campaign dropdown.');
+        });
+      getAutores()
+        .then(setAutorList)
+        .catch(err => {
+          console.error("Failed to fetch autores for campaign step:", err);
+          toast.error('Could not load autores for campaign dropdown.');
         });
     }
   }, [user]);
@@ -968,10 +979,12 @@ function HomePage() {
             onSaveCampaign={() => setShowSaveModal(true)}
             onLoadCampaign={() => setShowLoadModal(true)}
             onShowPersonas={() => handleNavigation(() => setCurrentView('personas'))}
+            onShowAutores={() => handleNavigation(() => setCurrentView('autores'))}
             onShowCampaigns={() => handleNavigation(() => setCurrentView('campaigns'))}
             currentView={currentView}
             onPersonaMenuClick={() => setPersonaDrawerOpen(!personaDrawerOpen)}
-            isDrawerOpen={currentView === 'personas' ? personaDrawerOpen : sidebarOpen}
+            onAutorMenuClick={() => setAutorDrawerOpen(!autorDrawerOpen)}
+            isDrawerOpen={currentView === 'personas' ? personaDrawerOpen : currentView === 'autores' ? autorDrawerOpen : sidebarOpen}
         />
         {currentView === 'campaigns' && (
           <>
@@ -1022,9 +1035,9 @@ function HomePage() {
                   followupPostsQuantity={followupPostsQuantity}
                   setFollowupPostsQuantity={setFollowupPostsQuantity}
                   setAspectRatio={setAspectRatio}
-                  personaList={personaList}
-                  selectedPersonaForCampaign={selectedPersonaForCampaign}
-                  setSelectedPersonaForCampaign={setSelectedPersonaForCampaign}
+                  autorList={autorList}
+                  selectedAutorForCampaign={selectedAutorForCampaign}
+                  setSelectedAutorForCampaign={setSelectedAutorForCampaign}
                 /></Container></div>
                 <div hidden={activeStep !== 2}><PostsCurtosStep steps={steps} inputMethod={inputMethod} setInputMethod={setInputMethod} handleDrop={handleDrop} handleDragOver={handleDragOver} fileInputRef={fileInputRef} handleCSVUpload={handleCSVUpload} downloadExampleCsv={downloadExampleCsv} setShowSetupModal={setShowSetupModal} promptNumRecords={promptNumRecords} setPromptNumRecords={setPromptNumRecords} promptText={promptText} setPromptText={setPromptText} generateImagesAutomatically={generateImagesAutomatically} setGenerateImagesAutomatically={setGenerateImagesAutomatically} handleGenerateIAContent={handleGenerateIAContent} isGenerating={isGenerating} csvData={csvData} csvHeaders={csvHeaders} onDadosAlterados={handleDadosAlterados} darkMode={darkMode} exportCsv={exportCsv} /></div>
                 <div hidden={activeStep !== 3}>
@@ -1079,6 +1092,7 @@ function HomePage() {
               </>
             )}
             {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} />}
+            {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} />}
         </Box>
       </Box>
       <UnsavedChangesDialog

--- a/src/utils/autorState.js
+++ b/src/utils/autorState.js
@@ -1,0 +1,126 @@
+import fetchWithAuth from './fetchWithAuth';
+import { toast } from 'sonner';
+
+/**
+ * This module provides functions for interacting with the autor API endpoints.
+ * It abstracts the fetch calls and handles authentication and basic error reporting.
+ */
+
+/**
+ * Fetches all autores for the currently authenticated user.
+ * @returns {Promise<Array>} A promise that resolves to an array of autor objects.
+ * @throws {Error} If the fetch request fails.
+ */
+export const getAutores = async () => {
+  const res = await fetchWithAuth('/api/autores');
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to fetch autores.');
+  }
+  return res.json();
+};
+
+/**
+ * Loads a single autor by its ID.
+ * @param {string|number} id - The ID of the autor to fetch.
+ * @returns {Promise<object>} A promise that resolves to the autor object.
+ * @throws {Error} If the fetch request fails.
+ */
+export const loadAutor = async (id) => {
+  const res = await fetchWithAuth(`/api/autores/${id}`);
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to load autor.');
+  }
+  return res.json();
+};
+
+/**
+ * Creates a new autor.
+ * @param {string} name - The name of the new autor.
+ * @param {object} autorData - The detailed data object for the autor.
+ * @returns {Promise<object>} A promise that resolves to the newly created autor object.
+ * @throws {Error} If the creation fails.
+ */
+export const saveAutor = async (name, autorData) => {
+  try {
+    const requestBody = JSON.stringify({ name, autor_data: autorData });
+
+    const createRes = await fetchWithAuth('/api/autores', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: requestBody,
+    });
+
+    if (!createRes.ok) {
+      const errorBody = await createRes.text();
+      throw new Error(`Failed to create autor. Server says: ${errorBody}`);
+    }
+
+    const result = await createRes.json();
+    return result;
+  } catch (error) {
+    toast.error(`Save failed: ${error.message}`);
+    throw error;
+  }
+};
+
+/**
+ * Updates an existing autor.
+ * @param {string|number} id - The ID of the autor to update.
+ * @param {string} name - The updated name of the autor.
+ * @param {object} autorData - The updated detailed data object for the autor.
+ * @returns {Promise<object>} A promise that resolves to the updated autor object.
+ * @throws {Error} If the update fails.
+ */
+export const updateAutor = async (id, name, autorData) => {
+    try {
+        const requestBody = JSON.stringify({ name, autor_data: autorData });
+
+        const res = await fetchWithAuth(`/api/autores/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: requestBody,
+        });
+
+        if (!res.ok) {
+            const errorBody = await res.text();
+            throw new Error(`Failed to update autor. Server says: ${errorBody}`);
+        }
+
+        const result = await res.json();
+        return result;
+    } catch (error) {
+        toast.error(`Update failed: ${error.message}`);
+        throw error;
+    }
+};
+
+/**
+ * Deletes an autor by its ID.
+ * @param {string|number} id - The ID of the autor to delete.
+ * @returns {Promise<object>} A promise that resolves to the confirmation message from the API.
+ * @throws {Error} If the deletion fails.
+ */
+export const deleteAutor = async (id) => {
+  try {
+    const res = await fetchWithAuth(`/api/autores/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      // Handle the specific 409 conflict error
+      if (res.status === 409) {
+        toast.error(err.error || 'This autor is in use and cannot be deleted.');
+      } else {
+        toast.error(err.error || 'Failed to delete autor.');
+      }
+      throw new Error(err.error || 'Failed to delete autor.');
+    }
+    // The success toast is now handled in the component to avoid duplication
+    // toast.success('Autor deleted successfully!');
+    return res.json();
+  } catch (error) {
+    // The toast is already shown for !res.ok cases, so we just re-throw
+    // for the component to catch and handle loading states etc.
+    throw error;
+  }
+};

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -2,7 +2,7 @@ const CAMPAIGN_PROMPT_STORAGE_KEY = 'campaignPrompt';
 
 /**
  * Salva o objeto do prompt de campanha no localStorage.
- * @param {object} promptData - O objeto com os dados do prompt ({ autor, instrucoes, formato, colors }).
+ * @param {object} promptData - O objeto com os dados do prompt ({ instrucoes, formato, colors }).
  */
 export function saveCampaignPrompt(promptData) {
   if (typeof window !== 'undefined' && window.localStorage) {
@@ -15,6 +15,9 @@ export function saveCampaignPrompt(promptData) {
       if (dataToStore.persona_id) {
         delete dataToStore.persona_id;
       }
+      if (dataToStore.autor) {
+        delete dataToStore.autor;
+      }
       window.localStorage.setItem(CAMPAIGN_PROMPT_STORAGE_KEY, JSON.stringify(dataToStore));
     } catch (error) {
       console.error("Erro ao salvar o prompt de campanha:", error);
@@ -25,20 +28,10 @@ export function saveCampaignPrompt(promptData) {
 /**
  * Recupera o objeto do prompt de campanha do localStorage.
  * Lida com a migração de formatos de dados antigos.
- * @returns {{autor: object, instrucoes: string, formato: string, colors: string[]}} O objeto do prompt ou um objeto com campos vazios.
+ * @returns {{instrucoes: string, formato: string, colors: string[]}} O objeto do prompt ou um objeto com campos vazios.
  */
 export function getCampaignPrompt() {
   const defaultPrompt = {
-    autor: {
-      identidade: '',
-      descricao: '',
-      tipo: '',
-      tipoOrganizacaoOutro: '',
-      objetivoEstrategico: '',
-      objetivoEngajamento: '',
-      dominioReferencia: '',
-      siteExclusao: '',
-    },
     instrucoes: '',
     formato: '',
     colors: [],
@@ -65,15 +58,9 @@ export function getCampaignPrompt() {
         return defaultPrompt;
       }
 
-      // Migração para o campo autor: se for uma string, converte para o novo formato de objeto.
-      if (typeof parsedData.autor === 'string') {
-        console.log("Migrando autor do formato antigo (string) para o novo (objeto).");
-        parsedData.autor = {
-          ...defaultPrompt.autor,
-          identidade: parsedData.autor,
-        };
-      } else if (typeof parsedData.autor !== 'object' || parsedData.autor === null) {
-        parsedData.autor = { ...defaultPrompt.autor };
+      // Migração para remover o campo autor
+      if (parsedData.autor) {
+        delete parsedData.autor;
       }
 
       // Migração para remover o campo aspectRatio
@@ -90,11 +77,6 @@ export function getCampaignPrompt() {
       const finalData = {
         ...defaultPrompt,
         ...parsedData,
-        // Garante que a estrutura aninhada de autor também seja mesclada
-        autor: {
-          ...defaultPrompt.autor,
-          ...(parsedData.autor || {}),
-        },
       };
 
       return finalData;


### PR DESCRIPTION
This commit refactors the author data management system to be analogous to the existing persona management system. Author data is no longer stored in localStorage but is now managed through a dedicated backend API and database table.

Key changes:
- Added an `autores` table to the database and linked it to the `campaigns` table via an `autor_id`.
- Created backend API endpoints (`/api/autores`) for author CRUD operations.
- Implemented a new `AutoresPage.jsx` for users to manage their authors (create, edit, delete).
- Refactored `AutorWizard.jsx` into a controlled component for the new management page.
- Integrated an author selection dropdown into the campaign creation flow, allowing a campaign to be associated with a specific author.
- Removed the legacy author implementation from `CampaignStandardsModal.jsx` and `utils/campaignPrompt.js`, which relied on localStorage.
- Added navigation to the new "Autores" page in the main application app bar.