### PR TITLE
fix(DraggableElement): Aplicar estilos diretamente no renderContent

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -102,9 +102,13 @@ const DraggableElementInternal = ({
     // Default to text rendering
     if (!enableHtmlRendering) {
       // Render the calculated lines to respect wrapping
-      return textLines.map((line, index) => (
-        <div key={index}>{line}</div>
-      ));
+      return (
+        <div style={textContentStyle}>
+          {textLines.map((line, index) => (
+            <div key={index}>{line}</div>
+          ))}
+        </div>
+      );
     }
 
     const sanitizedContent = sanitizeHtml(content);
@@ -117,7 +121,7 @@ const DraggableElementInternal = ({
           overflow: 'hidden',
           wordWrap: 'break-word',
           pointerEvents: 'none',
-          textAlign: style.textAlign || 'left',
+          ...textContentStyle,
         }}
       />
     );
@@ -614,7 +618,6 @@ const DraggableElementInternal = ({
             justifyContent: style.verticalAlign === 'top' ? 'flex-start' : style.verticalAlign === 'middle' ? 'center' : 'flex-end',
             alignItems: style.textAlign === 'left' ? 'flex-start' : style.textAlign === 'center' ? 'center' : 'flex-end',
             height: '100%',
-            ...textContentStyle,
           }}
         >
             {renderContent()}


### PR DESCRIPTION
A tentativa anterior de aplicar estilos no contêiner pai não foi eficaz. Esta nova abordagem aplica o objeto `textContentStyle` diretamente aos elementos `div` retornados pela função `renderContent`.

Para texto simples, o conteúdo é envolto em uma nova `div` que recebe os estilos. Para conteúdo HTML, os estilos são mesclados com o `style` existente do elemento.

Isso garante que os estilos de texto (cor, fonte, sombra, etc.) sejam aplicados da forma mais direta e específica possível, corrigindo o bug de renderização na pré-visualização.