### PR TITLE
Fix(api): Allow unauthenticated LinkedIn token refresh

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -432,12 +432,11 @@ async function handleGetMemberPostStatistics(fetch, request, response) {
     }
 }
 
-const mainHandler = async (request, response) => {
+const protectedHandler = async (request, response) => {
   const fetch = (await import('node-fetch')).default;
   const { action } = request.body;
   switch (action) {
     case 'tokenExchange': return handleTokenExchange(fetch, request, response);
-    case 'refreshToken': return handleRefreshToken(fetch, request, response);
     case 'testConnection': return handleGetProfile(fetch, request, response);
     case 'getProfile': return handleGetProfile(fetch, request, response);
     case 'registerUpload': return handleGenericPost(fetch, request, response, 'https://api.linkedin.com/rest/images?action=initializeUpload');
@@ -455,4 +454,18 @@ const mainHandler = async (request, response) => {
   }
 };
 
-export default withAuth(mainHandler);
+const mainHandler = async (request, response) => {
+  const { action } = request.body;
+  const fetch = (await import('node-fetch')).default;
+
+  // Actions that do not require user authentication
+  if (action === 'refreshToken') {
+    // Note: handleRefreshToken gets userId from the body, not from a session.
+    return handleRefreshToken(fetch, request, response);
+  }
+
+  // All other actions are protected and require a valid user session.
+  return withAuth(protectedHandler)(request, response);
+};
+
+export default mainHandler;


### PR DESCRIPTION
This commit fixes a bug where the scheduler was unable to refresh expired LinkedIn access tokens, causing all scheduled posts to fail.

The `refreshToken` action in `api/linkedin-proxy.js` was incorrectly protected by the `withAuth` middleware, which requires a user session. Since the scheduler runs in a server-to-server context without a user session, its calls to refresh the token were being rejected with a `401 Unauthorized` error.

The handler in `api/linkedin-proxy.js` has been refactored to separate the public `refreshToken` action from the other actions that require user authentication. This ensures that the scheduler can successfully refresh tokens while keeping all user-facing endpoints secure.