### PR TITLE
refactor: Remove default author and handle optional author in prompts

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -185,7 +185,6 @@ const Campaign = ({
     handleGenerateImage,
     setCampaignContent,
     onEditFollowup,
-    autor,
     autorList,
     selectedAutorForCampaign,
     setSelectedAutorForCampaign,
@@ -244,14 +243,15 @@ const Campaign = ({
             if (!finalPersona || Object.keys(finalPersona).length === 0) {
                 throw new Error("Por favor, selecione uma persona para obter sugestões.");
             }
-            const problems = await generateCommonProblems({ persona: finalPersona, autor });
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
+            const problems = await generateCommonProblems({ persona: finalPersona, autor: finalAutor });
             setCommonProblems(problems);
         } catch (error) {
             setProblemsError(error.message);
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [commonProblems.length, persona, autor, selectedPersonaForCampaign, personaList]);
+    }, [commonProblems.length, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     const handleRegenerateProblems = useCallback(async () => {
         setIsLoadingProblems(true);
@@ -262,14 +262,15 @@ const Campaign = ({
             if (!finalPersona || Object.keys(finalPersona).length === 0) {
                 throw new Error("Por favor, selecione uma persona para obter sugestões.");
             }
-            const problems = await generateCommonProblems({ persona: finalPersona, autor });
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
+            const problems = await generateCommonProblems({ persona: finalPersona, autor: finalAutor });
             setCommonProblems(problems);
         } catch (error) {
             setProblemsError(error.message);
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [persona, autor, selectedPersonaForCampaign, personaList]);
+    }, [persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     useEffect(() => {
         if (isHintModalOpen) {
@@ -287,7 +288,7 @@ const Campaign = ({
                 throw new Error("Descreva o problema primeiro.");
             }
             const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
             const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
         } catch (error) {
@@ -295,7 +296,7 @@ const Campaign = ({
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [commonSolutions.length, problema, persona, autor, selectedPersonaForCampaign, personaList, autorList]);
+    }, [commonSolutions.length, problema, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     const handleRegenerateSolutions = useCallback(async () => {
         setIsLoadingSolutions(true);
@@ -306,7 +307,7 @@ const Campaign = ({
                 throw new Error("Descreva o problema primeiro.");
             }
             const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
+            const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
             const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
         } catch (error) {
@@ -314,7 +315,7 @@ const Campaign = ({
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [problema, persona, autor, selectedPersonaForCampaign, personaList, autorList]);
+    }, [problema, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     useEffect(() => {
         if (isSolucaoHintModalOpen) {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -104,7 +104,6 @@ function HomePage() {
   const [editingField, setEditingField] = useState(null);
   const [isHtmlField, setIsHtmlField] = useState(false);
   const [persona, setPersona] = useState({});
-  const [autor, setAutor] = useState({});
   const [formato, setFormato] = useState('');
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [generatedImageUrl, setGeneratedImageUrl] = useState(null);
@@ -236,7 +235,6 @@ function HomePage() {
     setTomDeVoz(state.tomDeVoz ?? '');
     setCampaignContent(state.campaignContent ?? null);
     setPersona(state.persona ?? {});
-    setAutor(state.autor ?? {});
     setFormato(state.formato ?? '');
     setAspectRatio(state.aspectRatio ?? '1:1');
     setGeneratedImageUrl(state.generatedImageUrl ?? null);
@@ -303,7 +301,6 @@ function HomePage() {
       tomDeVoz,
       campaignContent,
       persona,
-      autor,
       formato,
       aspectRatio,
       followupPosts,
@@ -371,9 +368,8 @@ function HomePage() {
   };
 
   const loadCampaignStandards = useCallback(() => {
-    const { persona: personaData, autor: autorData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
+    const { persona: personaData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
     setPersona(personaData || {});
-    setAutor(autorData || {});
     setFormato(formatoData || '');
     setStandardsColors(colorsData || []);
   }, []);
@@ -744,7 +740,7 @@ function HomePage() {
 
     try {
       const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-      const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || autor;
+      const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
 
       setGenerationStatus('Criando o conteúdo geral da campanha...');
       const normalizedContent = await generateCampaignContent({ problema, solucao, objetivo, tomDeVoz, persona: finalPersona, autor: finalAutor });
@@ -950,7 +946,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, persona, autor, formato, aspectRatio, followupPosts, colors: standardsColors, };
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, persona, formato, aspectRatio, followupPosts, colors: standardsColors, };
 
   return (
     <ThemeProvider theme={currentTheme}>

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -49,10 +49,6 @@ export function getCampaignPrompt() {
         return defaultPrompt;
       }
 
-      // Migração para remover o campo autor
-      if (parsedData.autor) {
-        delete parsedData.autor;
-      }
 
       // Migração para remover o campo aspectRatio
       if (parsedData.aspectRatio) {

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -82,11 +82,16 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
   }
   geminiAPI.initialize(apiKey);
 
-  const { autor: defaultAutor, formato } = getCampaignPrompt();
-  const finalAutor = autor || defaultAutor;
+  const { formato } = getCampaignPrompt();
 
   const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
-  const autorString = formatObjectForPrompt(finalAutor);
+
+  let autorString;
+  if (typeof autor === 'string') {
+    autorString = autor;
+  } else {
+    autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
+  }
 
   const personaPromptSection = personaString
     ? `Destinatário (Persona): ${personaString}`
@@ -246,11 +251,14 @@ export const generateFollowupPlan = async ({ content, neededQuantity, existingPo
   }
   geminiAPI.initialize(apiKey);
 
-  const { autor: defaultAutor } = getCampaignPrompt();
-  const finalAutor = autor || defaultAutor;
-
   const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
-  const autorString = formatObjectForPrompt(finalAutor);
+
+  let autorString;
+  if (typeof autor === 'string') {
+    autorString = autor;
+  } else {
+    autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
+  }
 
   const existingPostsString = existingPosts.length > 0
     ? `
@@ -305,10 +313,14 @@ export const generateFollowupPosts = async ({ content, plan, persona = null, aut
   }
   geminiAPI.initialize(apiKey);
 
-  const { autor: defaultAutor } = getCampaignPrompt();
-  const finalAutor = autor || defaultAutor;
   const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
-  const autorString = formatObjectForPrompt(finalAutor);
+
+  let autorString;
+  if (typeof autor === 'string') {
+    autorString = autor;
+  } else {
+    autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
+  }
 
   const generatedPosts = [];
   const MAX_RETRIES = 3;
@@ -394,7 +406,13 @@ export const generateCommonSolutions = async ({ problema, persona, autor }) => {
   }
 
   const personaString = formatObjectForPrompt(persona, ['description']);
-  const autorString = autor ? formatObjectForPrompt(autor) : '';
+
+  let autorString;
+  if (typeof autor === 'string') {
+    autorString = autor;
+  } else {
+    autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
+  }
 
   const promptTemplate = await getPrompt('generateCommonSolutions');
   const prompt = fillPrompt(promptTemplate, {
@@ -437,7 +455,13 @@ export const generateCommonProblems = async ({ persona, autor }) => {
   }
 
   const personaString = formatObjectForPrompt(persona, ['description']);
-  const autorString = autor ? formatObjectForPrompt(autor) : '';
+
+  let autorString;
+  if (typeof autor === 'string') {
+    autorString = autor;
+  } else {
+    autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
+  }
 
   const promptTemplate = await getPrompt('generateCommonProblems');
   const prompt = fillPrompt(promptTemplate, {


### PR DESCRIPTION
This commit refactors the author handling logic based on new user requirements.

- **Removed Default Author:** The concept of a 'default author' stored in local storage (Campaign Standards) has been completely removed. This includes removing the state from `HomePage`, the persistence logic from `campaignPrompt.js`, and the fallback logic from all generation functions.

- **Handle Optional Author:** A campaign can now optionally have no author. If no author is selected from the dropdown list, the string 'indisponível' (unavailable) is passed to the AI prompt in place of the author data.

- **Updated Generation Handlers:** All relevant generation functions (`generateCampaignContent`, `generateCommonSolutions`, `generateFollowupPlan`, etc.) have been updated to correctly handle the `autor` parameter, whether it's a full author object or the 'indisponível' string.