### PR TITLE
refactor: Move author field and adjust campaign creation flow

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -375,27 +375,7 @@ const Campaign = ({
                 {/* Painel 0: Problema e Solução */}
                 <TabPanel value={activeTab} index={0}>
                     <Grid container spacing={3} sx={{ mt: 2 }}>
-                        <Grid item xs={12} md={6}>
-                            <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
-                                <InputLabel id="autor-select-label">Selecionar Autor</InputLabel>
-                                <Select
-                                    labelId="autor-select-label"
-                                    value={selectedAutorForCampaign}
-                                    onChange={(e) => setSelectedAutorForCampaign(e.target.value)}
-                                    label="Selecionar Autor"
-                                >
-                                    <MenuItem value="">
-                                        <em>Nenhum (Usará Padrões)</em>
-                                    </MenuItem>
-                                    {autorList.map((p) => (
-                                        <MenuItem key={p.id} value={p.id}>
-                                            {p.name}
-                                        </MenuItem>
-                                    ))}
-                                </Select>
-                            </FormControl>
-                        </Grid>
-                        <Grid item xs={12} md={6}>
+                        <Grid item xs={12}>
                             <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
                                 <InputLabel id="persona-select-label">Selecionar Persona</InputLabel>
                                 <Select
@@ -436,24 +416,46 @@ const Campaign = ({
                         </Grid>
 
                         {problema.trim() !== '' && (
-                            <Grid item xs={12}>
-                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                                    <TextField
-                                        label="Solução ou Proposta"
-                                        multiline
-                                        rows={4}
-                                        value={solucao}
-                                        onChange={(e) => setSolucao(e.target.value)}
-                                        variant="outlined"
-                                        fullWidth
-                                        placeholder="Descreva a solução que sua campanha oferece."
-                                        disabled={campaignContent !== null}
-                                    />
-                                    <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setSolucaoHintModalOpen(true)}>
-                                        <GeminiIcon />
-                                    </IconButton>
-                                </Box>
-                            </Grid>
+                            <>
+                                <Grid item xs={12}>
+                                    <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
+                                        <InputLabel id="autor-select-label">Selecionar Autor</InputLabel>
+                                        <Select
+                                            labelId="autor-select-label"
+                                            value={selectedAutorForCampaign}
+                                            onChange={(e) => setSelectedAutorForCampaign(e.target.value)}
+                                            label="Selecionar Autor"
+                                        >
+                                            <MenuItem value="">
+                                                <em>Nenhum (Usará Padrões)</em>
+                                            </MenuItem>
+                                            {autorList.map((p) => (
+                                                <MenuItem key={p.id} value={p.id}>
+                                                    {p.name}
+                                                </MenuItem>
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                                        <TextField
+                                            label="Solução ou Proposta"
+                                            multiline
+                                            rows={4}
+                                            value={solucao}
+                                            onChange={(e) => setSolucao(e.target.value)}
+                                            variant="outlined"
+                                            fullWidth
+                                            placeholder="Descreva a solução que sua campanha oferece."
+                                            disabled={campaignContent !== null}
+                                        />
+                                        <IconButton color="primary" sx={{ mt: 1 }} onClick={() => setSolucaoHintModalOpen(true)}>
+                                            <GeminiIcon />
+                                        </IconButton>
+                                    </Box>
+                                </Grid>
+                            </>
                         )}
                         {solucao.trim() !== '' && (
                             <>


### PR DESCRIPTION
This commit introduces several changes to the campaign creation process based on user feedback.

- **Reorder Author Field:** The 'Autor' (Author) selection field has been moved to appear after the 'Problema' (Problem) field. It is now conditionally rendered along with the 'Solução' (Solution) field, creating a more logical workflow.

- **Decouple Generation Tasks:** The main content generation no longer automatically triggers the creation of the reference image or follow-up posts. These tasks are now fully manual, giving the user more control.

- **Remove 'Instruções' Field:** All references to the legacy 'instrucoes' (instructions) field and its corresponding UI tab have been removed from the application.

- **Add Objective and Tone Fields:** Introduces 'Objetivo' (Objective) and 'Tom de Voz' (Tone of Voice) fields to the campaign definition, allowing for more specific prompt engineering.