### PR TITLE
fix(formatting): Scope all style properties to the selected field

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -107,32 +107,11 @@ const FormattingPanel = ({
   ];
 
   const updateFieldStyle = (field, property, value) => {
-    const boxProperties = [
-      'backgroundColor',
-      'backgroundOpacity',
-      'borderColor',
-      'borderWidth',
-      'borderRadius',
-      'padding'
-    ];
-
-    if (boxProperties.includes(property)) {
-      // Apply box styles to all fields to maintain consistency
-      const newStyles = { ...fieldStyles };
-      (csvHeaders || []).forEach(header => {
-        newStyles[header] = {
-          ...(fieldStyles[header] || {}),
-          [property]: value
-        };
-      });
-      setFieldStyles(newStyles);
-    } else {
-      // Original logic for font-specific styles
-      setFieldStyles(prev => ({
-        ...prev,
-        [field]: { ...(prev[field] || {}), [property]: value }
-      }));
-    }
+    // Per user feedback, all style updates should apply only to the selected field.
+    setFieldStyles(prev => ({
+      ...prev,
+      [field]: { ...(prev[field] || {}), [property]: value }
+    }));
   };
 
   const updateFieldPosition = (field, property, value) => {
@@ -560,9 +539,9 @@ const FormattingPanel = ({
                         />
                       </Grid>
                       <Grid item xs={6}>
-                        <Typography gutterBottom>Opacidade: {Math.round((currentElement.style.backgroundOpacity || 1) * 100)}%</Typography>
+                        <Typography gutterBottom>Opacidade: {Math.round((currentElement.style.backgroundOpacity ?? 1) * 100)}%</Typography>
                         <Slider
-                          value={currentElement.style.backgroundOpacity || 1}
+                          value={currentElement.style.backgroundOpacity ?? 1}
                           onChange={(e, value) => updateFieldStyle(selectedField, 'backgroundOpacity', value)}
                           min={0}
                           max={1}


### PR DESCRIPTION
This commit addresses several bugs in the text box formatting panel, ensuring style modifications apply only to the selected element, per user feedback.

1.  **Scoped Style Application:** The `updateFieldStyle` function has been refactored to apply all style changes (including background, opacity, borders, and padding) exclusively to the currently selected text field. This removes the previous behavior where some "box properties" were incorrectly applied to all fields globally.

2.  **Corrected Opacity Slider Display:** The opacity slider no longer defaults to 100% when its actual value is 0. It now correctly reflects the true opacity by using the nullish coalescing operator (`??`) to handle the `0` case properly.

These changes work together to resolve the user-reported issues by making the styling behavior more intuitive and fixing the downstream effects on page generation.