### PR TITLE
fix: Resolve ReferenceError in FieldPositioner

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -78,7 +78,7 @@ const FieldPositioner = ({
   isCropping,
   setIsCropping,
 }) => {
-  console.log('[FieldPositioner] props:', { backgroundImageSrc, backgroundElement, fieldStyles });
+  console.log('[FieldPositioner] props:', { backgroundElement, fieldStyles });
   // const [selectedField, setSelectedField] = useState(null); // REMOVED: Use parent state
   const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
   const [fontScale, setFontScale] = useState(1);
@@ -165,7 +165,7 @@ const FieldPositioner = ({
     observer.observe(container);
 
     return () => observer.disconnect();
-  }, [onImageDisplayedSizeChange, backgroundImageSrc]);
+  }, [onImageDisplayedSizeChange, backgroundElement?.src]);
 
   // This component should not be responsible for initializing or updating the parent's state.
   // It should just render the props it receives. The parent (HomePage) is responsible for

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -156,7 +156,6 @@ const ImageStep = ({
         <Grid item xs={12} md={8}>
           <FieldPositioner
             aspectRatio={aspectRatio}
-            backgroundImageSrc={backgroundElement?.src}
             csvHeaders={csvHeaders}
             fieldPositions={fieldPositions}
             setFieldPositions={setFieldPositions}


### PR DESCRIPTION
This commit fixes a `ReferenceError: backgroundImageSrc is not defined` that occurred in the `FieldPositioner` component.

The error was caused by two orphaned references to the `backgroundImageSrc` variable that remained after it was removed as a prop during a previous refactoring. A `console.log` and a `useEffect` dependency array were still attempting to access the non-existent variable.

This commit removes these references.

Additionally, it cleans up `ImageStep.jsx` to remove the now-redundant `backgroundImageSrc` prop that was being passed to `FieldPositioner`, ensuring the component's API is clean and consistent.