### PR TITLE
Fix: Resolve ReferenceError for backgroundElement

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -60,6 +60,7 @@ const PageGeneratorFrontendOnly = ({
   fontScale = 1,
   standardsColors,
   handleGenerateSinglePage, // Nova prop
+  backgroundElement,
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -214,6 +215,7 @@ const PageGeneratorFrontendOnly = ({
         fieldPositions,
         fieldStyles,
         fontScale,
+        backgroundElement,
       })
       .then(pageData => {
         setProgress(p => p + 1);


### PR DESCRIPTION
This commit fixes a `ReferenceError: backgroundElement is not defined` that occurred in the `PageGeneratorFrontendOnly` component.

The error was caused by two issues:
1. The `backgroundElement` prop was being used in a `useEffect` hook without being destructured from the component's props.
2. The `backgroundElement` prop was not being passed to the `composeSingleImage` function within the `generatePages` function.

This commit addresses both issues by:
- Adding `backgroundElement` to the props destructuring in `PageGeneratorFrontendOnly.jsx`.
- Passing the `backgroundElement` prop to the `composeSingleImage` function call.