### PR TITLE
Fix: Correct data sourcing and refactor Memorial Descritivo

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -37,7 +37,6 @@ const MainAppBar = ({
   onShowCampaigns,
   setShowSetupModal,
   setShowCampaignStandardsModal,
-  setShowMemorialDescritivoModal,
   onMenuClick,
   isMobile,
   onSaveCampaign,
@@ -175,10 +174,6 @@ const MainAppBar = ({
           <MenuItem onClick={() => { handleUserMenuClose(); setShowCampaignStandardsModal(true); }}>
             <Edit sx={{ mr: 1 }} />
             Padrões de Campanha
-          </MenuItem>
-          <MenuItem onClick={() => { handleUserMenuClose(); setShowMemorialDescritivoModal(true); }}>
-            <ArticleIcon sx={{ mr: 1 }} />
-            Memorial Descritivo
           </MenuItem>
           {user?.role === 'admin' && (
             <MenuItem onClick={() => { navigate('/admin/users'); handleUserMenuClose(); }}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -979,7 +979,6 @@ function HomePage() {
             setDarkMode={setDarkMode}
             setShowSetupModal={setShowSetupModal}
             setShowCampaignStandardsModal={setShowCampaignStandardsModal}
-            setShowMemorialDescritivoModal={setShowMemorialDescritivoModal}
             onMenuClick={() => setSidebarOpen(!sidebarOpen)}
             isMobile={isMobile}
             onSaveCampaign={() => setShowSaveModal(true)}


### PR DESCRIPTION
This commit includes a comprehensive set of fixes and refactoring based on user testing and feedback.

Key Changes:

1.  **Bug Fix - Persona/Author Data Sourcing:**
    - Corrected a critical bug where AI suggestion features were using default persona/author data from localStorage instead of the specific instances selected for the current campaign.
    - Performed a full audit and refactored all functions in `generationHandlers.js` and `helpers.js` to ensure they correctly receive and use campaign-specific persona and author objects.

2.  **Refactor - Memorial Descritivo Feature:**
    - The "Memorial Descritivo" (Descriptive Memo) feature has been relocated from the main menu and the generic "Campaign Standards" dialog.
    - It is now an action available on each individual campaign in the "My Campaigns" list, providing a more intuitive user experience.
    - This change ensures the Memorial always displays data from the correct, specific campaign loaded from the database.
    - Fixed a `ReferenceError` for `onShowMemorial` by removing the now-obsolete menu item from the `MainAppBar`.