### PR TITLE
fix(FieldPositioner): Use campaign aspect ratio for editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -52,6 +52,7 @@ import { autoArrangeFields as autoArrangeFieldsUtil } from '../utils/autoArrange
 
 
 const FieldPositioner = ({
+  aspectRatio: aspectRatioProp,
   backgroundImage,
   csvHeaders,
   fieldPositions,
@@ -281,7 +282,9 @@ const FieldPositioner = ({
     setCurrentPreviewIndex(csvData.length - 1);
   };
 
-  const aspectRatio = (effectiveImageSize?.width && effectiveImageSize?.height)
+  const aspectRatio = aspectRatioProp
+    ? String(aspectRatioProp).replace(':', ' / ')
+    : (effectiveImageSize?.width && effectiveImageSize?.height)
     ? `${effectiveImageSize.width} / ${effectiveImageSize.height}`
     : '16 / 9';
 

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -18,6 +18,7 @@ import FormattingPanel from './FormattingPanel';
 import FormattingDrawer from './FormattingDrawer';
 
 const ImageStep = ({
+  aspectRatio,
   steps,
   isDraggingOverImage,
   handleImageDrop,
@@ -155,6 +156,7 @@ const ImageStep = ({
       <Grid container spacing={isMobile ? 0 : 2}>
         <Grid item xs={12} md={8}>
           <FieldPositioner
+            aspectRatio={aspectRatio}
             backgroundImage={backgroundImage}
             csvHeaders={csvHeaders}
             fieldPositions={fieldPositions}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1139,6 +1139,7 @@ function HomePage() {
                 )}
                 {activeStep === 3 && (
                   <ImageStep
+                    aspectRatio={aspectRatio}
                     steps={steps}
                     isDraggingOverImage={isDraggingOverImage}
                     handleImageDrop={handleImageDrop}


### PR DESCRIPTION
The Field Editor in the "Image and Formatting" step was using the background image's dimensions as a reference, which was incorrect after a recent change that introduced page-based aspect ratios.

This change ensures the Field Editor respects the campaign's aspect ratio by passing the 'aspectRatio' prop from 'HomePage' down to 'FieldPositioner'.