### PR TITLE
fix: Correctly set src on new backgroundElement

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -583,11 +583,14 @@ function HomePage() {
     img.onload = () => {
       setOriginalImageSize({ width: img.width, height: img.height });
       if (existingBackgroundElement) {
-        setBackgroundElement(existingBackgroundElement);
+        // Ensure the new imageUrl is always set, even on an existing element
+        setBackgroundElement({ ...existingBackgroundElement, src: imageUrl });
       } else {
+        // FIX: The src property was missing, causing the image not to appear
         setBackgroundElement({
           id: '__background__',
           type: 'background',
+          src: imageUrl,
           x: 0,
           y: 0,
           width: 100,


### PR DESCRIPTION
This commit addresses a regression introduced in the previous refactoring. When a new background image was uploaded, the `src` property was not being added to the newly created `backgroundElement` state object. This caused the image preview to remain blank.

The fix ensures that `src: imageUrl` is correctly set in the `updateImageAndPalette` function in `HomePage.jsx` when a new background element is initialized.