### PR TITLE
fix(PageGenerator): Preserve background image on save

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -359,17 +359,13 @@ const PageGeneratorFrontendOnly = ({
       if (img.index !== pageIndex) {
         return img;
       }
-      // BUG FIX: The root of the "disappearing background" bug on save was here.
-      // `modifiedPageData` comes from the editor and does NOT have a `backgroundImage` property.
-      // The spread `{ ...img, ...modifiedPageData }` was overwriting `img.backgroundImage`
-      // with `undefined`.
-      // The fix is to manually construct the new object, EXPLICITLY preserving the
-      // `backgroundImage` from the existing state (`img`).
+      // The editor now sends back the correct background image it used.
+      // We trust the editor's data.
       return {
-        ...img, // Keep blob, url, etc.
+        ...img, // Keep existing properties like blob, url, etc.
         record: modifiedPageData.record,
-        backgroundImage: img.backgroundImage, // Keep the original background!
-        // Apply modifications from the editor
+        backgroundImage: modifiedPageData.backgroundImage, // Use the background from the editor.
+        // Apply other modifications from the editor
         customFieldPositions: modifiedPageData.fieldPositions,
         customFieldStyles: modifiedPageData.fieldStyles,
         customBrandElements: modifiedPageData.brandElements,


### PR DESCRIPTION
The background image of a page was being lost after entering the editor and saving changes.

This was caused by the `handleSaveIndividualModifications` function in `PageGeneratorFrontendOnly.jsx` incorrectly using the component's own state for the background image (`img.backgroundImage`) instead of the updated value coming from the editor (`modifiedPageData.backgroundImage`).

The `PageEditor` component correctly sends the background image it used for editing in its `onSave` callback. This change updates the parent component to trust and use this data, ensuring that any background image (either the original one or a newly replaced one) is preserved after saving.