### PR TITLE
fix: Correct field editor aspect ratio and disappearing background

### DIFF
--- a/src/components/BackgroundImageSelector.jsx
+++ b/src/components/BackgroundImageSelector.jsx
@@ -75,9 +75,17 @@ const BackgroundImageSelector = ({ open, onClose, onSelect, onLocalUpload }) => 
     try {
       // Call no longer needs token argument
       const blob = await getFileAsBlob(image.id);
-      const blobUrl = URL.createObjectURL(blob);
-      onSelect(blobUrl);
-      onClose(); // Close dialog on selection
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        const dataUrl = reader.result;
+        onSelect(dataUrl);
+        onClose(); // Close dialog on selection
+      };
+      reader.onerror = (error) => {
+        console.error("Error converting blob to data URL:", error);
+        toast.error("Falha ao converter a imagem para um formato utilizável.");
+      };
+      reader.readAsDataURL(blob);
     } catch (err) {
       setError(`Falha ao carregar imagem: ${err.message}`);
       toast.error(`Falha ao carregar imagem: ${err.message}`);


### PR DESCRIPTION
This commit addresses two related issues:

1.  **Field Editor Aspect Ratio:** The Field Editor in the "Image and Formatting" step was using the background image's dimensions as a reference, which was incorrect after a recent change that introduced page-based aspect ratios. This change ensures the Field Editor respects the campaign's aspect ratio by passing the 'aspectRatio' prop from 'HomePage' down to 'FieldPositioner'.

2.  **Disappearing Background Image:** When selecting an image from the Google Drive gallery, a temporary `blob:` URL was being used. This URL would become invalid when navigating between steps, causing the background image to disappear. This has been fixed by converting the image blob to a permanent `data:` URL in the `BackgroundImageSelector` component.