### PR TITLE
Fix: Correct style rendering in generated images

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -146,6 +146,7 @@ export const composeSingleImage = async ({
     fieldStyles = {},
     aspectRatio,
     backgroundElement, // Transformation object for the background
+    fontScale = 1,
 }) => {
 
     // 1. Create final canvas with fixed dimensions based on aspect ratio.
@@ -282,18 +283,18 @@ export const composeSingleImage = async ({
 
             const finalStyle = {
                 ...style,
-                fontSize: (style.fontSize || 24),
-                strokeWidth: (style.strokeWidth || 2),
-                shadowBlur: (style.shadowBlur || 4),
-                shadowOffsetX: (style.shadowOffsetX || 2),
-                shadowOffsetY: (style.shadowOffsetY || 2),
+                fontSize: (style.fontSize || 24) * fontScale,
+                strokeWidth: (style.strokeWidth || 2) * fontScale,
+                shadowBlur: (style.shadowBlur || 4) * fontScale,
+                shadowOffsetX: (style.shadowOffsetX || 2) * fontScale,
+                shadowOffsetY: (style.shadowOffsetY || 2) * fontScale,
             };
 
             const padding = (style.padding || 0);
             const borderRadius = (style.borderRadius || 0);
             const borderWidth = (style.borderWidth || 0);
 
-            const backgroundOpacity = style.backgroundOpacity !== undefined ? style.backgroundOpacity : 1;
+            const backgroundOpacity = style.backgroundOpacity !== undefined ? style.backgroundOpacity / 100 : 1;
             const backgroundColorHex = style.backgroundColor || '#000000';
             if (backgroundOpacity > 0) {
                 ctx.fillStyle = hexToRgba(backgroundColorHex, backgroundOpacity);


### PR DESCRIPTION
This commit resolves a visual discrepancy between the editor preview and the final generated images. The styles for text and background elements were not being applied correctly during the image composition process.

The specific issues addressed are:
1.  **Incorrect Font Scaling:** The `fontScale` parameter, which adjusts font sizes based on the preview's rendered size, was not being passed to or utilized by the `composeSingleImage` function. This caused text to appear at a different size in the final image compared to the preview. The fix involves adding `fontScale` to the function's signature and applying it to the `fontSize` and other scalable style properties (like shadows and strokes) within `imageComposer.js`.

2.  **Mishandled Background Opacity:** The `backgroundOpacity` for text fields, which is controlled by a slider (likely 0-100), was being used directly as a 0-1 value in the canvas renderer. This caused any background with an opacity less than 100% to appear fully opaque. The fix is to scale the `backgroundOpacity` value by dividing it by 100 before applying it.