### PR TITLE
fix: Correct auth middleware implementation for prompts API

### DIFF
--- a/api/prompts/[id].js
+++ b/api/prompts/[id].js
@@ -1,17 +1,9 @@
 import { query } from '../db';
-import { auth } from '../middleware/auth';
+import { withAdminAuth } from '../middleware/auth';
 
-export default async function handler(req, res) {
-  // Ensure the user is authenticated and is an admin
-  try {
-    await auth(req, res);
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Forbidden: Only admins can manage prompts.' });
-    }
-  } catch (error) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-
+const handler = async (req, res) => {
+  // withAdminAuth has already verified the user is an admin.
+  // req.user is available.
   const { id } = req.query;
 
   if (req.method === 'GET') {
@@ -20,12 +12,14 @@ export default async function handler(req, res) {
       if (rows.length === 0) {
         return res.status(404).json({ error: 'Prompt not found' });
       }
-      res.status(200).json(rows[0]);
+      return res.status(200).json(rows[0]);
     } catch (error) {
       console.error(`Error fetching prompt with id ${id}:`, error);
-      res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-  } else if (req.method === 'PUT') {
+  }
+
+  if (req.method === 'PUT') {
     try {
       const { name, description, prompt_text } = req.body;
       if (!name || !prompt_text) {
@@ -38,28 +32,31 @@ export default async function handler(req, res) {
       if (rows.length === 0) {
         return res.status(404).json({ error: 'Prompt not found' });
       }
-      res.status(200).json(rows[0]);
-    } catch (error)
-    {
-        console.error(`Error updating prompt with id ${id}:`, error);
-        if (error.code === '23505') {
-            return res.status(409).json({ error: 'A prompt with this name already exists.' });
-        }
-        res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(200).json(rows[0]);
+    } catch (error) {
+      console.error(`Error updating prompt with id ${id}:`, error);
+      if (error.code === '23505') {
+        return res.status(409).json({ error: 'A prompt with this name already exists.' });
+      }
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-  } else if (req.method === 'DELETE') {
+  }
+
+  if (req.method === 'DELETE') {
     try {
       const { rowCount } = await query('DELETE FROM prompts WHERE id = $1', [id]);
       if (rowCount === 0) {
         return res.status(404).json({ error: 'Prompt not found' });
       }
-      res.status(200).json({ message: 'Prompt deleted successfully' });
+      return res.status(200).json({ message: 'Prompt deleted successfully' });
     } catch (error) {
       console.error(`Error deleting prompt with id ${id}:`, error);
-      res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-  } else {
-    res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
-    res.status(405).end(`Method ${req.method} Not Allowed`);
   }
-}
+
+  res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+};
+
+export default withAdminAuth(handler);

--- a/api/prompts/index.js
+++ b/api/prompts/index.js
@@ -1,14 +1,8 @@
 import { query } from '../db';
-import { auth } from '../middleware/auth';
+import { withAuth } from '../middleware/auth';
 
-export default async function handler(req, res) {
-  // Ensure the user is authenticated
-  try {
-    await auth(req, res);
-  } catch (error) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-
+const handler = async (req, res) => {
+  // withAuth HOC has already run, so req.user is available.
   const { name } = req.query;
 
   if (req.method === 'GET') {
@@ -19,41 +13,45 @@ export default async function handler(req, res) {
         if (rows.length === 0) {
           return res.status(404).json({ error: 'Prompt not found' });
         }
-        res.status(200).json(rows[0]);
+        return res.status(200).json(rows[0]);
       } else {
-        // Fetch all prompts
+        // Fetch all prompts for the list view
         const { rows } = await query('SELECT id, name, description FROM prompts ORDER BY name');
-        res.status(200).json(rows);
+        return res.status(200).json(rows);
       }
     } catch (error) {
       console.error('Error fetching prompts:', error);
-      res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-  } else if (req.method === 'POST') {
-    // Check if the user is an admin
+  }
+
+  if (req.method === 'POST') {
+    // Additional check to ensure the user is an admin for this method
     if (req.user.role !== 'admin') {
-        return res.status(403).json({ error: 'Forbidden: Only admins can create prompts.' });
+      return res.status(403).json({ error: 'Forbidden: Only admins can create prompts.' });
     }
     try {
-      const { name, description, prompt_text } = req.body;
-      if (!name || !prompt_text) {
+      const { name: newName, description, prompt_text } = req.body;
+      if (!newName || !prompt_text) {
         return res.status(400).json({ error: 'Name and prompt text are required' });
       }
       const { rows } = await query(
         'INSERT INTO prompts (name, description, prompt_text) VALUES ($1, $2, $3) RETURNING *',
-        [name, description, prompt_text]
+        [newName, description, prompt_text]
       );
-      res.status(201).json(rows[0]);
+      return res.status(201).json(rows[0]);
     } catch (error) {
       console.error('Error creating prompt:', error);
       // Check for unique constraint violation
       if (error.code === '23505') {
-          return res.status(409).json({ error: 'A prompt with this name already exists.' });
+        return res.status(409).json({ error: 'A prompt with this name already exists.' });
       }
-      res.status(500).json({ error: 'Internal Server Error' });
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-  } else {
-    res.setHeader('Allow', ['GET', 'POST']);
-    res.status(405).end(`Method ${req.method} Not Allowed`);
   }
-}
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+};
+
+export default withAuth(handler);


### PR DESCRIPTION
This commit corrects the implementation of authentication and authorization for the `/api/prompts` endpoints. The previous implementation was calling a non-existent `auth` function instead of using the correct `withAuth` and `withAdminAuth` higher-order components.

This error caused all requests to the prompts API to fail, resulting in the prompt management page appearing empty.

The following changes were made:
- `api/prompts/index.js` is now correctly wrapped with `withAuth`, and an internal admin check is performed for the POST method.
- `api/prompts/[id].js` is now correctly wrapped with `withAdminAuth` to protect all its routes.