### PR TITLE
feat(api, frontend): Add admin-only manual scheduler trigger

### DIFF
--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -50,3 +50,25 @@ export const withAuth = (handler) => {
     }
   };
 };
+
+/**
+ * A higher-order function to protect API routes that require admin privileges.
+ * It verifies the JWT and checks if the user has the 'admin' role.
+ *
+ * @param {Function} handler The original API route handler.
+ * @returns {Function} The wrapped handler with admin authentication check.
+ */
+export const withAdminAuth = (handler) => {
+  // We can reuse the withAuth middleware and chain the admin check.
+  const authenticatedHandler = withAuth(async (req, res) => {
+    // By the time we get here, withAuth has already run successfully.
+    // req.user is guaranteed to be populated.
+    if (req.user.role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden: Administrator access required.' });
+    }
+    // If the user is an admin, proceed to the original handler.
+    return handler(req, res);
+  });
+
+  return authenticatedHandler;
+};

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -149,7 +149,7 @@ async function handleUpdateSchedule(request, response) {
 }
 
 // The main scheduler logic
-async function handleRunScheduler(request, response) {
+export async function handleRunScheduler(request, response) {
     const fetch = (await import('node-fetch')).default;
     console.log('Scheduler run initiated...');
     let publishedCount = 0;

--- a/api/schedule/run.js
+++ b/api/schedule/run.js
@@ -1,0 +1,26 @@
+import { withAdminAuth } from '../middleware/auth.js';
+import { handleRunScheduler } from '../schedule.js';
+
+/**
+ * API handler for manually triggering the scheduler by an admin.
+ * It only accepts POST requests and is protected by admin-only authentication.
+ *
+ * @param {import('http').IncomingMessage} req The request object.
+ * @param {import('http').ServerResponse} res The response object.
+ */
+const handler = (req, res) => {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+
+    // req.user is guaranteed to be available here because withAdminAuth runs first.
+    console.log(`Manual scheduler run initiated by admin user: ${req.user.email}`);
+
+    // The actual scheduler logic is in handleRunScheduler.
+    return handleRunScheduler(req, res);
+};
+
+// Wrap the main handler with the admin auth middleware.
+// This ensures that only authenticated admins can reach this point.
+export default withAdminAuth(handler);

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-bpFdQvvM.js"></script>
+  <script type="module" crossorigin src="/assets/index-DdnH59iC.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DBiS__Si.css">
 </head>
 

--- a/src/pages/AdminDashboardPage.jsx
+++ b/src/pages/AdminDashboardPage.jsx
@@ -64,7 +64,7 @@ const AdminDashboardPage = () => {
     setIsSchedulerRunning(true);
     toast.info('Scheduler run initiated...');
     try {
-      const res = await fetch('/api/schedule');
+      const res = await fetch('/api/schedule/run', { method: 'POST' });
       const data = await res.json();
       if (res.ok) {
         toast.success(data.message || 'Scheduler run completed successfully.');


### PR DESCRIPTION
This commit introduces a new feature allowing administrators to manually trigger the post scheduler from a button on the admin dashboard.

The implementation includes:
- A new reusable `withAdminAuth` middleware to protect routes that require administrator privileges. It checks for a valid user session and verifies that the user has the `role` of 'admin'.
- The core scheduler logic in `handleRunScheduler` has been exported from `api/schedule.js` to be reusable.
- A new, secure API endpoint at `POST /api/schedule/run` that is protected by the `withAdminAuth` middleware and executes the scheduler logic.
- The frontend Admin Dashboard page has been updated to call this new endpoint, replacing the previous incorrect call to `GET /api/schedule`.

This provides the requested manual trigger functionality while maintaining a secure separation between the automated cron job authentication and the user-based admin authentication.