### PR TITLE
fix(editor): Pass aspect ratio to PageEditor component

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -60,6 +60,7 @@ const PageEditor = ({
   brandElements,
   standardsColors,
   globalBackgroundElement,
+  aspectRatio,
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
   const [editedStyles, setEditedStyles] = useState({});
@@ -233,6 +234,7 @@ const PageEditor = ({
           <Grid container spacing={2}>
             <Grid item xs={12} md={isMobile ? 12 : 8}>
               <FieldPositioner
+                aspectRatio={aspectRatio}
                 csvHeaders={editorCsvHeaders} // Headers relevantes para esta imagem
                 fieldPositions={editedPositions}
                 setFieldPositions={setEditedPositions}

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -834,6 +834,7 @@ const PageGeneratorFrontendOnly = ({
         originalImageSize={originalImageSize}
         standardsColors={standardsColors}
         backgroundElement={backgroundElement}
+        aspectRatio={aspectRatio}
       />
 
       <input


### PR DESCRIPTION
This commit fixes a bug where the page editor modal would always default to a 16:9 aspect ratio, ignoring the campaign's actual setting.

The cause was that the `aspectRatio` prop was not being passed from the `PageGeneratorFrontendOnly` component to the `PageEditor` component.

This commit drills the `aspectRatio` prop down through the component tree (`PageGeneratorFrontendOnly` -> `PageEditor` -> `FieldPositioner`), ensuring the editor's preview canvas is rendered with the correct dimensions.