### PR TITLE
refactor(generation): Decouple WordPress content generation from main…

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -752,11 +752,10 @@ function HomePage() {
 
       setFollowupPosts([]);
 
-      setGenerationStatus('Gerando resumos e conteúdo formatado...');
+      setGenerationStatus('Gerando resumos...');
       await Promise.all([
         handleGenerateSummary(1800, normalizedContent),
         handleGenerateSummary(130, normalizedContent),
-        handleGenerateFormattedContent(normalizedContent),
       ]);
 
       toast.success("Campanha gerada com sucesso!");


### PR DESCRIPTION
… flow

This commit removes the automatic generation of formatted WordPress content from the main campaign creation process.

Previously, when a user clicked "Elaborar Postagens" (Elaborate Posts), the application would generate the main content, summaries, and the formatted HTML for WordPress simultaneously.

Now, the formatted WordPress content is only generated when the user explicitly clicks the "Gerar" (Generate) button within the "Conteúdo WordPress" tab. This gives the user more control over the workflow and reduces initial processing time.