### PR TITLE
fix(DraggableElement): Aplicar textContentStyle ao contêiner de texto

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -614,6 +614,7 @@ const DraggableElementInternal = ({
             justifyContent: style.verticalAlign === 'top' ? 'flex-start' : style.verticalAlign === 'middle' ? 'center' : 'flex-end',
             alignItems: style.textAlign === 'left' ? 'flex-start' : style.textAlign === 'center' ? 'center' : 'flex-end',
             height: '100%',
+            ...textContentStyle,
           }}
         >
             {renderContent()}


### PR DESCRIPTION
O objeto `textContentStyle`, que continha todas as regras de estilo de texto dinâmicas (como cor, família da fonte, sombra, etc.), estava sendo calculado, mas não era aplicado ao elemento que renderiza o texto.

Esta correção aplica o `textContentStyle` ao `sx` prop do `Box` que envolve o conteúdo do texto, garantindo que todos os estilos de campo sejam renderizados corretamente na pré-visualização.