### PR TITLE
fix: Resolve background image adjustment and selection issues

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -636,6 +636,9 @@ function HomePage() {
   const handleBackgroundImageUpload = async (file) => {
     if (!file) return;
 
+    const localUrl = URL.createObjectURL(file);
+    updateImageAndPalette(localUrl, null); // Process locally first
+
     const toastId = toast.loading("Salvando imagem na sua biblioteca do Google Drive...");
     try {
       if (!googleAccessToken) {
@@ -659,11 +662,8 @@ function HomePage() {
         throw new Error("O upload do arquivo para o Drive falhou.");
       }
 
-      // Construct a direct-access URL. This format works for public files.
-      // Ensure the file permissions are set correctly in the Drive API if issues arise.
       const permanentUrl = `https://lh3.googleusercontent.com/d/${uploadedFile.id}`;
-
-      updateImageAndPalette(permanentUrl);
+      setBackgroundImage(permanentUrl); // Update to permanent URL without reprocessing
 
       const imageStepIndex = steps.findIndex(step => step.label === 'Imagem e Formatação');
       if (imageStepIndex !== -1 && activeStep < imageStepIndex) {
@@ -674,6 +674,11 @@ function HomePage() {
     } catch (err) {
       console.error("Failed to upload and set background image:", err);
       toast.error(`Falha ao salvar imagem: ${err.message}`, { id: toastId });
+      // Clear image if upload fails
+      setBackgroundImage(null);
+      setBackgroundElement(null);
+    } finally {
+      URL.revokeObjectURL(localUrl); // Clean up local URL
     }
   };
 


### PR DESCRIPTION
This commit addresses several bugs related to background image handling.

1.  **Apply Filters and Shadows:** The preview now correctly reflects changes to background image filters (e.g., brightness) and shadows. This was fixed by ensuring the complete style object is passed to the `DraggableElement` component and that it applies the `filter` and `box-shadow` CSS properties.

2.  **Enable Direct Manipulation:** The background image can now be resized and positioned directly on the preview canvas, as the code that disabled these manipulation handles has been removed.

3.  **Enable Editing in 'Generate Pages':** The background image is now selectable and adjustable when editing an individual page in the 'Generate Pages' step. This was achieved by propagating the `backgroundElement` state to the `PageEditor` and saving any page-specific modifications.

4.  **Fix 'Image Disappearing' Regression:** A bug was fixed where selecting a background image would cause it to appear briefly and then vanish. This was due to a CORS error when attempting to process the permanent Google Drive URL for color palette extraction. The solution is to first use a local object URL for immediate processing and preview, and then, after a successful upload to Google Drive, update the image source to the permanent URL. This provides a more robust and responsive user experience.