### PR TITLE
fix: Correct props for PageEditor component

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -821,8 +821,8 @@ const PageGeneratorFrontendOnly = ({
 
       {console.log('[PageGeneratorFrontendOnly] rendering PageEditor with props:', { showGeneratedPageEditor, generatedPages, editingGeneratedPageIndex, csvHeaders, fieldPositions, fieldStyles, brandElements, colorPalette, originalImageSize, standardsColors, backgroundElement })}
       <PageEditor
-        showGeneratedPageEditor={showGeneratedPageEditor}
-        handleCloseGeneratedPageEditor={handleCloseGeneratedPageEditor}
+        open={showGeneratedPageEditor}
+        onClose={handleCloseGeneratedPageEditor}
         generatedPages={generatedPages}
         editingGeneratedPageIndex={editingGeneratedPageIndex}
         csvHeaders={csvHeaders}


### PR DESCRIPTION
This commit fixes a bug introduced during a diagnostic test where the Page Editor modal would not open.

The cause was a mismatch in prop names. The `PageEditor` component expects `open` and `onClose`, but after a previous change, it was being passed `showGeneratedPageEditor` and `handleCloseGeneratedPageEditor`.

This commit corrects the prop names, allowing the editor to open correctly. This unblocks the diagnostic test for the original aspect ratio bug.