### PR TITLE
fix: Correct parameter for individual image generation

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -916,7 +916,7 @@ function HomePage() {
 
     setGenerationStatus(`Gerando imagem para o post ${index + 1}/${csvData.length}...`);
     try {
-      const rawBgImageUrl = await generateCampaignImage({ content: { titulo: imagePrompt }, aspectRatio });
+      const rawBgImageUrl = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
 
       const blob = await (await fetch(rawBgImageUrl)).blob();
       const stableDataUrl = await new Promise((resolve, reject) => {


### PR DESCRIPTION
This commit fixes a bug where the individual image generation was failing. The `generateCampaignImage` function was being called with a `content` object instead of the expected `prompt` string.

The `handleGenerateSingleImage` function in `HomePage.jsx` has been corrected to pass the `prompt` parameter correctly, resolving the generation failure.