### PR TITLE
feat: Decouple main content generation from sub-tasks

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -752,40 +752,12 @@ function HomePage() {
 
       setFollowupPosts([]);
 
-      setGenerationStatus('Gerando a imagem de referência da campanha...');
-      const imageSuccess = await handleGenerateImage(normalizedContent);
-      if (!imageSuccess) {
-        setCampaignGenerationFailed(true);
-        setGenerationError("A geração de texto foi bem-sucedida, mas a criação da imagem falhou. Você pode tentar gerar a imagem novamente.");
-        toast.warning("Geração de imagem falhou, mas o texto está pronto.");
-      }
-
       setGenerationStatus('Gerando resumos e conteúdo formatado...');
       await Promise.all([
         handleGenerateSummary(1800, normalizedContent),
         handleGenerateSummary(130, normalizedContent),
         handleGenerateFormattedContent(normalizedContent),
       ]);
-
-      if (followupPostsQuantity > 0) {
-        setGenerationStatus('Planejando os posts de follow-up...');
-        const plan = await generateFollowupPlan({
-          content: normalizedContent,
-          neededQuantity: followupPostsQuantity,
-          existingPosts: [],
-        });
-
-        const newPosts = [];
-        for (let i = 0; i < plan.length; i++) {
-          const postPlan = plan[i];
-          setGenerationStatus(`Gerando post de follow-up ${i + 1}/${plan.length}...`);
-          const generatedPost = await generateFollowupPosts({ content: normalizedContent, plan: [postPlan] });
-          if (generatedPost && generatedPost.length > 0) {
-            newPosts.push(...generatedPost);
-            setFollowupPosts([...newPosts]);
-          }
-        }
-      }
 
       toast.success("Campanha gerada com sucesso!");
 


### PR DESCRIPTION
This commit changes the campaign generation flow to no longer automatically trigger the generation of the reference image and follow-up posts when the main content is created. These sub-tasks should now be triggered manually by the user via their respective buttons.

This improves the user experience by giving them more control over the generation process and reducing the initial waiting time.

refactor: Remove 'instrucoes' field and tab

This commit removes all references to the 'instrucoes' (instructions) field from the codebase.

Changes include:
- Removing the 'Instruções' tab from the Campaign Standards modal.
- Removing the `instrucoes` state and related logic from the main application page.
- Removing `instrucoes` from the campaign prompt local storage utility.
- Removing `instrucoes` from the AI content generation prompt.

feat: Add campaign objective and tone of voice fields

This commit introduces two new fields to the campaign definition:
- **Objetivo Principal do Post:** (Main Post Objective)
- **Tom de Voz:** (Tone of Voice)

These fields are now:
- Included in the campaign creation UI.
- Saved and loaded with the rest of the campaign data.
- Passed as parameters to the `generateCampaignContent` function to influence the AI's output.