### PR TITLE
Fix(schedule): Ensure scheduled posts are processed correctly

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -246,12 +246,12 @@ export async function handleRunScheduler(request, response) {
     let failedCount = 0;
 
     try {
-        const now = new Date();
+        const now = new Date().toISOString();
         const { rows: duePosts } = await query(
             `SELECT ls.*, c.campaign_data, u.linkedin_access_token
              FROM linkedin_schedules ls
              LEFT JOIN campaigns c ON ls.campaign_id = c.id
-             JOIN users u ON ls.user_id = u.id
+             LEFT JOIN users u ON ls.user_id = u.id
              WHERE ls.scheduled_at <= $1 AND ls.status = 'scheduled'`,
             [now]
         );


### PR DESCRIPTION
This commit addresses an issue where scheduled posts were getting stuck in the 'scheduled' state and not being published.

The primary cause of the issue was an incorrect time comparison in the database query that fetches due posts. The query was comparing a `TIMESTAMPTZ` (UTC) column with a local `new Date()` object, which could lead to timezone-related errors. This has been fixed by using `new Date().toISOString()` to ensure the comparison is always done in UTC.

Additionally, the database query has been made more resilient by changing the `JOIN` on the `users` table to a `LEFT JOIN`. This prevents posts from getting stuck in the queue indefinitely if their associated user is deleted. The scheduler will now attempt to process these orphaned posts, fail due to the missing user/token, and correctly mark their status as 'failed', clearing them from the active schedule.