### PR TITLE
Fix: Correct aspect ratio for thumbnails and page editor

### DIFF
--- a/src/components/MemoizedPageEditor.jsx
+++ b/src/components/MemoizedPageEditor.jsx
@@ -15,6 +15,7 @@ const MemoizedPageEditor = ({
   backgroundImage,
   originalImageSize,
   backgroundElement,
+  aspectRatio,
 }) => {
   console.log('[MemoizedPageEditor] props:', { backgroundElement });
   const pageToEdit = useMemo(() => {
@@ -79,6 +80,7 @@ const MemoizedPageEditor = ({
       originalImageSize={pageToEdit.customOriginalImageSize || originalImageSize}
       globalBackgroundElement={backgroundElement}
       brandElements={memoizedBrandElements}
+      aspectRatio={aspectRatio}
     />
   );
 };

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -61,6 +61,7 @@ const PageEditor = ({
   brandElements,
   standardsColors,
   globalBackgroundElement,
+  aspectRatio,
 }) => {
   console.log('[PageEditor] props:', { pageData, globalBackgroundImage, globalBackgroundElement });
   const [editedPositions, setEditedPositions] = useState({});
@@ -261,6 +262,7 @@ const PageEditor = ({
                 backgroundElement={editedBackgroundElement}
                 setBackgroundElement={setEditedBackgroundElement}
                 currentPreviewIndex={0}
+                aspectRatio={aspectRatio}
               />
             </Grid>
             {!isMobile && (

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -678,10 +678,10 @@ const PageGeneratorFrontendOnly = ({
                         </Box>
 
 <Box sx={{
+                          aspectRatio: aspectRatio ? String(aspectRatio).replace(':', ' / ') : '1 / 1',
                           width: '100%',
                           maxWidth: '100%',
                           height: 'auto',
-                          maxHeight: '180px',
                           display: 'flex',
                           flexDirection: 'column',
                           justifyContent: 'center',
@@ -815,6 +815,7 @@ const PageGeneratorFrontendOnly = ({
         originalImageSize={originalImageSize}
         standardsColors={standardsColors}
         backgroundElement={backgroundElement}
+        aspectRatio={aspectRatio}
       />
 
       <input


### PR DESCRIPTION
This commit fixes a bug where the campaign's aspect ratio was not being respected in the generated page thumbnails and the individual page editor.

The key changes include:

1.  **Thumbnail Aspect Ratio:** The `Box` component wrapping each thumbnail in `PageGeneratorFrontendOnly.jsx` now has its `aspectRatio` style property set dynamically based on the campaign's aspect ratio. This ensures thumbnails are displayed with the correct proportions.

2.  **Propagated Aspect Ratio to Editor:** The `aspectRatio` prop is now correctly passed from `PageGeneratorFrontendOnly` through `MemoizedPageEditor` and `PageEditor` down to the `FieldPositioner` component within the editor modal. This ensures the editor canvas also respects the campaign's aspect ratio.

This commit builds upon the previous regression fix to provide a complete and visually correct user experience.