### PR TITLE
fix: Correct ReferenceError for imageFilters

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BSHyFTwX.js"></script>
+  <script type="module" crossorigin src="/assets/index-Dmjwnjbr.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DBiS__Si.css">
 </head>
 

--- a/src/components/ImageGeneratorFrontendOnly.jsx
+++ b/src/components/ImageGeneratorFrontendOnly.jsx
@@ -828,6 +828,7 @@ const ImageGeneratorFrontendOnly = ({
         backgroundImage={backgroundImage}
         originalImageSize={originalImageSize}
         standardsColors={standardsColors}
+        imageFilters={backgroundElement.filters}
       />
 
       <input


### PR DESCRIPTION
This commit fixes a `ReferenceError: imageFilters is not defined` that occurred when opening the Generated Image Editor.

The error was caused by the `ImageGeneratorFrontendOnly` component not passing the `imageFilters` prop to the `MemoizedGeneratedImageEditor` component. This commit adds the missing prop, passing `backgroundElement.filters` as the value.