### PR TITLE
fix: Add defensive guards to prevent TypeError

### DIFF
--- a/src/components/MemoizedPageEditor.jsx
+++ b/src/components/MemoizedPageEditor.jsx
@@ -50,9 +50,12 @@ const MemoizedPageEditor = ({
   }, [pageToEdit, fieldStyles]);
 
   const memoizedBrandElements = useMemo(() => {
-    return pageToEdit?.customBrandElements !== undefined
-      ? pageToEdit.customBrandElements
-      : brandElements;
+    // Defensively check if customBrandElements is an array. If not, fallback to the global brandElements.
+    if (pageToEdit && Array.isArray(pageToEdit.customBrandElements)) {
+      return pageToEdit.customBrandElements;
+    }
+    // Fallback to global brandElements, ensuring it's also an array.
+    return Array.isArray(brandElements) ? brandElements : [];
   }, [pageToEdit, brandElements]);
 
   if (!showGeneratedPageEditor || editingGeneratedPageIndex === null || !pageToEdit) {

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -98,9 +98,16 @@ const PageEditor = ({
 
   useEffect(() => {
     if (open && pageData && initialFieldPositions && initialFieldStyles) {
-      const brands = JSON.parse(JSON.stringify(pageData.customBrandElements || brandElements || []));
+      // Ensure brandElements and globalCsvHeaders are arrays before use.
+      const safeBrandElements = Array.isArray(pageData.customBrandElements)
+        ? pageData.customBrandElements
+        : (Array.isArray(brandElements) ? brandElements : []);
 
+      const safeGlobalCsvHeaders = Array.isArray(globalCsvHeaders) ? globalCsvHeaders : [];
+
+      const brands = JSON.parse(JSON.stringify(safeBrandElements));
       const positions = JSON.parse(JSON.stringify(initialFieldPositions));
+
       // Defensively add filters to brand elements
       brands.forEach(el => {
         if (!el.filters) {
@@ -121,7 +128,7 @@ const PageEditor = ({
       let zIndexCounter = zIndices.size > 0 ? Math.max(...zIndices) + 1 : 0;
 
       // Assign zIndex to text fields if they don't have one
-      globalCsvHeaders.forEach(header => {
+      safeGlobalCsvHeaders.forEach(header => {
         if (!positions[header]) positions[header] = {};
         if (positions[header].zIndex === undefined) {
           positions[header].zIndex = zIndexCounter++;
@@ -141,7 +148,7 @@ const PageEditor = ({
 
       // Simplified style initialization, as props are now pre-merged
       const newEditedStyles = {};
-      globalCsvHeaders.forEach(field => {
+      safeGlobalCsvHeaders.forEach(field => {
         newEditedStyles[field] = {
           ...COMPLETE_DEFAULT_STYLE,
           ...(initialFieldStyles?.[field] || {}),


### PR DESCRIPTION
This commit addresses a `TypeError: Cannot read properties of undefined (reading 'length')` that was occurring in the application. The root cause was that several components were attempting to iterate over or access the `.length` property of props that were expected to be arrays, but could be `null` or `undefined` when loading campaign data that might have missing fields.

This commit adds defensive guards in the following components:

1.  **`RecordManager.jsx`**: Added `Array.isArray` checks for `registrosIniciais` and `colunasIniciais` props to ensure they are always treated as arrays. Also removed an unnecessary dependency from a `useEffect` hook to prevent unstable re-renders.

2.  **`PageEditor.jsx`**: Added `Array.isArray` checks for `globalCsvHeaders` and `brandElements` props before they are used in loops or array methods.

3.  **`MemoizedPageEditor.jsx`**: Added a guard to ensure that `customBrandElements` from a loaded page is an array before being passed down.

These changes make the components more robust and prevent the application from crashing when encountering incomplete data.