### PR TITLE
fix(scheduler): Implement on-demand LinkedIn token refresh

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -148,6 +148,96 @@ async function handleUpdateSchedule(request, response) {
     }
 }
 
+// Helper function to publish a single post to LinkedIn.
+// It returns the final response from the proxy.
+async function publishPost(fetch, post, accessToken) {
+    const postContent = post.post_content;
+    const authorUrn = postContent.authorUrn;
+    const proxyApiBaseUrl = process.env.VITE_API_BASE_URL || 'http://localhost:5173';
+
+    const postText = [
+        postContent.titulo.toUpperCase(),
+        '',
+        markdownToLinkedinText(postContent.conteudo),
+        '',
+        '----',
+        postContent.cta,
+        '----',
+        (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
+    ].join('\n');
+
+    const images = post.campaign_data?.images || [];
+    const imageUrns = [];
+
+    if (images.length > 0) {
+        for (const imageUrl of images) {
+            const imageResponse = await fetch(imageUrl);
+            if (!imageResponse.ok) throw new Error(`Failed to fetch image from blob store: ${imageUrl}`);
+
+            const imageBuffer = await imageResponse.arrayBuffer();
+            const imageBase64 = Buffer.from(imageBuffer).toString('base64');
+            const imageType = imageResponse.headers.get('content-type');
+
+            const registerResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    action: 'registerUpload',
+                    accessToken,
+                    payload: {
+                        registerUploadRequest: {
+                            owner: authorUrn,
+                            recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
+                            serviceRelationships: [{
+                                relationshipType: 'OWNER',
+                                identifier: 'urn:li:userGeneratedContent'
+                            }]
+                        }
+                    }
+                })
+            });
+
+            if (registerResponse.status === 401) return registerResponse;
+            if (!registerResponse.ok) {
+                const errorData = await registerResponse.json();
+                throw new Error(`Failed to register image upload: ${errorData.message || 'Unknown error'}`);
+            }
+
+            const { uploadUrl, assetUrn } = await registerResponse.json();
+
+            const uploadResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'uploadImage', accessToken, uploadUrl, imageBase64, imageType })
+            });
+
+            if (uploadResponse.status === 401) return uploadResponse;
+            if (!uploadResponse.ok) {
+                const errorData = await uploadResponse.json();
+                throw new Error(`Failed to upload image: ${errorData.message || 'Unknown error'}`);
+            }
+
+            imageUrns.push(assetUrn);
+        }
+    }
+
+    const videoUrn = post.post_content?.video;
+    const payload = {
+        author: authorUrn,
+        content: postText,
+        images: imageUrns,
+        video: videoUrn,
+        title: post.post_content?.titulo || 'Video Post'
+    };
+
+    return fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'createPost', accessToken, payload }),
+    });
+}
+
+
 // The main scheduler logic
 export async function handleRunScheduler(request, response) {
     const fetch = (await import('node-fetch')).default;
@@ -167,123 +257,47 @@ export async function handleRunScheduler(request, response) {
         );
 
         if (duePosts.length === 0) {
+            console.log('No due posts to publish.');
             return response.status(200).json({ message: 'No due posts to publish.' });
         }
 
+        console.log(`Found ${duePosts.length} posts to process.`);
+
         for (const post of duePosts) {
             try {
-                const postContent = post.post_content;
-                const authorUrn = postContent.authorUrn;
                 let accessToken = post.linkedin_access_token;
 
-                // NOTE: Token refresh logic might need adjustment depending on where it's stored and how it's managed.
-                // Assuming a refresh mechanism exists.
-                const refreshResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'refreshToken', userId: post.user_id }),
-                });
+                // First attempt to publish
+                let proxyResponse = await publishPost(fetch, post, accessToken);
 
-                if (refreshResponse.ok) {
-                    const { accessToken: newAccessToken } = await refreshResponse.json();
-                    accessToken = newAccessToken;
-                } else {
-                    console.warn(`Failed to refresh token for user ${post.user_id}. Proceeding with existing token.`);
-                }
+                // If the token is expired (401), try to refresh it
+                if (proxyResponse.status === 401) {
+                    console.log(`Access token for user ${post.user_id} may have expired. Attempting to refresh.`);
 
-                const postText = [
-                    postContent.titulo.toUpperCase(),
-                    '',
-                    markdownToLinkedinText(postContent.conteudo),
-                    '',
-                    '----',
-                    postContent.cta,
-                    '----',
-                    (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
-                ].join('\n');
+                    const refreshResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ action: 'refreshToken', userId: post.user_id }),
+                    });
 
-                const images = post.campaign_data?.images || [];
-                const imageUrns = [];
+                    if (refreshResponse.ok) {
+                        const { accessToken: newAccessToken } = await refreshResponse.json();
+                        accessToken = newAccessToken; // Update token
+                        console.log(`Token refreshed successfully for user ${post.user_id}. Retrying post.`);
 
-                if (images.length > 0) {
-                    for (const imageUrl of images) {
-                        // Fetch the image from the blob store
-                        const imageResponse = await fetch(imageUrl);
-                        if (!imageResponse.ok) {
-                            throw new Error(`Failed to fetch image from blob store: ${imageUrl}`);
-                        }
-                        const imageBuffer = await imageResponse.arrayBuffer();
-                        const imageBase64 = Buffer.from(imageBuffer).toString('base64');
-                        const imageType = imageResponse.headers.get('content-type');
-
-                        // Register the upload with LinkedIn
-                        const registerResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                                action: 'registerUpload',
-                                accessToken,
-                                payload: {
-                                    registerUploadRequest: {
-                                        owner: authorUrn,
-                                        recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
-                                        serviceRelationships: [{
-                                            relationshipType: 'OWNER',
-                                            identifier: 'urn:li:userGeneratedContent'
-                                        }]
-                                    }
-                                }
-                            })
-                        });
-
-                        if (!registerResponse.ok) {
-                            throw new Error('Failed to register image upload with LinkedIn.');
-                        }
-                        const registerData = await registerResponse.json();
-                        const uploadUrl = registerData.uploadUrl;
-                        const assetUrn = registerData.assetUrn;
-
-                        // Upload the image to LinkedIn
-                        const uploadResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({
-                                action: 'uploadImage',
-                                accessToken,
-                                uploadUrl,
-                                imageBase64,
-                                imageType
-                            })
-                        });
-
-                        if (!uploadResponse.ok) {
-                            throw new Error('Failed to upload image to LinkedIn.');
-                        }
-
-                        imageUrns.push(assetUrn);
+                        // Second attempt to publish with the new token
+                        proxyResponse = await publishPost(fetch, post, accessToken);
+                    } else {
+                        // If refresh fails, we can't proceed with this post.
+                        const errorData = await refreshResponse.json();
+                        throw new Error(`Failed to refresh token: ${errorData.message || `Status ${refreshResponse.status}`}`);
                     }
                 }
 
-                const videoUrn = post.post_content?.video;
-
-                const payload = {
-                    author: authorUrn,
-                    content: postText,
-                    images: imageUrns,
-                    video: videoUrn,
-                    title: post.post_content?.titulo || 'Video Post'
-                };
-
-                const proxyUrl = `${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`;
-                const proxyResponse = await fetch(proxyUrl, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'createPost', accessToken, payload }),
-                });
-
+                // Check the result of the final publish attempt
                 if (!proxyResponse.ok) {
                     const errorData = await proxyResponse.json();
-                    throw new Error(`LinkedIn API Error: ${errorData.message || 'Unknown'}`);
+                    throw new Error(`LinkedIn API Error after potential refresh: ${errorData.message || `Status code ${proxyResponse.status}`}`);
                 }
 
                 const result = await proxyResponse.json();
@@ -296,8 +310,10 @@ export async function handleRunScheduler(request, response) {
                     [result.id, linkedinPostUrl, post.id]
                 );
                 publishedCount++;
+                console.log(`Successfully published post ${post.id} for user ${post.user_id}.`);
 
             } catch (error) {
+                console.error(`Failed to process post ${post.id} for user ${post.user_id}. Error: ${error.message}`);
                 await query(
                     `UPDATE linkedin_schedules
                      SET status = 'failed', error_message = $1, updated_at = NOW()
@@ -309,6 +325,7 @@ export async function handleRunScheduler(request, response) {
         }
 
         const summary = `Scheduler run finished. Published: ${publishedCount}, Failed: ${failedCount}.`;
+        console.log(summary);
         return response.status(200).json({ message: summary });
 
     } catch (error) {


### PR DESCRIPTION
The LinkedIn scheduler was attempting to refresh the access token on every run, which was inefficient and caused failures when the refresh token was invalid. This led to posts failing with 401 Unauthorized errors.

This commit refactors the scheduler logic to only refresh the access token when a LinkedIn API call fails with a 401 status.

- The post creation logic has been extracted into a `publishPost` helper function.
- The main `handleRunScheduler` function now calls `publishPost` and checks for a 401 response.
- If a 401 error occurs, the scheduler attempts to refresh the token via the `linkedin-proxy`.
- If the token is successfully refreshed, the post creation is retried with the new token.
- If the refresh or the retry fails, the post is marked as 'failed' with a detailed error message.
- Added more detailed logging to the scheduler to improve debuggability.