### PR TITLE
feat: Add campaign objective and tone of voice fields

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -157,6 +157,10 @@ const Campaign = ({
     setProblema,
     solucao,
     setSolucao,
+    objetivo,
+    setObjetivo,
+    tomDeVoz,
+    setTomDeVoz,
     followupPostsQuantity,
     setFollowupPostsQuantity,
     aspectRatio,
@@ -450,6 +454,43 @@ const Campaign = ({
                                     </IconButton>
                                 </Box>
                             </Grid>
+                        )}
+                        {solucao.trim() !== '' && (
+                            <>
+                                <Grid item xs={12} md={6}>
+                                    <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
+                                        <InputLabel id="objetivo-select-label">Objetivo Principal do Post</InputLabel>
+                                        <Select
+                                            labelId="objetivo-select-label"
+                                            value={objetivo}
+                                            onChange={(e) => setObjetivo(e.target.value)}
+                                            label="Objetivo Principal do Post"
+                                        >
+                                            <MenuItem value="Gerar leads">Gerar leads</MenuItem>
+                                            <MenuItem value="Construir autoridade">Construir autoridade</MenuItem>
+                                            <MenuItem value="Educar o mercado">Educar o mercado</MenuItem>
+                                            <MenuItem value="Iniciar uma conversa">Iniciar uma conversa</MenuItem>
+                                            <MenuItem value="Promover um serviço/produto">Promover um serviço/produto</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                                <Grid item xs={12} md={6}>
+                                    <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
+                                        <InputLabel id="tom-de-voz-select-label">Tom de Voz</InputLabel>
+                                        <Select
+                                            labelId="tom-de-voz-select-label"
+                                            value={tomDeVoz}
+                                            onChange={(e) => setTomDeVoz(e.target.value)}
+                                            label="Tom de Voz"
+                                        >
+                                            <MenuItem value="Profissional e direto">Profissional e direto</MenuItem>
+                                            <MenuItem value="Inspirador e motivacional">Inspirador e motivacional</MenuItem>
+                                            <MenuItem value="Técnico e educativo">Técnico e educativo</MenuItem>
+                                            <MenuItem value="Conversacional e amigável">Conversacional e amigável</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                            </>
                         )}
                     </Grid>
                     <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3, gap: 2 }}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -94,6 +94,8 @@ function HomePage() {
   const [standardsColors, setStandardsColors] = useState([]);
   const [problema, setProblema] = useState('');
   const [solucao, setSolucao] = useState('');
+  const [objetivo, setObjetivo] = useState('');
+  const [tomDeVoz, setTomDeVoz] = useState('');
   const [isGeneratingCampaign, setIsGeneratingCampaign] = useState(false);
   const [generationStatus, setGenerationStatus] = useState('');
   const [campaignContent, setCampaignContent] = useState(null);
@@ -231,6 +233,8 @@ function HomePage() {
     }
     setProblema(state.problema ?? '');
     setSolucao(state.solucao ?? '');
+    setObjetivo(state.objetivo ?? '');
+    setTomDeVoz(state.tomDeVoz ?? '');
     setCampaignContent(state.campaignContent ?? null);
     setPersona(state.persona ?? {});
     setAutor(state.autor ?? {});
@@ -297,6 +301,8 @@ function HomePage() {
       activeStep,
       problema,
       solucao,
+      objetivo,
+      tomDeVoz,
       campaignContent,
       persona,
       autor,
@@ -737,7 +743,7 @@ function HomePage() {
       const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
 
       setGenerationStatus('Criando o conteúdo geral da campanha...');
-      const normalizedContent = await generateCampaignContent({ problema, solucao, persona: finalPersona, autor: finalAutor });
+      const normalizedContent = await generateCampaignContent({ problema, solucao, objetivo, tomDeVoz, persona: finalPersona, autor: finalAutor });
       if (!normalizedContent) {
         throw new Error("A geração do conteúdo principal falhou e não retornou dados.");
       }
@@ -1014,6 +1020,10 @@ function HomePage() {
                   {...campaignData}
                   setProblema={setProblema}
                   setSolucao={setSolucao}
+                  objetivo={objetivo}
+                  setObjetivo={setObjetivo}
+                  tomDeVoz={tomDeVoz}
+                  setTomDeVoz={setTomDeVoz}
                   isGeneratingCampaign={isGeneratingCampaign}
                   campaignGenerationFailed={campaignGenerationFailed}
                   generationError={generationError}

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -75,7 +75,7 @@ const formatObjectForPrompt = (obj, excludeKeys = [], indentation = '') => {
 /**
  * Generates the main campaign content using an AI API.
  */
-export const generateCampaignContent = async ({ problema, solucao, persona = null, autor = null }) => {
+export const generateCampaignContent = async ({ problema, solucao, objetivo, tomDeVoz, persona = null, autor = null }) => {
   const apiKey = getGeminiApiKey();
   if (!apiKey) {
     throw new Error('Chave de API Gemini não configurada.');
@@ -99,6 +99,8 @@ export const generateCampaignContent = async ({ problema, solucao, persona = nul
     formato: stripHtml(formato),
     problema: stripHtml(problema),
     solucao: stripHtml(solucao),
+    objetivo: stripHtml(objetivo),
+    tomDeVoz: stripHtml(tomDeVoz),
     instrucoes: stripHtml(instrucoes)
   });
 


### PR DESCRIPTION
This commit introduces two new fields to the campaign definition:

- **Objetivo Principal do Post:** (Main Post Objective)
- **Tom de Voz:** (Tone of Voice)

These fields are now:
- Included in the campaign creation UI.
- Saved and loaded with the rest of the campaign data.
- Passed as parameters to the `generateCampaignContent` function to influence the AI's output.