### PR TITLE
fix: Append aspect ratio to individual image prompts

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -914,9 +914,11 @@ function HomePage() {
       return false;
     }
 
+    const finalPrompt = `${imagePrompt.trim()} --ar ${aspectRatio}`;
+
     setGenerationStatus(`Gerando imagem para o post ${index + 1}/${csvData.length}...`);
     try {
-      const rawBgImageUrl = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
+      const rawBgImageUrl = await generateCampaignImage({ prompt: finalPrompt, aspectRatio });
 
       const blob = await (await fetch(rawBgImageUrl)).blob();
       const stableDataUrl = await new Promise((resolve, reject) => {


### PR DESCRIPTION
This commit fixes a bug where the selected aspect ratio was not being applied during the generation of individual images.

The `handleGenerateSingleImage` function in `HomePage.jsx` has been updated to explicitly append the aspect ratio to the prompt string (e.g., `--ar 16:9`) before sending it to the image generation service. This ensures that all individually generated or regenerated images respect the campaign's aspect ratio setting.