### PR TITLE
fix: Resolve campaign saving and page generation bugs

### DIFF
--- a/api/campaigns/index.js
+++ b/api/campaigns/index.js
@@ -33,9 +33,13 @@ const handler = async (req, res) => {
       if (!name || !campaign_data) {
         return res.status(400).json({ error: 'Campaign name and data are required.' });
       }
+      // Convert empty strings to null for foreign key fields
+      const final_autor_id = autor_id === '' ? null : autor_id;
+      const final_persona_id = persona_id === '' ? null : persona_id;
+
       const { rows } = await query(
         'INSERT INTO campaigns (user_id, name, campaign_data, autor_id, persona_id) VALUES ($1, $2, $3, $4, $5) RETURNING id, name, updated_at',
-        [userId, name, campaign_data, autor_id, persona_id]
+        [userId, name, campaign_data, final_autor_id, final_persona_id]
       );
       return res.status(201).json(rows[0]);
     } catch (error) {

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -58,7 +58,6 @@ const PageEditor = ({
   colorPalette, // Paleta de cores global
   globalBackgroundImage, // Imagem de fundo global, como fallback
   originalImageSize,
-  imageFilters, // Adicionado
   brandElements,
   standardsColors,
   globalBackgroundElement,
@@ -174,7 +173,7 @@ const PageEditor = ({
     } else {
       setStylesAreInitialized(false);
     }
-  }, [open, pageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, imageFilters, brandElements]);
+  }, [open, pageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, brandElements, globalBackgroundElement]);
 
   if (!pageData) {
     return null;
@@ -194,7 +193,6 @@ const PageEditor = ({
       fieldPositions: editedPositions,
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
-      imageFilters: editedBackgroundElement ? editedBackgroundElement.filters : defaultFilters,
       fontScale: fontScale,
       customBackgroundElement: editedBackgroundElement,
 

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -54,7 +54,6 @@ const PageGeneratorFrontendOnly = ({
   initialGeneratedPagesData,
   onThumbnailRecordTextUpdate,
   originalImageSize,
-  imageFilters,
   brandElements,
   onBrandElementsChange,
   fontScale = 1,
@@ -138,13 +137,14 @@ const PageGeneratorFrontendOnly = ({
           const positionsToUse = pageData.customFieldPositions || fieldPositions;
           const stylesToUse = pageData.customFieldStyles || fieldStyles;
           const elementsToUse = pageData.customBrandElements !== undefined ? pageData.customBrandElements : brandElements;
+          const backgroundElementToUse = pageData.customBackgroundElement || backgroundElement;
 
           // Call the composition function to regenerate the merged page
           return composeSingleImage({
             record: pageData.record,
             index: pageData.index,
             itemBackgroundImage: pageData.backgroundImage,
-            imageFilters: pageData.customImageFilters || imageFilters, // Use custom filters if available
+            backgroundElement: backgroundElementToUse,
             brandElements: elementsToUse,
             fieldPositions: positionsToUse,
             fieldStyles: stylesToUse,
@@ -212,7 +212,6 @@ const PageGeneratorFrontendOnly = ({
         record,
         index: i,
         itemBackgroundImage,
-        imageFilters,
         brandElements,
         fieldPositions,
         fieldStyles,
@@ -285,8 +284,7 @@ const PageGeneratorFrontendOnly = ({
         fieldStyles, // Usando os estilos de campo globais
         originalImageSize,
         brandElements,
-        fontScale,
-        imageFilters
+        fontScale
       );
     } else {
       alert("Não foi possível resetar a página. A imagem de fundo principal não está disponível.");
@@ -393,7 +391,6 @@ const PageGeneratorFrontendOnly = ({
           sizeToUse,
           elementsToUse,
           1, // Always use a fontScale of 1 when saving/regenerating from an edit
-          modifiedPageData.imageFilters || imageFilters,
           pageToRegenerate.customBackgroundElement || backgroundElement,
         );
 
@@ -422,7 +419,7 @@ const PageGeneratorFrontendOnly = ({
     handleCloseGeneratedPageEditor();
   };
 
-  const regenerateSinglePage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1, customImageFilters = imageFilters, backgroundElementToUse = backgroundElement) => {
+  const regenerateSinglePage = async (index, record, currentBackgroundImage, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1, backgroundElementToUse = backgroundElement) => {
     if (!currentBackgroundImage || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
       console.error('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
       throw new Error('Pré-requisitos para regeneração não atendidos.');
@@ -459,11 +456,11 @@ const PageGeneratorFrontendOnly = ({
           const img = new Image();
           img.onload = () => {
             const newSize = { width: img.width, height: img.height };
-            regenerateSinglePage(replacingImageIndex, pageToUpdate.record, newBgUrl, pageToUpdate.customFieldPositions || fieldPositions, pageToUpdate.customFieldStyles || fieldStyles, newSize, pageToUpdate.customBrandElements || brandElements, fontScale);
+            regenerateSinglePage(replacingImageIndex, pageToUpdate.record, newBgUrl, pageToUpdate.customFieldPositions || fieldPositions, pageToUpdate.customFieldStyles || fieldStyles, newSize, pageToUpdate.customBrandElements || brandElements, fontScale, pageToUpdate.customBackgroundElement || backgroundElement);
           };
           img.onerror = () => {
             console.error('Failed to load the new background page to get its dimensions.');
-            regenerateSinglePage(replacingImageIndex, pageToUpdate.record, newBgUrl, pageToUpdate.customFieldPositions || fieldPositions, pageToUpdate.customFieldStyles || fieldStyles, null, pageToUpdate.customBrandElements || brandElements, fontScale);
+            regenerateSinglePage(replacingImageIndex, pageToUpdate.record, newBgUrl, pageToUpdate.customFieldPositions || fieldPositions, pageToUpdate.customFieldStyles || fieldStyles, null, pageToUpdate.customBrandElements || brandElements, fontScale, pageToUpdate.customBackgroundElement || backgroundElement);
           };
           img.src = newBgUrl;
         }
@@ -802,7 +799,7 @@ const PageGeneratorFrontendOnly = ({
         </DialogActions>
       </Dialog>
 
-      {console.log('[PageGeneratorFrontendOnly] rendering MemoizedPageEditor with props:', { showGeneratedPageEditor, generatedPages, editingGeneratedPageIndex, csvHeaders, fieldPositions, fieldStyles, brandElements, colorPalette, backgroundImage, originalImageSize, standardsColors, imageFilters })}
+      {console.log('[PageGeneratorFrontendOnly] rendering MemoizedPageEditor with props:', { showGeneratedPageEditor, generatedPages, editingGeneratedPageIndex, csvHeaders, fieldPositions, fieldStyles, brandElements, colorPalette, backgroundImage, originalImageSize, standardsColors, backgroundElement })}
       <MemoizedPageEditor
         showGeneratedPageEditor={showGeneratedPageEditor}
         handleCloseGeneratedPageEditor={handleCloseGeneratedPageEditor}
@@ -815,8 +812,7 @@ const PageGeneratorFrontendOnly = ({
         handleSaveIndividualModifications={handleSaveIndividualModifications}
         colorPalette={colorPalette}
         backgroundImage={backgroundImage}
-        originalImageSize={originalImageSize}
-        imageFilters={imageFilters}
+        originalImageSizd={originalImageSize}
         standardsColors={standardsColors}
         backgroundElement={backgroundElement}
       />


### PR DESCRIPTION
This commit addresses two critical bugs in the campaign creation workflow.

1.  **Backend: Fix Campaign Saving Error**
    - A 500 Internal Server Error occurred when saving a campaign if no author or persona was selected. This was because the frontend sent an empty string for `autor_id` or `persona_id`, which the database rejected as an invalid integer.
    - The fix, in `api/campaigns/index.js`, checks for empty strings in these fields and converts them to `null` before executing the `INSERT` query.

2.  **Frontend: Preserve Background Settings**
    - In the 'Generate Pages' step, all background image adjustments (position, size, filters, shadows) were being lost. This resulted in blank thumbnails and an incorrectly rendered background in the page editor.
    - The root cause was that the `backgroundElement` state object was not being consistently used during the page generation and editing processes.
    - The `PageGeneratorFrontendOnly` component has been refactored to correctly pass the `backgroundElement` to the `composeSingleImage` function for thumbnail generation and to the `PageEditor` for individual page editing.
    - A redundant `imageFilters` prop was also removed to clean up the code and prevent confusion.