### PR TITLE
Fix: Ensure correct aspect ratio is used for generated images

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -61,6 +61,7 @@ const PageGeneratorFrontendOnly = ({
   standardsColors,
   handleGenerateSinglePage, // Nova prop
   backgroundElement,
+  aspectRatio,
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -148,6 +149,7 @@ const PageGeneratorFrontendOnly = ({
             fieldPositions: positionsToUse,
             fieldStyles: stylesToUse,
             fontScale: pageData.fontScale || 1, // Use custom font scale if available
+            aspectRatio,
           }).catch(error => {
             console.error(`[Thumbnail-Regen] Failed to regenerate thumbnail for index ${pageData.index}:`, error);
             return pageData; // On error, return the original data to not lose it
@@ -216,6 +218,7 @@ const PageGeneratorFrontendOnly = ({
         fieldStyles,
         fontScale,
         backgroundElement,
+        aspectRatio,
       })
       .then(pageData => {
         setProgress(p => p + 1);
@@ -421,6 +424,7 @@ const PageGeneratorFrontendOnly = ({
         fieldPositions: positionsToUse,
         fieldStyles: stylesToUse,
         fontScale,
+        aspectRatio,
       });
 
       setGeneratedPages(prevPages => {


### PR DESCRIPTION
This commit fixes a bug where the image generation process was not consistently using the campaign's defined aspect ratio. This was most noticeable when generating thumbnails for items that did not have their own specific background image, causing them to fall back to a default square aspect ratio instead of the intended portrait (e.g., 4:5) setting.

The root cause was that the `PageGeneratorFrontendOnly` component, while receiving the `aspectRatio` prop from `HomePage`, failed to destructure it and pass it along to its internal image generation calls.

The fix involves modifying `PageGeneratorFrontendOnly.jsx` to:
1.  Correctly destructure the `aspectRatio` prop.
2.  Pass the `aspectRatio` prop to all three internal calls of the `composeSingleImage` utility (in the `generatePages` function, the `regenerateSinglePage` function, and the `useEffect` hook for regenerating thumbnails on load).

This ensures that the user-defined aspect ratio is respected in all image generation scenarios within the component.