### PR TITLE
feat: Improve campaign creation workflow and fields

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -188,7 +188,6 @@ const Campaign = ({
     autorList,
     selectedAutorForCampaign,
     setSelectedAutorForCampaign,
-    persona,
     personaList,
     selectedPersonaForCampaign,
     setSelectedPersonaForCampaign,
@@ -239,8 +238,8 @@ const Campaign = ({
         setProblemsError(null);
         setCommonProblems([]);
         try {
-            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            if (!finalPersona || Object.keys(finalPersona).length === 0) {
+            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || 'indisponível';
+            if (finalPersona === 'indisponível') {
                 throw new Error("Por favor, selecione uma persona para obter sugestões.");
             }
             const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
@@ -251,15 +250,15 @@ const Campaign = ({
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [commonProblems.length, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
+    }, [commonProblems.length, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     const handleRegenerateProblems = useCallback(async () => {
         setIsLoadingProblems(true);
         setProblemsError(null);
         setCommonProblems([]);
         try {
-            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
-            if (!finalPersona || Object.keys(finalPersona).length === 0) {
+            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || 'indisponível';
+            if (finalPersona === 'indisponível') {
                 throw new Error("Por favor, selecione uma persona para obter sugestões.");
             }
             const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
@@ -270,7 +269,7 @@ const Campaign = ({
         } finally {
             setIsLoadingProblems(false);
         }
-    }, [persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
+    }, [selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     useEffect(() => {
         if (isHintModalOpen) {
@@ -287,7 +286,7 @@ const Campaign = ({
             if (!problema.trim()) {
                 throw new Error("Descreva o problema primeiro.");
             }
-            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
+            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || 'indisponível';
             const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
             const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
@@ -296,7 +295,7 @@ const Campaign = ({
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [commonSolutions.length, problema, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
+    }, [commonSolutions.length, problema, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     const handleRegenerateSolutions = useCallback(async () => {
         setIsLoadingSolutions(true);
@@ -306,7 +305,7 @@ const Campaign = ({
             if (!problema.trim()) {
                 throw new Error("Descreva o problema primeiro.");
             }
-            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
+            const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || 'indisponível';
             const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
             const solutions = await generateCommonSolutions({ problema, persona: finalPersona, autor: finalAutor });
             setCommonSolutions(solutions);
@@ -315,7 +314,7 @@ const Campaign = ({
         } finally {
             setIsLoadingSolutions(false);
         }
-    }, [problema, persona, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
+    }, [problema, selectedPersonaForCampaign, personaList, autorList, selectedAutorForCampaign]);
 
     useEffect(() => {
         if (isSolucaoHintModalOpen) {
@@ -379,7 +378,7 @@ const Campaign = ({
                 <TabPanel value={activeTab} index={0}>
                     <Grid container spacing={3} sx={{ mt: 2 }}>
                         <Grid item xs={12}>
-                            <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
+                            <FormControl fullWidth variant="outlined" sx={{ mb: 2 }} disabled={campaignContent !== null}>
                                 <InputLabel id="persona-select-label">Selecionar Persona</InputLabel>
                                 <Select
                                     labelId="persona-select-label"
@@ -388,7 +387,7 @@ const Campaign = ({
                                     label="Selecionar Persona"
                                 >
                                     <MenuItem value="">
-                                        <em>Nenhuma (Usará Padrões)</em>
+                                        <em>Não especificar</em>
                                     </MenuItem>
                                     {personaList.map((p) => (
                                         <MenuItem key={p.id} value={p.id}>
@@ -421,7 +420,7 @@ const Campaign = ({
                         {problema.trim() !== '' && (
                             <>
                                 <Grid item xs={12}>
-                                    <FormControl fullWidth variant="outlined" sx={{ mb: 2 }}>
+                                    <FormControl fullWidth variant="outlined" sx={{ mb: 2 }} disabled={campaignContent !== null}>
                                         <InputLabel id="autor-select-label">Selecionar Autor</InputLabel>
                                         <Select
                                             labelId="autor-select-label"
@@ -430,7 +429,7 @@ const Campaign = ({
                                             label="Selecionar Autor"
                                         >
                                             <MenuItem value="">
-                                                <em>Nenhum (Usará Padrões)</em>
+                                                <em>Não especificar</em>
                                             </MenuItem>
                                             {autorList.map((p) => (
                                                 <MenuItem key={p.id} value={p.id}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -103,7 +103,6 @@ function HomePage() {
   const [generationError, setGenerationError] = useState('');
   const [editingField, setEditingField] = useState(null);
   const [isHtmlField, setIsHtmlField] = useState(false);
-  const [persona, setPersona] = useState({});
   const [formato, setFormato] = useState('');
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [generatedImageUrl, setGeneratedImageUrl] = useState(null);
@@ -234,7 +233,6 @@ function HomePage() {
     setObjetivo(state.objetivo ?? '');
     setTomDeVoz(state.tomDeVoz ?? '');
     setCampaignContent(state.campaignContent ?? null);
-    setPersona(state.persona ?? {});
     setFormato(state.formato ?? '');
     setAspectRatio(state.aspectRatio ?? '1:1');
     setGeneratedImageUrl(state.generatedImageUrl ?? null);
@@ -300,7 +298,6 @@ function HomePage() {
       objetivo,
       tomDeVoz,
       campaignContent,
-      persona,
       formato,
       aspectRatio,
       followupPosts,
@@ -368,8 +365,7 @@ function HomePage() {
   };
 
   const loadCampaignStandards = useCallback(() => {
-    const { persona: personaData, formato: formatoData, colors: colorsData } = getCampaignPrompt();
-    setPersona(personaData || {});
+    const { formato: formatoData, colors: colorsData } = getCampaignPrompt();
     setFormato(formatoData || '');
     setStandardsColors(colorsData || []);
   }, []);
@@ -739,7 +735,7 @@ function HomePage() {
     setGenerationStatus('Iniciando geração de campanha...');
 
     try {
-      const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || persona;
+      const finalPersona = personaList.find(p => p.id === selectedPersonaForCampaign) || 'indisponível';
       const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign) || 'indisponível';
 
       setGenerationStatus('Criando o conteúdo geral da campanha...');
@@ -946,7 +942,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, persona, formato, aspectRatio, followupPosts, colors: standardsColors, };
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, };
 
   return (
     <ThemeProvider theme={currentTheme}>

--- a/src/utils/campaignPrompt.js
+++ b/src/utils/campaignPrompt.js
@@ -49,6 +49,16 @@ export function getCampaignPrompt() {
         return defaultPrompt;
       }
 
+      if (parsedData.persona) {
+        delete parsedData.persona;
+      }
+      if (parsedData.autor) {
+        delete parsedData.autor;
+      }
+      if (parsedData.instrucoes) {
+        delete parsedData.instrucoes;
+      }
+
 
       // Migração para remover o campo aspectRatio
       if (parsedData.aspectRatio) {

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -84,7 +84,7 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
 
   const { formato } = getCampaignPrompt();
 
-  const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
+  const personaString = typeof persona === 'string' ? persona : (persona ? formatObjectForPrompt(persona, ['description']) : 'indisponível');
 
   let autorString;
   if (typeof autor === 'string') {
@@ -93,7 +93,7 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
     autorString = autor ? formatObjectForPrompt(autor) : 'indisponível';
   }
 
-  const personaPromptSection = personaString
+  const personaPromptSection = personaString && personaString !== 'indisponível'
     ? `Destinatário (Persona): ${personaString}`
     : 'O destinatário é um público geral interessado no problema e solução apresentados.';
 
@@ -251,7 +251,7 @@ export const generateFollowupPlan = async ({ content, neededQuantity, existingPo
   }
   geminiAPI.initialize(apiKey);
 
-  const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
+  const personaString = typeof persona === 'string' ? persona : (persona ? formatObjectForPrompt(persona, ['description']) : 'indisponível');
 
   let autorString;
   if (typeof autor === 'string') {
@@ -313,7 +313,7 @@ export const generateFollowupPosts = async ({ content, plan, persona = null, aut
   }
   geminiAPI.initialize(apiKey);
 
-  const personaString = persona ? formatObjectForPrompt(persona, ['description']) : '';
+  const personaString = typeof persona === 'string' ? persona : (persona ? formatObjectForPrompt(persona, ['description']) : 'indisponível');
 
   let autorString;
   if (typeof autor === 'string') {
@@ -405,7 +405,7 @@ export const generateCommonSolutions = async ({ problema, persona, autor }) => {
     throw new Error('Problema não definido. Por favor, descreva o problema primeiro.');
   }
 
-  const personaString = formatObjectForPrompt(persona, ['description']);
+  const personaString = typeof persona === 'string' ? persona : (persona ? formatObjectForPrompt(persona, ['description']) : 'indisponível');
 
   let autorString;
   if (typeof autor === 'string') {
@@ -450,11 +450,11 @@ export const generateCommonProblems = async ({ persona, autor }) => {
   }
   geminiAPI.initialize(apiKey);
 
-  if (!persona || Object.keys(persona).length === 0) {
+  if (!persona) {
     throw new Error('Persona não definida. Por favor, configure a persona primeiro.');
   }
 
-  const personaString = formatObjectForPrompt(persona, ['description']);
+  const personaString = typeof persona === 'string' ? persona : (persona ? formatObjectForPrompt(persona, ['description']) : 'indisponível');
 
   let autorString;
   if (typeof autor === 'string') {


### PR DESCRIPTION
This commit introduces a comprehensive set of features, refactors, and bugfixes to the campaign creation process based on user feedback.

Key changes include:

- **New Fields:** Adds 'Objetivo' (Objective) and 'Tom de Voz' (Tone of Voice) fields to the campaign definition. These fields are conditionally displayed, saved with the campaign, and used to enrich the AI prompt.

- **Refactor Author/Persona Handling:**
  - Removes the concept of a 'default' author and persona from local storage and the application state.
  - Selection is now optional. If no author or persona is selected, the value 'indisponível' (unavailable) is passed to the generation prompts.
  - The 'Autor' and 'Persona' selection dropdowns are now disabled after content generation, creating a more consistent UI flow.
  - The placeholder text in these dropdowns has been updated to 'Não especificar' (Do not specify).

- **Bugfix: Stale Dropdown Lists:**
  - Fixes a bug where creating a new author or persona would not update the selection lists on the campaign page. This is resolved by implementing a callback system to refetch the data.

- **Bugfix: Incorrect Author in Prompts:**
  - Fixes a bug where the wrong author (or no author) was being used in prompts for generating solution ideas. The correctly selected author is now always used.

- **Deprecation: 'Instruções' Field:**
  - The legacy 'Instruções' (Instructions) field and its corresponding UI tab have been completely removed from the application.