### PR TITLE
feat: Campaign workflow improvements and bugfixes

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -287,14 +287,15 @@ const Campaign = ({
                 throw new Error("Descreva o problema primeiro.");
             }
             const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor });
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
+            const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
         } catch (error) {
             setSolutionsError(error.message);
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [commonSolutions.length, problema, persona, autor, selectedPersonaForCampaign, personaList]);
+    }, [commonSolutions.length, problema, persona, autor, selectedPersonaForCampaign, personaList, autorList]);
 
     const handleRegenerateSolutions = useCallback(async () => {
         setIsLoadingSolutions(true);
@@ -305,14 +306,15 @@ const Campaign = ({
                 throw new Error("Descreva o problema primeiro.");
             }
             const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor });
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
+            const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
         } catch (error) {
             setSolutionsError(error.message);
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [problema, persona, autor, selectedPersonaForCampaign, personaList]);
+    }, [problema, persona, autor, selectedPersonaForCampaign, personaList, autorList]);
 
     useEffect(() => {
         if (isSolucaoHintModalOpen) {


### PR DESCRIPTION
This commit includes a series of features and bugfixes based on user feedback to improve the campaign creation workflow.

- **Add Campaign Objective and Tone Fields:** Introduces 'Objetivo' (Objective) and 'Tom de Voz' (Tone of Voice) fields to the campaign definition for more specific prompt engineering. These fields are saved and loaded with the campaign data.

- **Decouple Generation Tasks:** The main content generation no longer automatically triggers the creation of the reference image or follow-up posts. These tasks are now fully manual.

- **Reorder Author Field:** The 'Autor' (Author) selection field has been moved to appear after the 'Problema' (Problem) field and is now conditionally rendered along with the 'Solução' (Solution) field.

- **Remove 'Instruções' Field:** All references to the legacy 'instrucoes' (instructions) field and its corresponding UI tab have been removed.

- **Fix Stale Persona/Author Lists:** The persona and author dropdown lists on the campaign page now correctly refresh after a new item is created or deleted on their respective management pages.

- **Fix Incorrect Author in Solution Prompt:** The 'generateCommonSolutions' function now correctly uses the author selected for the specific campaign, rather than the default author.