### PR TITLE
feat: Make background selectable in editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -223,7 +223,9 @@ const FieldPositioner = ({
   }, [csvHeaders, fieldPositions, fieldStyles, setFieldPositions, setFieldStyles]);
 
   const handlePositionChange = (id, newPosition) => {
-    if (id === '__cropbox__') {
+    if (id === 'background') {
+      setBackgroundElement(prev => ({ ...prev, ...newPosition }));
+    } else if (id === '__cropbox__') {
       setBackgroundElement(prev => ({ ...prev, crop: { ...prev.crop, ...newPosition } }));
     } else if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
@@ -241,7 +243,9 @@ const FieldPositioner = ({
   };
 
   const handleSizeChange = (id, newSize) => {
-    if (id === '__cropbox__') {
+    if (id === 'background') {
+      setBackgroundElement(prev => ({ ...prev, ...newSize }));
+    } else if (id === '__cropbox__') {
       setBackgroundElement(prev => ({ ...prev, crop: { ...prev.crop, ...newSize } }));
     } else if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
@@ -367,7 +371,7 @@ const FieldPositioner = ({
     const elements = [
       // Add background element first so it's at the bottom
       ...(backgroundElement ? [{
-        id: '__background__',
+        id: 'background',
         type: 'background',
         position: backgroundElement,
         style: backgroundElement.filters,
@@ -529,12 +533,12 @@ const FieldPositioner = ({
                     }}
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
-                        handleFieldSelectInternal('__background__');
+                        handleFieldSelectInternal('background');
                       }
                     }}
                     onTouchStart={(e) => {
                       if (e.target === e.currentTarget) {
-                        handleFieldSelectInternal('__background__');
+                        handleFieldSelectInternal('background');
                       }
                     }}
                   >

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -80,7 +80,7 @@ const PageEditor = ({
 
   // Local state for image filters and toggles
   const defaultFilters = { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 };
-  const [editedImageFilters, setEditedImageFilters] = useState(imageFilters || defaultFilters);
+  const [editedBackgroundElement, setEditedBackgroundElement] = useState(null);
 
   const handleInternalFieldSelection = useCallback((fieldToSelect) => {
     setSelectedFieldInternal(fieldToSelect);
@@ -150,7 +150,17 @@ const PageEditor = ({
       setEditedStyles(newEditedStyles);
       setStylesAreInitialized(true);
 
-      setEditedImageFilters(imageFilters || defaultFilters);
+      setEditedBackgroundElement({
+        id: 'background',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        rotation: 0,
+        visible: true,
+        filters: pageData.imageFilters || defaultFilters,
+        crop: null, // PageEditor doesn't support cropping yet
+      });
       setFontScale(pageData.fontScale || 1); // Initialize font scale from pageData
     } else {
       setStylesAreInitialized(false);
@@ -175,7 +185,7 @@ const PageEditor = ({
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
-      imageFilters: editedImageFilters, // Pass back the edited filters
+      imageFilters: editedBackgroundElement ? editedBackgroundElement.filters : defaultFilters,
       fontScale: fontScale,
 
       // Explicitly set the background image that was used for editing
@@ -236,10 +246,11 @@ const PageEditor = ({
                 onSelectFieldExternal={handleInternalFieldSelection} // Use memoized handler
                 onCsvDataUpdate={handleFieldPositionerCsvDataUpdate} // Use memoized handler
                 originalImageSize={originalImageSize}
-                imageFilters={editedImageFilters}
                 onFontScaleChange={setFontScale}
                 brandElements={editedBrandElements}
                 setBrandElements={setEditedBrandElements}
+                backgroundElement={editedBackgroundElement}
+                setBackgroundElement={setEditedBackgroundElement}
                 currentPreviewIndex={0}
               />
             </Grid>
@@ -252,8 +263,8 @@ const PageEditor = ({
                   fieldPositions={editedPositions}
                   setFieldPositions={setEditedPositions}
                   csvHeaders={editorCsvHeaders}
-                  imageFilters={editedImageFilters}
-                  setImageFilters={setEditedImageFilters}
+                  backgroundElement={editedBackgroundElement}
+                  setBackgroundElement={setEditedBackgroundElement}
                   brandElements={editedBrandElements}
                   setBrandElements={setEditedBrandElements}
                   onDeselectField={handleDeselectField}
@@ -293,8 +304,8 @@ const PageEditor = ({
             setFieldPositions={setEditedPositions}
             csvHeaders={editorCsvHeaders}
             onOpenHtmlEditor={handleOpenHtmlEditor}
-            imageFilters={editedImageFilters}
-            setImageFilters={setEditedImageFilters}
+            backgroundElement={editedBackgroundElement}
+            setBackgroundElement={setEditedBackgroundElement}
             brandElements={editedBrandElements}
             setBrandElements={setEditedBrandElements}
             fontScale={fontScale}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -575,7 +575,7 @@ function HomePage() {
     img.onload = () => {
       setOriginalImageSize({ width: img.width, height: img.height });
       setBackgroundElement({
-        id: '__background__',
+        id: 'background',
         x: 0,
         y: 0,
         width: 100,


### PR DESCRIPTION
This commit implements the ability for the user to select the background image in the editor to access its formatting properties.

The changes include:
- Passing the `backgroundElement` and `setBackgroundElement` states from `HomePage.jsx` through `ImageStep.jsx` to `FieldPositioner.jsx`.
- Modifying `FieldPositioner.jsx` to render the background as a selectable element within the `renderableElements` array, using a special 'background' id.
- Updating `handlePositionChange` and `handleSizeChange` in `FieldPositioner.jsx` to call `setBackgroundElement` when the background element is modified.
- Standardizing the background element's id to 'background' during its creation in `HomePage.jsx`.
- Updating the `PageEditor.jsx` component to also correctly provide the `backgroundElement` prop to its instance of `FieldPositioner`, ensuring compatibility.