### PR TITLE
feat: Implement crop mode for background image

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -84,9 +84,19 @@ const DraggableElementInternal = ({
     }
 
     if (element.type === 'cropbox') {
-        return (
-            <Box sx={{ width: '100%', height: '100%', backgroundColor: 'rgba(0, 0, 0, 0.5)', border: '1px dashed #fff' }} />
-        );
+      return (
+        <Box
+          sx={{
+            width: '100%',
+            height: '100%',
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            border: '2px dashed rgba(255, 255, 255, 0.7)',
+            boxSizing: 'border-box',
+            boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.5)',
+            pointerEvents: 'none',
+          }}
+        />
+      );
     }
 
     // Default to text rendering
@@ -390,7 +400,11 @@ const DraggableElementInternal = ({
         rotationDegrees
       );
       
-      onPositionChange(element.id, { ...position, x: newX, y: newY, rotation: rotationDegrees });
+      if (element.type === 'cropbox') {
+        onPositionChange(element.id, { x: newX, y: newY });
+      } else {
+        onPositionChange(element.id, { ...position, x: newX, y: newY, rotation: rotationDegrees });
+      }
       onSizeChange(element.id, { width: newWidth, height: newHeight });
     }
   }, [isDragging, isResizing, isRotating, dragStart, initialRotation, element, position, containerSize, initialPosition, initialSize, resizeHandle, onPositionChange, onSizeChange, getRotatedBoundingBox]);
@@ -452,7 +466,11 @@ const DraggableElementInternal = ({
         rotationDegrees
       );
 
-      onPositionChange(element.id, { ...position, x: newX, y: newY, rotation: rotationDegrees });
+      if (element.type === 'cropbox') {
+        onPositionChange(element.id, { x: newX, y: newY });
+      } else {
+        onPositionChange(element.id, { ...position, x: newX, y: newY, rotation: rotationDegrees });
+      }
       onSizeChange(element.id, { width: newWidth, height: newHeight });
     }
   }, [isDragging, isResizing, isRotating, dragStart, initialRotation, element, position, containerSize, initialPosition, initialSize, resizeHandle, onPositionChange, onSizeChange, getRotatedBoundingBox]);
@@ -615,18 +633,20 @@ const DraggableElementInternal = ({
                 onTouchStart={(e) => handleTouchStart(e, 'resize', handle)}
               />
             ))}
-            <Box
-              className={styles.rotateHandle}
-              sx={{
-                top: `-${handleSize * 2.5}px`,
-                left: '50%',
-                transform: 'translateX(-50%)',
-                width: `${handleSize * 1.5}px`,
-                height: `${handleSize * 1.5}px`,
-              }}
-              onMouseDown={(e) => doHandleMouseDown(e, 'rotate')}
-              onTouchStart={(e) => handleTouchStart(e, 'rotate')}
-            />
+            {element.type !== 'cropbox' && (
+              <Box
+                className={styles.rotateHandle}
+                sx={{
+                  top: `-${handleSize * 2.5}px`,
+                  left: '50%',
+                  transform: 'translateX(-50%)',
+                  width: `${handleSize * 1.5}px`,
+                  height: `${handleSize * 1.5}px`,
+                }}
+                onMouseDown={(e) => doHandleMouseDown(e, 'rotate')}
+                onTouchStart={(e) => handleTouchStart(e, 'rotate')}
+              />
+            )}
           </>
         )}
       </Box>

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -74,7 +74,8 @@ const FieldPositioner = ({
   currentPreviewIndex,
   setCurrentPreviewIndex,
   onFontScaleChange,
-  cropMode,
+  isCropping,
+  setIsCropping,
 }) => {
   console.log('[FieldPositioner] props:', { backgroundImage, backgroundElement, fieldStyles });
   const [selectedField, setSelectedField] = useState(null);
@@ -381,7 +382,7 @@ const FieldPositioner = ({
         fontScale: 1,
         enableHtmlRendering: false,
       }] : []),
-      ...(cropMode && backgroundElement ? [{
+      ...(isCropping && backgroundElement ? [{
         id: '__cropbox__',
         type: 'cropbox',
         position: backgroundElement.crop || { x: 10, y: 10, width: 80, height: 80 },
@@ -434,7 +435,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => a.zIndex - b.zIndex);
     return elements;
-  }, [backgroundElement, backgroundImage, cropMode, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
+  }, [backgroundElement, backgroundImage, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
   if (!backgroundImage) {
     return (

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -70,8 +70,8 @@ const FormattingPanel = ({
   standardsColors,
   templateFieldStyles,
   activeStep,
-  cropMode,
-  setCropMode,
+  isCropping,
+  setIsCropping,
 }) => {
   const fonts = [
     // Sans-serif
@@ -634,6 +634,18 @@ const FormattingPanel = ({
                     )}
                   </AccordionDetails>
                 </Accordion>
+
+                {/* Cortar Imagem */}
+                <Box sx={{ mt: 2 }}>
+                  <Button
+                    variant={isCropping ? "contained" : "outlined"}
+                    color="primary"
+                    onClick={() => setIsCropping(!isCropping)}
+                    fullWidth
+                  >
+                    {isCropping ? 'Salvar Corte' : 'Cortar Imagem'}
+                  </Button>
+                </Box>
               </>
             )}
 

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -59,7 +59,7 @@ const ImageStep = ({
   console.log('[ImageStep] props:', { backgroundImage, backgroundElement, fieldStyles });
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [fontScale, setFontScale] = useState(1);
-  const [cropMode, setCropMode] = useState(false);
+  const [isCropping, setIsCropping] = useState(false);
 
   if (!backgroundImage) {
     return (
@@ -177,8 +177,8 @@ const ImageStep = ({
             currentPreviewIndex={currentPreviewIndex}
             setCurrentPreviewIndex={setCurrentPreviewIndex}
             onFontScaleChange={setFontScale}
-            cropMode={cropMode}
-            setCropMode={setCropMode}
+            isCropping={isCropping}
+            setIsCropping={setIsCropping}
           />
         </Grid>
         {!isMobile ? (
@@ -202,8 +202,8 @@ const ImageStep = ({
               fontScale={fontScale}
               templateFieldStyles={templateFieldStyles}
               activeStep={activeStep}
-              cropMode={cropMode}
-              setCropMode={setCropMode}
+              isCropping={isCropping}
+              setIsCropping={setIsCropping}
             />
           </Grid>
         ) : (
@@ -227,11 +227,11 @@ const ImageStep = ({
               onDeselectField={onDeselectField}
               onOpenHtmlEditor={onOpenHtmlEditor}
               standardsColors={standardsColors}
-              fontScale={fontScale}
+.              fontScale={fontScale}
               templateFieldStyles={templateFieldStyles}
               activeStep={activeStep}
-              cropMode={cropMode}
-              setCropMode={setCropMode}
+              isCropping={isCropping}
+              setIsCropping={setIsCropping}
             />
           </>
         )}


### PR DESCRIPTION
This commit introduces the crop mode functionality for the background image.

- Adds an `isCropping` state to `ImageStep.jsx` to manage the crop mode.
- Passes the `isCropping` state and its setter down to `FieldPositioner` and `FormattingPanel`.
- Adds a "Crop Image" button to the `FormattingPanel` to toggle the crop mode.
- Conditionally renders a `DraggableElement` with `type: 'cropbox'` in `FieldPositioner` when crop mode is active.
- The crop box's position and size are controlled by the `backgroundElement.crop` object.
- The `onPositionChange` and `onSizeChange` handlers for the crop box update the `backgroundElement.crop` state.
- The `DraggableElement` is styled to visually represent the crop box with a dashed border and a semi-transparent overlay.
- The rotation handle is hidden for the crop box.