### PR TITLE
Debug: Add console logs for opacity issue

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -202,6 +202,8 @@ const PageGeneratorFrontendOnly = ({
     setProgress(0);
     isCancelledRef.current = false;
 
+    console.log('[PageGenerator] Initial generation. Using fieldStyles:', fieldStyles);
+
     const pagePromises = csvData.map((record, i) => {
       if (isCancelledRef.current) return Promise.resolve(null);
 
@@ -414,6 +416,7 @@ const PageGeneratorFrontendOnly = ({
       alert('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       return;
     }
+    console.log(`[PageGenerator] Regenerating page ${index}. Using stylesToUse:`, stylesToUse);
     try {
       const newPageData = await composeSingleImage({
         record,

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1017,6 +1017,8 @@ function HomePage() {
   const currentTheme = darkMode ? darkTheme : lightTheme;
   const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, };
 
+  console.log('[HomePage] About to render. Current fieldStyles:', fieldStyles);
+
   return (
     <ThemeProvider theme={currentTheme}>
       <CssBaseline />


### PR DESCRIPTION
This commit is for debugging purposes only and does not contain a fix.

It adds `console.log` statements to `HomePage.jsx` and `PageGeneratorFrontendOnly.jsx` to trace the `fieldStyles` object through the component lifecycle.

The goal is to capture the state of the style objects during the initial, buggy page generation and during the subsequent, correct regeneration after a save. This code is intended to be deployed to a preview environment where the user can trigger the workflow and provide the console output for analysis.