### PR TITLE
fix: Apply background image adjustments and enable selection

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -554,6 +554,12 @@ const DraggableElementInternal = ({
     return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturate}%) blur(${blur}px) opacity(${opacity}%)`;
   };
 
+  const getBoxShadowString = (style) => {
+    if (!style || !style.shadow) return 'none';
+    const { shadowColor = '#000000', shadowBlur = 4, shadowOffsetX = 2, shadowOffsetY = 2 } = style;
+    return `${shadowOffsetX}px ${shadowOffsetY}px ${shadowBlur}px ${shadowColor}`;
+  };
+
   const textContentStyle = {
     fontFamily: style.fontFamily || 'Arial',
     fontSize: `${scaledFontSize}px`,
@@ -569,12 +575,10 @@ const DraggableElementInternal = ({
   };
 
   const effectiveHandleMouseDown = (e, type, handle = null) => {
-    if (element.type === 'background') return;
     doHandleMouseDown(e, type, handle);
   };
 
   const effectiveHandleTouchStart = (e, type, handle = null) => {
-    if (element.type === 'background') return;
     handleTouchStart(e, type, handle);
   };
 
@@ -598,6 +602,8 @@ const DraggableElementInternal = ({
             : `${(style.borderWidth || 0) * fontScale}px solid ${style.borderColor || '#000000'}`,
           borderRadius: `${(style.borderRadius || 0) * fontScale}px`,
           padding: element.type === 'image' || element.type === 'background' || element.type === 'cropbox' ? 0 : `${(style.padding || 0) * fontScale}px`,
+          filter: (element.type === 'image' || element.type === 'background') ? getFilterString(style) : 'none',
+          boxShadow: (element.type === 'image' || element.type === 'background') ? getBoxShadowString(style) : 'none',
         }}
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
         onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}
@@ -623,7 +629,7 @@ const DraggableElementInternal = ({
             {renderContent()}
         </Box>
 
-        {isSelected && element.type !== 'background' && (
+        {isSelected && (
           <>
             {resizeHandles.map((handle) => (
               <Box

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -334,7 +334,7 @@ const FieldPositioner = ({
         id: '__background__',
         type: 'background',
         position: backgroundElement,
-        style: backgroundElement.filters,
+        style: { ...backgroundElement.filters, ...backgroundElement },
         content: backgroundImage,
         zIndex: -1, // Ensure it's always at the back
         rotation: backgroundElement.rotation,
@@ -381,7 +381,7 @@ const FieldPositioner = ({
             id: element.id,
             type: 'image',
             position: element,
-            style: { ...element.filters },
+            style: { ...element.filters, ...element },
             content: element.url,
             zIndex: element.zIndex || 0,
             rotation: element.rotation,

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -60,7 +60,8 @@ const PageEditor = ({
   originalImageSize,
   imageFilters, // Adicionado
   brandElements,
-  standardsColors
+  standardsColors,
+  globalBackgroundElement,
 }) => {
   console.log('[PageEditor] props:', { pageData, globalBackgroundImage, imageFilters });
   const [editedPositions, setEditedPositions] = useState({});
@@ -157,7 +158,7 @@ const PageEditor = ({
       setEditedStyles(newEditedStyles);
       setStylesAreInitialized(true);
 
-      setEditedBackgroundElement({
+      const backgroundToUse = pageData.customBackgroundElement || globalBackgroundElement || {
         id: 'background',
         x: 0,
         y: 0,
@@ -165,9 +166,10 @@ const PageEditor = ({
         height: 100,
         rotation: 0,
         visible: true,
-        filters: pageData.imageFilters || defaultFilters,
-        crop: null, // PageEditor doesn't support cropping yet
-      });
+        filters: defaultFilters,
+        crop: null,
+      };
+      setEditedBackgroundElement(backgroundToUse);
       setFontScale(pageData.fontScale || 1); // Initialize font scale from pageData
     } else {
       setStylesAreInitialized(false);
@@ -194,6 +196,7 @@ const PageEditor = ({
       brandElements: editedBrandElements,
       imageFilters: editedBackgroundElement ? editedBackgroundElement.filters : defaultFilters,
       fontScale: fontScale,
+      customBackgroundElement: editedBackgroundElement,
 
       // Explicitly set the background image that was used for editing
       backgroundImage: currentBackgroundImageForEditor,

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -368,6 +368,7 @@ const PageGeneratorFrontendOnly = ({
         customFieldStyles: modifiedPageData.fieldStyles,
         customBrandElements: modifiedPageData.brandElements,
         fontScale: modifiedPageData.fontScale,
+        customBackgroundElement: modifiedPageData.customBackgroundElement,
       };
     });
 
@@ -392,7 +393,8 @@ const PageGeneratorFrontendOnly = ({
           sizeToUse,
           elementsToUse,
           1, // Always use a fontScale of 1 when saving/regenerating from an edit
-          modifiedPageData.imageFilters || imageFilters
+          modifiedPageData.imageFilters || imageFilters,
+          pageToRegenerate.customBackgroundElement || backgroundElement,
         );
 
         // Now, create the final array by merging the regenerated image data (url, blob)
@@ -420,7 +422,7 @@ const PageGeneratorFrontendOnly = ({
     handleCloseGeneratedPageEditor();
   };
 
-  const regenerateSinglePage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1, customImageFilters = imageFilters) => {
+  const regenerateSinglePage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1, customImageFilters = imageFilters, backgroundElementToUse = backgroundElement) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       console.error('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       throw new Error('Pré-requisitos para regeneração não atendidos.');
@@ -430,7 +432,7 @@ const PageGeneratorFrontendOnly = ({
       record,
       index,
       itemBackgroundImage: currentBackgroundImage,
-      backgroundElement: { filters: customImageFilters },
+      backgroundElement: backgroundElementToUse,
       brandElements: elementsToUse,
       fieldPositions: positionsToUse,
       fieldStyles: stylesToUse,
@@ -816,6 +818,7 @@ const PageGeneratorFrontendOnly = ({
         originalImageSize={originalImageSize}
         imageFilters={imageFilters}
         standardsColors={standardsColors}
+        backgroundElement={backgroundElement}
       />
 
       <input


### PR DESCRIPTION
This commit addresses several issues with background image manipulation:

1.  **Filters and Shadows Not Applying:** The preview did not reflect changes to background image filters (brightness, contrast, etc.) or shadows. This was because the style properties were not being correctly passed to or applied by the `DraggableElement` component. The fix involves passing the complete background style object and adding logic to `DraggableElement` to apply the `filter` and `box-shadow` CSS properties.

2.  **No Direct Manipulation of Background:** The user could not resize or position the background image directly on the preview. The code that explicitly disabled manipulation handles for background elements in `DraggableElement.jsx` has been removed.

3.  **Background Not Selectable in 'Generate Pages':** When editing a single generated page, the background was not selectable for adjustments. This was due to the page-specific editor (`PageEditor.jsx`) not receiving the `backgroundElement` state. The fix involves propagating the `backgroundElement` to the editor and handling page-specific background modifications, which are then saved and used for regeneration.