### PR TITLE
feat: Implement multiple UI and workflow improvements

### DIFF
--- a/src/pages/AutoresPage.jsx
+++ b/src/pages/AutoresPage.jsx
@@ -14,7 +14,7 @@ import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
 import { getGeminiApiKey } from '../utils/geminiCredentials';
 import geminiAPI from '../utils/geminiAPI';
 
-const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected }) => {
+const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected, onUpdate }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -94,6 +94,7 @@ const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected })
             : await saveAutor(autorToSave.name, autorToSave.autor_data);
         toast.success("Autor salvo com sucesso!");
         await fetchAutores();
+        if (onUpdate) onUpdate();
         setSelectedAutor(saved);
         setAutorFormData(saved.autor_data);
         setIsAutorDirty(false);
@@ -179,6 +180,7 @@ Retorne apenas um único objeto JSON.`;
       await deleteAutor(autorId);
       toast.success('Autor excluído com sucesso!');
       fetchAutores(); // Refresh list
+      if (onUpdate) onUpdate();
       setSelectedAutor(null); // Deselect if the deleted one was selected
     } catch (error) {
       console.error(error);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -384,23 +384,31 @@ function HomePage() {
     if (apiKey) geminiAPI.initialize(apiKey);
   }, [loadCampaignStandards]);
 
+  const fetchPersonasForCampaign = useCallback(() => {
+    return getPersonas()
+      .then(setPersonaList)
+      .catch(err => {
+        console.error("Failed to fetch personas for campaign step:", err);
+        toast.error('Could not load personas for campaign dropdown.');
+      });
+  }, []);
+
+  const fetchAutoresForCampaign = useCallback(() => {
+    return getAutores()
+      .then(setAutorList)
+      .catch(err => {
+        console.error("Failed to fetch autores for campaign step:", err);
+        toast.error('Could not load autores for campaign dropdown.');
+      });
+  }, []);
+
   useEffect(() => {
     // Fetch personas for the campaign step dropdown
     if (user) {
-      getPersonas()
-        .then(setPersonaList)
-        .catch(err => {
-          console.error("Failed to fetch personas for campaign step:", err);
-          toast.error('Could not load personas for campaign dropdown.');
-        });
-      getAutores()
-        .then(setAutorList)
-        .catch(err => {
-          console.error("Failed to fetch autores for campaign step:", err);
-          toast.error('Could not load autores for campaign dropdown.');
-        });
+      fetchPersonasForCampaign();
+      fetchAutoresForCampaign();
     }
-  }, [user]);
+  }, [user, fetchPersonasForCampaign, fetchAutoresForCampaign]);
 
   useEffect(() => {
     const checkCampaignsAndSetInitialStep = async () => {
@@ -942,7 +950,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, campaignContent, persona, autor, formato, aspectRatio, followupPosts, colors: standardsColors, };
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, persona, autor, formato, aspectRatio, followupPosts, colors: standardsColors, };
 
   return (
     <ThemeProvider theme={currentTheme}>
@@ -1077,8 +1085,8 @@ function HomePage() {
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} ><Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button><Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box><Button onClick={handleNext} disabled={isGenerating || activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1)} variant="contained" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Próximo</Button></Box>
               </>
             )}
-            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} />}
-            {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} />}
+            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} onUpdate={fetchPersonasForCampaign} />}
+            {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} onUpdate={fetchAutoresForCampaign} />}
         </Box>
       </Box>
       <UnsavedChangesDialog

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -22,7 +22,7 @@ import geminiAPI from '../utils/geminiAPI';
  * where the `PersonaWizard` is displayed. The component is self-contained and handles
  * all its state and API interactions.
  */
-const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected }) => {
+const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected, onUpdate }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -121,6 +121,7 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
             : await savePersona(personaToSave.name, personaToSave.persona_data);
         toast.success("Persona salva com sucesso!");
         await fetchPersonas();
+        if (onUpdate) onUpdate();
         setSelectedPersona(saved);
         setPersonaFormData(saved.persona_data);
         setIsPersonaDirty(false);
@@ -205,6 +206,7 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
       await deletePersona(personaId);
       toast.success('Persona excluída com sucesso!');
       fetchPersonas(); // Refresh list
+      if (onUpdate) onUpdate();
       setSelectedPersona(null); // Deselect if the deleted one was selected
     } catch (error) {
       // Error toast is handled inside deletePersona, but you could add more here if needed


### PR DESCRIPTION
This commit includes a series of features and bugfixes based on recent user feedback.

1.  **Add Campaign Objective and Tone Fields:**
    - Introduces 'Objetivo' (Objective) and 'Tom de Voz' (Tone of Voice) fields to the campaign definition for more specific prompt engineering.
    - These fields are saved and loaded with the campaign data.

2.  **Decouple Generation Tasks:**
    - The main content generation no longer automatically triggers the creation of the reference image or follow-up posts. These tasks are now fully manual.

3.  **Reorder Author Field:**
    - The 'Autor' (Author) selection field has been moved to appear after the 'Problema' (Problem) field and is now conditionally rendered with the 'Solução' (Solution) field.

4.  **Remove 'Instruções' Field:**
    - All references to the legacy 'instrucoes' (instructions) field and its corresponding UI tab have been removed.

5.  **Fix Stale Persona/Author Lists:**
    - The persona and author dropdown lists on the campaign page now correctly refresh after a new item is created or deleted on their respective management pages.