### PR TITLE
Fix: Correct default number of short posts

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -244,7 +244,8 @@ function HomePage() {
     setSelectedImages(state.selectedImages ?? {});
     setSelectedVideos(state.selectedVideos ?? {});
     setInputMethod(state.inputMethod ?? 'ia');
-    setPromptNumRecords(state.promptNumRecords ?? 10);
+    // Default to 5, which matches the slider's max value in PostsCurtosStep.
+    setPromptNumRecords(state.promptNumRecords ?? 5);
     setPromptText(state.promptText ?? '');
     setFieldPositions(state.fieldPositions ?? {});
     setTemplateFieldStyles(state.templateFieldStyles ?? {});


### PR DESCRIPTION
The application was generating 10 short posts by default, while the UI slider for this setting has a maximum of 5. This caused an inconsistency if the user did not interact with the slider before generation.

This change corrects the default value for `promptNumRecords` from 10 to 5 in the `applyAppState` function within `src/pages/HomePage.jsx`. This ensures that the default number of generated posts aligns with the UI's constraint.

A comment has been added to clarify the reason for the default value.