### PR TITLE
Fix: Restore reference and exclusion site fields in Author Wizard

### DIFF
--- a/src/components/AutorWizard.jsx
+++ b/src/components/AutorWizard.jsx
@@ -60,7 +60,7 @@ export const AutorWizardContent = ({ onSave, onClose, onGenerate, isGeneratingAu
   const handleGenerateClick = () => {
     const hasExistingData = autorData && autorData.identidade;
     const proceed = () => {
-        onGenerate(autorData.descricaoGeral, (generatedAutor) => {
+        onGenerate(autorData.descricaoGeral, autorData.dominioReferencia, autorData.siteExclusao, (generatedAutor) => {
             onAutorDataChange(prev => ({ ...prev, ...generatedAutor }));
             setActiveStep(1);
         });
@@ -78,13 +78,41 @@ export const AutorWizardContent = ({ onSave, onClose, onGenerate, isGeneratingAu
   const getStepContent = (step) => {
     switch (step) {
       case 0: return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <TextField name="descricaoGeral" label="Descrição do Autor" multiline rows={6} fullWidth value={autorData.descricaoGeral || ''} onChange={handleChange} placeholder="Ex: 'Uma empresa de consultoria...'" disabled={isGeneratingAutor} />
-            <Tooltip title="Gerar autor com IA">
-                <IconButton onClick={handleGenerateClick} disabled={isGeneratingAutor || !autorData.descricaoGeral?.trim()} color="primary">
-                    {isGeneratingAutor ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
-                </IconButton>
-            </Tooltip>
+        <Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                <TextField name="descricaoGeral" label="Descrição do Autor" multiline rows={6} fullWidth value={autorData.descricaoGeral || ''} onChange={handleChange} placeholder="Ex: 'Uma empresa de consultoria...'" disabled={isGeneratingAutor} />
+                <Tooltip title="Gerar autor com IA">
+                    <IconButton onClick={handleGenerateClick} disabled={isGeneratingAutor || !autorData.descricaoGeral?.trim()} color="primary">
+                        {isGeneratingAutor ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
+                    </IconButton>
+                </Tooltip>
+            </Box>
+            <Grid container spacing={2}>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                      name="dominioReferencia"
+                      label="Domínio de Referência (Opcional)"
+                      fullWidth
+                      value={autorData.dominioReferencia || ''}
+                      onChange={handleChange}
+                      placeholder="Ex: 'empresa.com.br'"
+                      helperText="A IA usará este site como fonte de informação."
+                      disabled={isGeneratingAutor}
+                    />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                    <TextField
+                      name="siteExclusao"
+                      label="Site para Excluir da Busca (Opcional)"
+                      fullWidth
+                      value={autorData.siteExclusao || ''}
+                      onChange={handleChange}
+                      placeholder="Ex: 'concorrente.com.br'"
+                      helperText="A IA evitará este site em sua busca."
+                      disabled={isGeneratingAutor}
+                    />
+                </Grid>
+            </Grid>
         </Box>
       );
       case 1: return <Box><Typography variant="h6" gutterBottom>Revisão e Detalhamento</Typography><Grid container spacing={3}><Grid item xs={12}><TextField label="Nome do Autor" name="identidade" value={autorData.identidade || ''} onChange={handleChange} fullWidth required /></Grid><Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Descrição da Empresa</Typography><TextEditor value={autorData.descricao || ''} onChange={(v) => handleRichTextChange('descricao', v)} html={true} /></Grid><Grid item xs={12}><FormControl fullWidth><InputLabel>Tipo de Organização</InputLabel><Select name="tipo" value={autorData.tipo || ''} onChange={handleChange} label="Tipo de Organização">{TIPO_ORGANIZACAO_OPTIONS.map((o) => (<MenuItem key={o} value={o}>{o}</MenuItem>))}</Select></FormControl></Grid>{autorData.tipo === 'Outro' && <Grid item xs={12}><TextField label="Especifique o Tipo" name="tipoOrganizacaoOutro" value={autorData.tipoOrganizacaoOutro || ''} onChange={handleChange} fullWidth /></Grid>}<Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Objetivo Estratégico</Typography><TextEditor value={autorData.objetivoEstrategico || ''} onChange={(v) => handleRichTextChange('objetivoEstrategico', v)} html={true} /></Grid><Grid item xs={12}><Typography variant="subtitle1" gutterBottom>Objetivo de Engajamento</Typography><TextEditor value={autorData.objetivoEngajamento || ''} onChange={(v) => handleRichTextChange('objetivoEngajamento', v)} html={true} /></Grid></Grid></Box>;

--- a/src/pages/AutoresPage.jsx
+++ b/src/pages/AutoresPage.jsx
@@ -104,7 +104,7 @@ const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected })
     }
   };
 
-    const handleGenerateAutorWithAI = async (description, callback) => {
+    const handleGenerateAutorWithAI = async (descricaoGeral, dominioReferencia, siteExclusao, callback) => {
         if (!geminiAPI.isInitialized) {
             const apiKey = getGeminiApiKey();
             if (!apiKey) {
@@ -114,7 +114,19 @@ const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected })
             geminiAPI.initialize(apiKey);
         }
         setIsGeneratingAutor(true);
-        const prompt = `Crie um objeto JSON para um autor de marketing detalhado com base na seguinte descrição: '${description}'. O JSON deve ter as seguintes chaves: 'identidade' (string), 'descricao' (string), 'tipo' (string), 'tipoOrganizacaoOutro' (string), 'objetivoEstrategico' (string), e 'objetivoEngajamento' (string).`;
+        const prompt = `
+Com base na descrição do autor, preencha os campos do objeto JSON abaixo.
+**Descrição do Autor:** ${descricaoGeral}
+**Instruções Adicionais:**
+${dominioReferencia ? `- Use o site \`${dominioReferencia}\` como principal fonte de referência.` : ''}
+${siteExclusao ? `- NÃO use o site \`${siteExclusao}\` como referência.` : ''}
+**Campos para preencher (use exatamente estes nomes de chave):**
+- identidade: (string)
+- descricao: (string em HTML)
+- tipo: (string)
+- objetivoEstrategico: (string em HTML)
+- objetivoEngajamento: (string em HTML)
+Retorne apenas um único objeto JSON.`;
         let cleanedResponse = '';
         try {
             const response = await geminiAPI.generateContent(prompt);


### PR DESCRIPTION
This commit fixes a regression where the "reference site" and "exclusion site" fields were removed from the Author Wizard during the refactoring process.

The following changes have been made:
- The `dominioReferencia` and `siteExclusao` fields have been re-added to the UI in the first step of the `AutorWizard`.
- The `handleGenerateAutorWithAI` function in `AutoresPage.jsx` has been updated to accept these fields and include them in the prompt sent to the generative AI.

This restores the original functionality that allows users to guide the AI generation by providing reference and exclusion websites.