### PR TITLE
fix(PageGenerator): Ensure background is drawn on regeneration

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -415,7 +415,7 @@ const PageGeneratorFrontendOnly = ({
         record,
         index,
         itemBackgroundImage: currentBackgroundImage,
-        imageFilters: customImageFilters,
+        backgroundElement: { filters: customImageFilters },
         brandElements: elementsToUse,
         fieldPositions: positionsToUse,
         fieldStyles: stylesToUse,


### PR DESCRIPTION
This commit fixes a bug where the background image would disappear from a thumbnail after being edited and saved.

The root cause was that the `regenerateSinglePage` function was not passing the required `backgroundElement` prop to the `composeSingleImage` utility. The image composer would therefore skip drawing the background.

The fix involves modifying the call to `composeSingleImage` within `regenerateSinglePage` to correctly construct and pass the `backgroundElement` object, ensuring the background and its filters are applied during thumbnail regeneration.

This commit also includes a previous change that correctly persists the `backgroundImage` property from the editor's save data into the component's state. Both changes are necessary to fully resolve the issue.