### PR TITLE
Fix: Overhaul background image manipulation and persistence

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -586,7 +586,7 @@ const DraggableElementInternal = ({
     <>
       <Box
         ref={textBoxRef}
-        className={`${styles.textBox} ${isDragging ? styles.dragging : ''} ${isSelected && element.type !== 'background' ? styles.selected : ''}`}
+        className={`${styles.textBox} ${isDragging ? styles.dragging : ''} ${isSelected ? styles.selected : ''}`}
         sx={{
           left: `${position.x}%`,
           top: `${position.y}%`,

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -586,11 +586,12 @@ function HomePage() {
     img.onload = () => {
       setOriginalImageSize({ width: img.width, height: img.height });
       if (existingBackgroundElement) {
-        setBackgroundElement(existingBackgroundElement);
+        setBackgroundElement({ ...existingBackgroundElement, src: imageUrl });
       } else {
         setBackgroundElement({
           id: '__background__',
           type: 'background',
+          src: imageUrl,
           x: 0,
           y: 0,
           width: 100,
@@ -663,7 +664,24 @@ function HomePage() {
       }
 
       const permanentUrl = `https://lh3.googleusercontent.com/d/${uploadedFile.id}`;
-      setBackgroundImage(permanentUrl); // Update to permanent URL without reprocessing
+
+      // FIX: Update both the general background image state and the src within the element state.
+      // This ensures that when the local URL is revoked, the element still has a valid source.
+      setBackgroundImage(permanentUrl);
+      setBackgroundElement(prev => {
+        if (prev) {
+          return { ...prev, src: permanentUrl };
+        }
+        // This fallback should ideally not be hit if updateImageAndPalette ran correctly
+        return {
+          id: '__background__',
+          type: 'background',
+          src: permanentUrl,
+          x: 0, y: 0, width: 100, height: 100, rotation: 0, visible: true,
+          filters: { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 },
+          shadow: false, shadowColor: '#000000', shadowBlur: 10, shadowOffsetX: 5, shadowOffsetY: 5, crop: null,
+        };
+      });
 
       const imageStepIndex = steps.findIndex(step => step.label === 'Imagem e Formatação');
       if (imageStepIndex !== -1 && activeStep < imageStepIndex) {
@@ -678,7 +696,8 @@ function HomePage() {
       setBackgroundImage(null);
       setBackgroundElement(null);
     } finally {
-      URL.revokeObjectURL(localUrl); // Clean up local URL
+      // It's now safe to revoke the local URL because the state points to the permanent one.
+      URL.revokeObjectURL(localUrl);
     }
   };
 

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -72,7 +72,7 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
   if (needsUpload(cleanState.backgroundImage)) {
     assetsToUploadCount++;
   }
-  if (needsUpload(cleanState.generatedImageUrl)) {
+  if (needsUpload(cleanState.generatedPageUrl)) {
     assetsToUploadCount++;
   }
   if (Array.isArray(cleanState.brandElements)) {
@@ -104,11 +104,11 @@ export const serializeCampaignData = async (state, userId, campaignId = null, on
     }
 
     // Main Campaign Image
-    if (needsUpload(cleanState.generatedImageUrl)) {
+    if (needsUpload(cleanState.generatedPageUrl)) {
       const filename = `campaign_image_${Date.now()}.png`;
       console.log(`[serializeCampaignData] Uploading asset ${assetsUploadedCount + 1}/${assetsToUploadCount}: ${filename}`);
-      const permanentUrl = await uploadAsset(cleanState.generatedImageUrl, filename, campaignId, userId);
-      cleanState.generatedImageUrl = permanentUrl;
+      const permanentUrl = await uploadAsset(cleanState.generatedPageUrl, filename, campaignId, userId);
+      cleanState.generatedPageUrl = permanentUrl;
       assetsUploadedCount++;
       onProgress({ current: assetsUploadedCount, total: assetsToUploadCount });
     }


### PR DESCRIPTION
This commit completely fixes the background image handling feature. It addresses several bugs that prevented users from selecting, modifying, and saving background images correctly.

The key changes include:

1.  **Image Upload Logic (`HomePage.jsx`):**
    -   The `backgroundElement` state object is now the single source of truth and includes the image `src`.
    -   Fixed a bug where the background image would disappear after upload. The `handleBackgroundImageUpload` function now correctly updates the `backgroundElement` with the permanent URL from Google Drive before the local object URL is revoked.

2.  **Element Selection (`DraggableElement.jsx`):**
    -   Removed the logic that prevented the background element from being selected. Users can now see a selection highlight and use the resize/rotate handles on the background image.

3.  **State Persistence (`campaignState.js`):**
    -   Corrected a property name mismatch during serialization. The code now correctly uses `generatedPageUrl` instead of the non-existent `generatedImageUrl`, allowing the main campaign image to be saved.

These changes ensure that a user can select a background image, adjust its properties (filters, shadows, position), and have those changes correctly applied and persisted throughout the entire campaign creation and generation workflow.