### PR TITLE
feat: Improve image generation flow and add regeneration options

### DIFF
--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -33,7 +33,8 @@ import {
   Google,
   Edit,
   SwapHoriz,
-  Share
+  Share,
+  AutoAwesomeOutlined as GeminiIcon,
 } from '@mui/icons-material';
 import GeneratedImageEditor from './GeneratedImageEditor';
 import MemoizedGeneratedImageEditor from './MemoizedGeneratedImageEditor';
@@ -56,7 +57,8 @@ const ImageGeneratorFrontendOnly = ({
   brandElements,
   onBrandElementsChange,
   fontScale = 1,
-  standardsColors
+  standardsColors,
+  handleGenerateSingleImage, // Nova prop
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -170,6 +172,15 @@ const ImageGeneratorFrontendOnly = ({
 
 
   const generateImages = async () => {
+    if (isGenerating) return;
+
+    // Se já existem imagens, o botão funciona como "Regerar Tudo"
+    if (generatedImages.some(img => img.url)) {
+      handleRegenerateAll();
+      return;
+    }
+
+    // Lógica original para gerar pela primeira vez
     if ((!backgroundImage && initialGeneratedImagesData.some(img => !img.backgroundImage)) || csvData.length === 0) {
       alert('Por favor, carregue um arquivo CSV e uma imagem de fundo global, ou garanta que todas as imagens tenham um fundo individual.');
       return;
@@ -227,6 +238,27 @@ const ImageGeneratorFrontendOnly = ({
       setIsGenerating(false);
       setShowProgressModal(false);
     }
+  };
+
+  const handleRegenerateAll = async () => {
+    if (!handleGenerateSingleImage) {
+      alert("A função de regeneração não está disponível.");
+      return;
+    }
+    setShowProgressModal(true);
+    setIsGenerating(true);
+    setProgress(0);
+    isCancelledRef.current = false;
+
+    for (let i = 0; i < csvData.length; i++) {
+      if (isCancelledRef.current) break;
+      const record = csvData[i];
+      await handleGenerateSingleImage(record, i);
+      setProgress(p => p + 1);
+    }
+
+    setIsGenerating(false);
+    setShowProgressModal(false);
   };
 
   const handleCancelGeneration = () => { isCancelledRef.current = true; };
@@ -511,15 +543,15 @@ const ImageGeneratorFrontendOnly = ({
                 variant="contained"
                 color="primary"
                 onClick={generateImages}
-                disabled={isGenerating || !fontsLoaded || (generatedImages.length > 0 && generatedImages.some(img => img.url))}
+                disabled={isGenerating || !fontsLoaded}
                 startIcon={<ImageIcon />}
                 fullWidth
               >
-                {generatedImages.length > 0 && generatedImages.some(img => img.url) ? 'Imagens Já Geradas' : (isGenerating ? 'Gerando...' : 'Gerar Imagens')}
+                {generatedImages.some(img => img.url) ? 'Regerar imagens' : 'Gerar Imagens'}
               </Button>
             </Grid>
 
-            {generatedImages.length > 0 && (
+            {generatedImages.some(img => img.url) && (
               <Grid item xs={12} md={6}>
                 <Button
                   variant="outlined"
@@ -527,7 +559,7 @@ const ImageGeneratorFrontendOnly = ({
                   startIcon={<Download />}
                   fullWidth
                 >
-                  Download Todas ({generatedImages.length})
+                  Download Todas ({generatedImages.filter(img => img.url).length})
                 </Button>
               </Grid>
             )}
@@ -670,35 +702,47 @@ const ImageGeneratorFrontendOnly = ({
                             }}
                           />
                         </Box>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleOpenGeneratedImageEditor(imageData, imageData.index)}
-                            title="Editar Posições/Estilos"
-                          >
-                            <Edit />
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleReplaceImageClick(imageData.index)}
-                            title="Substituir Imagem de Fundo"
-                          >
-                            <SwapHoriz />
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            onClick={() => downloadImage(imageData)}
-                            title="Download"
-                          >
-                            <Download />
-                          </IconButton>
-                          <IconButton
-                            size="small"
-                            onClick={() => handleShare(imageData)}
-                            title="Compartilhar"
-                          >
-                            <Share />
-                          </IconButton>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-around', gap: 1 }}>
+                           <Tooltip title="Regerar com IA">
+                                <IconButton
+                                    size="small"
+                                    onClick={() => handleGenerateSingleImage(imageData.record, imageData.index)}
+                                >
+                                    <GeminiIcon />
+                                </IconButton>
+                            </Tooltip>
+                          <Tooltip title="Editar Posições/Estilos">
+                            <IconButton
+                                size="small"
+                                onClick={() => handleOpenGeneratedImageEditor(imageData, imageData.index)}
+                            >
+                                <Edit />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Substituir Fundo">
+                            <IconButton
+                                size="small"
+                                onClick={() => handleReplaceImageClick(imageData.index)}
+                            >
+                                <SwapHoriz />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Download">
+                            <IconButton
+                                size="small"
+                                onClick={() => downloadImage(imageData)}
+                            >
+                                <Download />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Compartilhar">
+                            <IconButton
+                                size="small"
+                                onClick={() => handleShare(imageData)}
+                            >
+                                <Share />
+                            </IconButton>
+                          </Tooltip>
                         </Box>
                       </CardContent>
                     </Card>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -885,49 +885,15 @@ function HomePage() {
       if (generateImagesAutomatically) {
         toast.info('Geração de posts concluída. Iniciando geração automática de imagens...');
         let firstImageSet = false;
-        let currentImagesData = [...newGeneratedImagesData];
 
-        for (let i = 0; i < currentImagesData.length; i++) {
-          const record = currentImagesData[i].record;
+        for (let i = 0; i < csvDataResult.length; i++) {
+          const record = csvDataResult[i];
           const imagePrompt = record.prompt_imagem_carrossel;
 
           if (imagePrompt && imagePrompt.trim() !== '') {
-            setGenerationStatus(`Gerando imagem para o post ${i + 1}/${currentImagesData.length}...`);
-            try {
-              const rawBgImageUrl = await generateCampaignImage({ content: { titulo: imagePrompt }, aspectRatio });
-
-              const blob = await (await fetch(rawBgImageUrl)).blob();
-              const stableDataUrl = await new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.onloadend = () => resolve(reader.result);
-                reader.onerror = reject;
-                reader.readAsDataURL(blob);
-              });
-
-              if (!firstImageSet) {
-                updateImageAndPalette(stableDataUrl);
-                firstImageSet = true;
-              }
-
-              const finalImageData = await composeSingleImage({
-                record: record,
-                index: i,
-                itemBackgroundImage: stableDataUrl,
-                imageFilters,
-                brandElements,
-                fieldPositions: updatedFieldPositions,
-                fieldStyles: updatedFieldStyles,
-              });
-
-              finalImageData.backgroundImage = stableDataUrl;
-
-              currentImagesData[i] = finalImageData;
-              setGeneratedImagesData([...currentImagesData]);
-              toast.success(`Imagem final para o post #${i + 1} gerada.`);
-
-            } catch (error) {
-              console.error(`Error during automatic generation for post ${i + 1}:`, error);
-              toast.error(`Falha na geração automática para o post #${i + 1}: ${error.message}`);
+            const success = await handleGenerateSingleImage(record, i, !firstImageSet);
+            if (success && !firstImageSet) {
+              firstImageSet = true;
             }
           }
         }
@@ -937,6 +903,58 @@ function HomePage() {
       toast.error(`Erro ao gerar conteúdo com IA: ${error.message}`);
     } finally {
       setIsGenerating(false);
+      setGenerationStatus('');
+    }
+  };
+
+  const handleGenerateSingleImage = async (record, index, setAsBackground = false) => {
+    const imagePrompt = record.prompt_imagem_carrossel;
+    if (!imagePrompt || imagePrompt.trim() === '') {
+      toast.info(`O post #${index + 1} não possui um prompt para geração de imagem.`);
+      return false;
+    }
+
+    setGenerationStatus(`Gerando imagem para o post ${index + 1}/${csvData.length}...`);
+    try {
+      const rawBgImageUrl = await generateCampaignImage({ content: { titulo: imagePrompt }, aspectRatio });
+
+      const blob = await (await fetch(rawBgImageUrl)).blob();
+      const stableDataUrl = await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+      });
+
+      if (setAsBackground) {
+        updateImageAndPalette(stableDataUrl);
+      }
+
+      const finalImageData = await composeSingleImage({
+        record: record,
+        index: index,
+        itemBackgroundImage: stableDataUrl,
+        imageFilters,
+        brandElements,
+        fieldPositions,
+        fieldStyles,
+      });
+
+      finalImageData.backgroundImage = stableDataUrl;
+
+      setGeneratedImagesData(currentImagesData => {
+        const newImagesData = [...currentImagesData];
+        newImagesData[index] = finalImageData;
+        return newImagesData;
+      });
+
+      toast.success(`Imagem final para o post #${index + 1} gerada.`);
+      return true;
+    } catch (error) {
+      console.error(`Error during image generation for post ${index + 1}:`, error);
+      toast.error(`Falha na geração para o post #${index + 1}: ${error.message}`);
+      return false;
+    } finally {
       setGenerationStatus('');
     }
   };
@@ -1068,7 +1086,7 @@ function HomePage() {
                     activeStep={activeStep}
                   />
                 </div>
-                <div hidden={activeStep !== 4}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} standardsColors={standardsColors} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} fontScale={fontScale} /></div>
+                <div hidden={activeStep !== 4}><ImageGeneratorFrontendOnly csvData={csvData} backgroundImage={backgroundImage} fieldPositions={fieldPositions} fieldStyles={fieldStyles} displayedImageSize={displayedImageSize} csvHeaders={csvHeaders} colorPalette={colorPalette} standardsColors={standardsColors} setGeneratedImagesData={setGeneratedImagesData} initialGeneratedImagesData={generatedImagesData} onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate} originalImageSize={originalImageSize} imageFilters={imageFilters} brandElements={brandElements} onBrandElementsChange={setBrandElements} fontScale={fontScale} handleGenerateSingleImage={handleGenerateSingleImage} /></div>
                 <div hidden={activeStep !== 5}><AudioGenerator csvData={csvData} fieldPositions={fieldPositions} onAudiosGenerated={setGeneratedAudioData} initialAudioData={generatedAudioData} /></div>
                 <div hidden={activeStep !== 6}><VideoGenerator2 generatedImages={generatedImagesData} generatedAudioData={generatedAudioData} onVideoGenerated={(videoData) => setGeneratedVideosData(videoData)} /></div>
                 <div hidden={activeStep !== 7}><Publisher settings={settings} campaignContent={campaignContent} generatedImagesData={generatedImagesData} generatedVideosData={generatedVideosData} followupPosts={followupPosts} isScheduled={isScheduled} setIsScheduled={setIsScheduled} scheduleDate={scheduleDate} setScheduleDate={setScheduleDate} weeklySchedule={weeklySchedule} setWeeklySchedule={setWeeklySchedule} selectedProfile={selectedProfile} setSelectedProfile={setSelectedProfile} selectedImages={selectedImages} setSelectedImages={setSelectedImages} selectedVideos={selectedVideos} setSelectedVideos={setSelectedVideos} currentCampaign={currentCampaign} /></div>


### PR DESCRIPTION
This commit introduces several improvements to the image generation step:

1.  **Centralized Image Generation:** A new `handleGenerateSingleImage` function has been created in `HomePage.jsx` to centralize the logic for generating an image for a single post. This improves maintainability and code reuse.

2.  **Button Label Change:** The main "Gerar Imagens" button in the `ImageGeneratorFrontendOnly` component now changes its label to "Regerar imagens" after the initial image generation, providing clearer user feedback.

3.  **Individual Image Regeneration:** A new "Regenerate" button with an AI icon has been added to each individual post card. This allows users to regenerate the image for a specific post without having to regenerate all of them.

4.  **Updated Regeneration Flow:** The "Regerar imagens" button now triggers a function that iterates through all posts and calls the centralized `handleGenerateSingleImage` function for each, allowing for a full regeneration of all images. The initial automatic generation flow is also updated to use this centralized function.