### PR TITLE
refactor: Remove 'instrucoes' field and tab

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -78,7 +78,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const [value, setValue] = useState(0);
 
   // Other states
-  const [instrucoes, setInstrucoes] = useState('');
   const [formato, setFormato] = useState('');
   const [colors, setColors] = useState([]);
   const [editingField, setEditingField] = useState(null);
@@ -93,14 +92,13 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
       const apiKey = getGeminiApiKey();
       if (apiKey && !geminiAPI.isInitialized) geminiAPI.initialize(apiKey);
 
-      const { instrucoes, formato, colors: loadedColors } = getCampaignPrompt();
+      const { formato, colors: loadedColors } = getCampaignPrompt();
 
-      setInstrucoes(instrucoes);
       setFormato(formato);
       const colorsAsObjects = (loadedColors || []).map(hex => ({ hex, name: `Cor (${hex})`, role: 'Salva', justification: '' }));
       setColors(colorsAsObjects);
 
-      setInitialState({ instrucoes, formato, colors: colorsAsObjects });
+      setInitialState({ formato, colors: colorsAsObjects });
     }
   }, [open]);
 
@@ -108,7 +106,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
 
   const handleSave = () => {
     const colorsToSave = colors.map(color => color.hex).filter(Boolean);
-    saveCampaignPrompt({ instrucoes, formato, colors: colorsToSave });
+    saveCampaignPrompt({ formato, colors: colorsToSave });
     toast.success('Padrões de campanha salvos com sucesso!');
     onClose();
   };
@@ -122,20 +120,17 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
   const handleCloseEditor = () => setEditingField(null);
 
   const handleSaveEditor = (newContent) => {
-    if (editingField === 'instrucoes') setInstrucoes(newContent);
-    else if (editingField === 'formato') setFormato(newContent);
+    if (editingField === 'formato') setFormato(newContent);
     setEditingField(null);
   };
 
   const getCurrentContent = () => {
     if (!editingField) return '';
-    if (editingField === 'instrucoes') return instrucoes;
     if (editingField === 'formato') return formato;
     return '';
   };
 
   const getEditorTitle = () => {
-    if (editingField === 'instrucoes') return 'Editar Instruções';
     if (editingField === 'formato') return 'Editar Formato';
     return 'Editar';
   };
@@ -178,7 +173,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
 
   const hasUnsavedChanges = () => {
     if (!initialState) return false;
-    const currentState = { instrucoes, formato, colors };
+    const currentState = { formato, colors };
     // Custom comparison for colors as it's an array of objects
     const initialColorsHex = initialState.colors.map(c => c.hex);
     const currentColorsHex = currentState.colors.map(c => c.hex);
@@ -205,8 +200,7 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <Tabs orientation="horizontal" variant="scrollable" value={value} onChange={handleChange}>
               <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Formato" {...a11yProps(0)} />
-              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Instruções" {...a11yProps(1)} />
-              <Tab icon={<PaletteIcon />} iconPosition="start" label="Cores" {...a11yProps(2)} />
+              <Tab icon={<PaletteIcon />} iconPosition="start" label="Cores" {...a11yProps(1)} />
             </Tabs>
           </Box>
           <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
@@ -214,9 +208,6 @@ const CampaignStandardsModal = ({ open, onClose, onGeneratePalette }) => {
               <HtmlDisplayField title="Formato" htmlContent={formato} onClick={() => handleOpenEditor('formato')} />
             </TabPanel>
             <TabPanel value={value} index={1}>
-              <HtmlDisplayField title="Instruções" htmlContent={instrucoes} onClick={() => handleOpenEditor('instruções')} />
-            </TabPanel>
-            <TabPanel value={value} index={2}>
               <Stack spacing={2} sx={{ mb: 3 }}>
                 <Button variant="contained" startIcon={<AutoAwesomeIcon />} onClick={() => setShowPaletteWizard(true)} disabled={!onGeneratePalette} sx={{ alignSelf: 'flex-start' }}>Assistente de Paleta</Button>
               </Stack>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -105,7 +105,6 @@ function HomePage() {
   const [isHtmlField, setIsHtmlField] = useState(false);
   const [persona, setPersona] = useState({});
   const [autor, setAutor] = useState({});
-  const [instrucoes, setInstrucoes] = useState('');
   const [formato, setFormato] = useState('');
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [generatedImageUrl, setGeneratedImageUrl] = useState(null);
@@ -238,7 +237,6 @@ function HomePage() {
     setCampaignContent(state.campaignContent ?? null);
     setPersona(state.persona ?? {});
     setAutor(state.autor ?? {});
-    setInstrucoes(state.instrucoes ?? '');
     setFormato(state.formato ?? '');
     setAspectRatio(state.aspectRatio ?? '1:1');
     setGeneratedImageUrl(state.generatedImageUrl ?? null);
@@ -306,7 +304,6 @@ function HomePage() {
       campaignContent,
       persona,
       autor,
-      instrucoes,
       formato,
       aspectRatio,
       followupPosts,
@@ -374,10 +371,9 @@ function HomePage() {
   };
 
   const loadCampaignStandards = useCallback(() => {
-    const { persona: personaData, autor: autorData, instrucoes: instrucoesData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
+    const { persona: personaData, autor: autorData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
     setPersona(personaData || {});
     setAutor(autorData || {});
-    setInstrucoes(instrucoesData || '');
     setFormato(formatoData || '');
     setStandardsColors(colorsData || []);
   }, []);
@@ -974,7 +970,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, campaignContent, persona, autor, formato, instrucoes, aspectRatio, followupPosts, colors: standardsColors, };
+  const campaignData = { problema, solucao, campaignContent, persona, autor, formato, aspectRatio, followupPosts, colors: standardsColors, };
 
   return (
     <ThemeProvider theme={currentTheme}>

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -32,7 +32,6 @@ export function saveCampaignPrompt(promptData) {
  */
 export function getCampaignPrompt() {
   const defaultPrompt = {
-    instrucoes: '',
     formato: '',
     colors: [],
   };
@@ -44,15 +43,7 @@ export function getCampaignPrompt() {
         return defaultPrompt;
       }
 
-      let parsedData;
-      try {
-        parsedData = JSON.parse(storedData);
-      } catch (e) {
-        console.log("Migrando prompt do formato antigo (string) para o novo (objeto).");
-        const migratedData = { ...defaultPrompt, instrucoes: storedData };
-        saveCampaignPrompt(migratedData);
-        return migratedData;
-      }
+      let parsedData = JSON.parse(storedData);
 
       if (typeof parsedData !== 'object' || parsedData === null) {
         return defaultPrompt;

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -82,7 +82,7 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
   }
   geminiAPI.initialize(apiKey);
 
-  const { autor: defaultAutor, instrucoes, formato } = getCampaignPrompt();
+  const { autor: defaultAutor, formato } = getCampaignPrompt();
   const finalAutor = autor || defaultAutor;
 
   const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
@@ -100,8 +100,7 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
     problema: stripHtml(problema),
     solucao: stripHtml(solucao),
     objetivo: stripHtml(objetivo),
-    tomDeVoz: stripHtml(tomDeVoz),
-    instrucoes: stripHtml(instrucoes)
+    tomDeVoz: stripHtml(tomDeVoz)
   });
 
   const response = await geminiAPI.generateContent(finalPrompt, 'Geração de Conteúdo de Campanha');


### PR DESCRIPTION
This commit removes all references to the 'instrucoes' (instructions) field from the codebase.

Changes include:
- Removing the 'Instruções' tab from the Campaign Standards modal.
- Removing the `instrucoes` state and related logic from the main application page.
- Removing `instrucoes` from the campaign prompt local storage utility.
- Removing `instrucoes` from the AI content generation prompt.