### PR TITLE
feat: Improve image regeneration workflow

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -1287,11 +1287,11 @@ export default ImageGeneratorFrontendOnly;      try {
                 variant="contained"
                 color="primary"
                 onClick={generateImages}
-                disabled={isGenerating || !fontsLoaded || (generatedImages.length > 0 && generatedImages.some(img => img.url))}
+                disabled={isGenerating || !fontsLoaded}
                 startIcon={<ImageIcon />}
                 fullWidth
               >
-                {generatedImages.length > 0 && generatedImages.some(img => img.url) ? 'Imagens Já Geradas' : (isGenerating ? 'Gerando...' : 'Gerar Imagens')}
+                {generatedImages.some(img => img.url) ? 'Regerar imagens' : (isGenerating ? 'Gerando...' : 'Gerar Imagens')}
               </Button>
             </Grid>
 
@@ -1474,6 +1474,46 @@ export default ImageGeneratorFrontendOnly;      try {
                             title="Compartilhar"
                           >
                             <Share />
+                          </IconButton>
+                          <IconButton
+                            size="small"
+                            onClick={async () => {
+                              const imageToRegenerate = generatedImages.find(img => img.index === imageData.index);
+                              if (imageToRegenerate) {
+                                let bgToUse = imageToRegenerate.backgroundImage || backgroundImage;
+
+                                try {
+                                  const newBg = await generateSingleImageWithPrompt(imageToRegenerate.record, imageData.index);
+                                  if (newBg) {
+                                    bgToUse = newBg;
+                                  }
+                                } catch (error) {
+                                  return; // Stop if AI generation fails
+                                }
+
+                                const positionsToUse = imageToRegenerate.customFieldPositions || fieldPositions;
+                                const stylesToUse = imageToRegenerate.customFieldStyles || fieldStyles;
+                                const elementsToUse = imageToRegenerate.customBrandElements !== undefined ? imageToRegenerate.customBrandElements : brandElements;
+                                const sizeToUse = imageToRegenerate.customOriginalImageSize || originalImageSize;
+                                const fontScaleToUse = imageToRegenerate.fontScale || fontScale;
+                                const imageFiltersToUse = imageToRegenerate.customImageFilters || imageFilters;
+
+                                regenerateSingleImage(
+                                  imageData.index,
+                                  imageToRegenerate.record,
+                                  bgToUse,
+                                  positionsToUse,
+                                  stylesToUse,
+                                  sizeToUse,
+                                  elementsToUse,
+                                  fontScaleToUse,
+                                  imageFiltersToUse
+                                );
+                              }
+                            }}
+                            title="Regerar com IA"
+                          >
+                            <AutoFixHigh />
                           </IconButton>
                         </Box>
                       </CardContent>


### PR DESCRIPTION
This commit addresses the user's request to improve the image generation process by making the following changes:

1.  **Update Main Button Label**: The main "Gerar Imagens" button in the image generation step now correctly displays "Regerar imagens" after the initial set of images has been generated. The button's `disabled` state has also been updated to allow for this regeneration.

2.  **Add Individual Regeneration Button**: A new "Regenerate with AI" button, using the `AutoFixHigh` icon, has been added to each individual image card. This allows users to regenerate a specific post's image without affecting the others.

3.  **Implement Individual Regeneration Logic**: The `onClick` handler for the new button triggers a process that: a. Generates a new background image using the AI prompt associated with that specific post (`prompt_imagem`). b. Re-composites the final image with the new background and all existing text overlays and brand elements. c. Updates the view to display the newly generated image.

These changes provide a more flexible and intuitive workflow for users creating and refining campaign images.