### PR TITLE
Refactor: Relocate Memorial Descritivo feature

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -73,7 +73,7 @@ function TabPanel(props) {
   );
 }
 
-const CampaignStandardsModal = ({ open, onClose, onGeneratePalette, onShowMemorial }) => {
+const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
 

--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -18,15 +18,18 @@ import {
   CardActions,
   Fab,
 } from '@mui/material';
-import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon, Article as ArticleIcon } from '@mui/icons-material';
 import { useIsMobile } from '../hooks/use-mobile';
-import { getCampaigns, deleteCampaign } from '../utils/campaignState';
+import { getCampaigns, deleteCampaign, loadCampaign } from '../utils/campaignState';
 import { toast } from 'sonner';
+import MemorialDescritivoModal from './MemorialDescritivoModal';
 
 const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [showMemorialModal, setShowMemorialModal] = useState(false);
+  const [selectedCampaignData, setSelectedCampaignData] = useState(null);
   const isMobile = useIsMobile();
 
   const fetchCampaigns = () => {
@@ -57,6 +60,16 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
       } catch (err) {
         toast.error(err.message);
       }
+    }
+  };
+
+  const handleShowMemorial = async (campaignId) => {
+    try {
+      const campaignData = await loadCampaign(campaignId);
+      setSelectedCampaignData(campaignData.campaign_data);
+      setShowMemorialModal(true);
+    } catch (err) {
+      toast.error(`Failed to load campaign data: ${err.message}`);
     }
   };
 
@@ -93,20 +106,25 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
               </Typography>
             ) : (
               campaigns.map((campaign) => (
-                <Card key={campaign.id} sx={{ mb: 2, cursor: 'pointer' }} onClick={() => onLoadCampaign(campaign.id)}>
-                  <CardContent>
-                    <Typography variant="h6" component="div">
-                      {campaign.name}
-                    </Typography>
-                    <Typography sx={{ mb: 1.5 }} color="text.secondary">
-                      Atualizada em: {new Date(campaign.updated_at).toLocaleString()}
-                    </Typography>
-                  </CardContent>
+                <Card key={campaign.id} sx={{ mb: 2 }}>
+                  <ListItemButton onClick={() => onLoadCampaign(campaign.id)} sx={{ p: 0 }}>
+                    <CardContent sx={{ flexGrow: 1 }}>
+                      <Typography variant="h6" component="div">
+                        {campaign.name}
+                      </Typography>
+                      <Typography sx={{ mb: 1.5 }} color="text.secondary">
+                        Atualizada em: {new Date(campaign.updated_at).toLocaleString()}
+                      </Typography>
+                    </CardContent>
+                  </ListItemButton>
                   <CardActions sx={{ justifyContent: 'flex-end' }}>
-                    <IconButton aria-label="edit" onClick={(e) => { e.stopPropagation(); onEditCampaign(campaign); }}>
+                    <IconButton aria-label="view memorial" onClick={() => handleShowMemorial(campaign.id)}>
+                      <ArticleIcon />
+                    </IconButton>
+                    <IconButton aria-label="edit" onClick={() => onEditCampaign(campaign)}>
                       <EditIcon />
                     </IconButton>
-                    <IconButton aria-label="delete" onClick={(e) => { e.stopPropagation(); handleDelete(campaign.id, campaign.name); }}>
+                    <IconButton aria-label="delete" onClick={() => handleDelete(campaign.id, campaign.name)}>
                       <DeleteIcon />
                     </IconButton>
                   </CardActions>
@@ -130,6 +148,13 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
           </Fab>
         )}
       </Paper>
+      {selectedCampaignData && (
+        <MemorialDescritivoModal
+          open={showMemorialModal}
+          onClose={() => setShowMemorialModal(false)}
+          campaignData={selectedCampaignData}
+        />
+      )}
     </Container>
   );
 };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1114,7 +1114,7 @@ function HomePage() {
       <SaveCampaignModal open={showSaveModal} onClose={() => setShowSaveModal(false)} onSave={handleSaveCampaign} campaignToEdit={currentCampaign} isSaving={isSaving} />
       <LoadCampaignModal open={showLoadModal} onClose={() => setShowLoadModal(false)} onLoad={handleLoadCampaign} onEdit={(campaign) => { setCurrentCampaign(campaign); setShowSaveModal(true); }} />
       <MemorialDescritivoModal open={showMemorialDescritivoModal} onClose={() => setShowMemorialDescritivoModal(false)} campaignData={campaignData} />
-      <CampaignStandardsModal open={showCampaignStandardsModal} onClose={() => { setShowCampaignStandardsModal(false); loadCampaignStandards(); }} onShowMemorial={() => setShowMemorialDescritivoModal(true)} onGeneratePalette={async (briefing) => { try { const palette = await generateColorPalette(briefing); return palette; } catch (error) { toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores."); throw error; } }} />
+      <CampaignStandardsModal open={showCampaignStandardsModal} onClose={() => { setShowCampaignStandardsModal(false); loadCampaignStandards(); }} onGeneratePalette={async (briefing) => { try { const palette = await generateColorPalette(briefing); return palette; } catch (error) { toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores."); throw error; } }} />
       <BackgroundImageSelector
         open={showBgSelector}
         onClose={() => setShowBgSelector(false)}


### PR DESCRIPTION
This commit refactors the "Memorial Descritivo" (Descriptive Memo) feature based on user feedback to improve usability and data correctness.

Key changes:
1.  **Removed from Campaign Standards:** The button to view the Memorial Descritivo has been removed from the `CampaignStandardsModal`, as it was not contextually appropriate.
2.  **Integrated into My Campaigns:** A new icon button has been added to each campaign listed in `MyCampaignsStep`. This allows users to view the Memorial for any specific saved campaign.
3.  **Corrected Data Sourcing:** The action now loads the full data for the selected campaign from the database, ensuring that the Memorial displays the correct campaign details, including the specific persona and author associated with that campaign, rather than relying on default values from localStorage.