### PR TITLE
Fix: Prevent double font scaling on generated page save

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -402,7 +402,7 @@ const PageGeneratorFrontendOnly = ({
         stylesToUse,
         sizeToUse,
         elementsToUse,
-        modifiedPageData.fontScale || 1,
+        1, // Always use a fontScale of 1 when saving/regenerating from an edit
         modifiedPageData.imageFilters || imageFilters
       );
     }


### PR DESCRIPTION
This commit fixes a bug where editing and saving a generated page would cause the font size to shrink with each save. This was due to the editor's preview `fontScale` being applied a second time during the regeneration of the page's thumbnail.

Based on valuable user feedback, the fix is to hardcode the `fontScale` to `1` in the `regenerateSinglePage` call within the `handleSaveIndividualModifications` function. This ensures that when regenerating a thumbnail after an edit, the font size from the editor's styles is used as-is, without being incorrectly scaled down again.