### PR TITLE
fix: Resolve TypeError in VideoGenerator and improve app robustness

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -17,7 +17,7 @@ import NarrationSettings from './VideoGenerator/NarrationSettings';
 import Preview from './VideoGenerator/Preview';
 import SlidesSettings from './VideoGenerator/SlidesSettings';
 
-const VideoGenerator2 = ({ generatedImages, generatedAudioData, onVideoGenerated }) => {
+const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, onVideoGenerated }) => {
   const [video, setVideo] = useState(null);
   const [videos, setVideos] = useState([]);
   const [error, setError] = useState(null);


### PR DESCRIPTION
This commit provides a definitive fix for the recurring `TypeError: Cannot read properties of undefined (reading 'length')` and addresses other issues discovered during the investigation.

The primary cause of the TypeError was a prop name mismatch. The `HomePage` component was passing a prop named `generatedPages` to `VideoGenerator2.jsx`, but the `VideoGenerator2` component was expecting a prop named `generatedImages`. This resulted in `generatedImages` being `undefined` and causing a crash when its `.length` property was accessed. This has been corrected by aliasing the prop in `VideoGenerator2.jsx`.

In addition to the primary fix, this commit includes several other improvements to enhance the application's stability:

- **Defensive Guards**: Added `Array.isArray()` checks in `RecordManager.jsx`, `PageEditor.jsx`, and `MemoizedPageEditor.jsx` to ensure that props expected to be arrays are handled safely, preventing similar errors.
- **Build Error Fix**: Removed an invalid import of `composeImage` from `PageGeneratorFrontendOnly.jsx`, which was causing the build to fail.

These changes collectively resolve the user's reported issues and make the application more robust against incomplete or malformed data.