### PR TITLE
fix: Ensure aspect ratio is correctly applied during image generation

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -914,11 +914,9 @@ function HomePage() {
       return false;
     }
 
-    const finalPrompt = `${imagePrompt.trim()} --ar ${aspectRatio}`;
-
     setGenerationStatus(`Gerando imagem para o post ${index + 1}/${csvData.length}...`);
     try {
-      const rawBgImageUrl = await generateCampaignImage({ prompt: finalPrompt, aspectRatio });
+      const rawBgImageUrl = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
 
       const blob = await (await fetch(rawBgImageUrl)).blob();
       const stableDataUrl = await new Promise((resolve, reject) => {

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -201,11 +201,16 @@ export const generateCampaignImage = async ({ prompt, aspectRatio }) => {
     : '';
 
   const promptTemplate = await getPrompt('generateCampaignImage');
-  const finalImagePrompt = fillPrompt(promptTemplate, {
+  let finalImagePrompt = fillPrompt(promptTemplate, {
       prompt: prompt,
       colorPalettePrompt: colorPalettePrompt,
       aspectRatio: aspectRatio,
   });
+
+  // Ensure aspect ratio is in the prompt, even if the template is missing it.
+  if (!finalImagePrompt.includes('--ar')) {
+    finalImagePrompt = `${finalImagePrompt.trim()} --ar ${aspectRatio}`;
+  }
 
   const base64Image = await geminiAPI.generateImage(finalImagePrompt, 'Geração de Imagem de Campanha');
   return `data:image/png;base64,${base64Image}`;


### PR DESCRIPTION
This commit provides a robust fix for the aspect ratio bug.

- The `generateCampaignImage` handler in `generationHandlers.js` is updated to ensure the aspect ratio is always included in the final prompt sent to the AI, even if the prompt template in the database is misconfigured.
- The previous, incorrect client-side fix in `HomePage.jsx` that manually added the aspect ratio to the prompt string has been reverted. The logic is now correctly handled in the generation service layer.

This ensures that all generated images will respect the campaign's aspect ratio setting.