### PR TITLE
feat: Make Prompts Management page responsive

### DIFF
--- a/src/components/PromptCard.jsx
+++ b/src/components/PromptCard.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card,
+  CardContent,
+  CardActions,
+  Typography,
+  IconButton,
+  Box,
+} from '@mui/material';
+import { Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+
+const PromptCard = ({ prompt, onEdit, onDelete }) => {
+  return (
+    <Card sx={{ mb: 2, width: '100%' }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <Box>
+            <Typography variant="h6" component="div" sx={{ wordBreak: 'break-word' }}>
+              {prompt.name}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1, wordBreak: 'break-word' }}>
+              {prompt.description}
+            </Typography>
+          </Box>
+          <CardActions sx={{ p: 0, pl: 1 }}>
+            <IconButton onClick={() => onEdit(prompt)} aria-label="edit">
+              <EditIcon />
+            </IconButton>
+            <IconButton onClick={() => onDelete(prompt.id, prompt.name)} aria-label="delete">
+              <DeleteIcon />
+            </IconButton>
+          </CardActions>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+PromptCard.propTypes = {
+  prompt: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string,
+  }).isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export default PromptCard;

--- a/src/pages/PromptsPage.jsx
+++ b/src/pages/PromptsPage.jsx
@@ -1,12 +1,26 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { DataGrid } from '@mui/x-data-grid';
-import { Box, Button, Container, Typography, Paper, CircularProgress, Alert, IconButton } from '@mui/material';
+import {
+  Box,
+  Button,
+  Container,
+  Typography,
+  Paper,
+  CircularProgress,
+  Alert,
+  IconButton,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
 import fetchWithAuth from '../utils/fetchWithAuth';
 import PromptEditModal from '../components/PromptEditModal';
+import PromptCard from '../components/PromptCard';
 
 const PromptsPage = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [prompts, setPrompts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -123,14 +137,29 @@ const PromptsPage = () => {
         ) : error ? (
           <Alert severity="error">{error}</Alert>
         ) : (
-          <Box sx={{ height: '70vh', width: '100%' }}>
-            <DataGrid
-              rows={prompts}
-              columns={columns}
-              pageSize={10}
-              rowsPerPageOptions={[10, 25, 50]}
-              disableSelectionOnClick
-            />
+          <Box sx={{ width: '100%', mt: 3 }}>
+            {isMobile ? (
+              <Box>
+                {prompts.map((prompt) => (
+                  <PromptCard
+                    key={prompt.id}
+                    prompt={prompt}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </Box>
+            ) : (
+              <Box sx={{ height: '70vh', width: '100%' }}>
+                <DataGrid
+                  rows={prompts}
+                  columns={columns}
+                  pageSize={10}
+                  rowsPerPageOptions={[10, 25, 50]}
+                  disableSelectionOnClick
+                />
+              </Box>
+            )}
           </Box>
         )}
       </Paper>


### PR DESCRIPTION
This commit introduces a responsive design to the Prompts Management page (`PromptsPage.jsx`) to ensure a better user experience on mobile devices.

On desktop screens, the page will continue to display the `DataGrid` for a comprehensive overview.

On mobile screens (detected using `useMediaQuery`), the layout switches to a vertical list of `Card` components. A new `PromptCard.jsx` component has been created to display each prompt's information and actions in a mobile-friendly format.