### PR TITLE
fix(editor): Fix editor not opening due to incorrect props

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -804,10 +804,9 @@ const PageGeneratorFrontendOnly = ({
       <PageEditor
         open={showGeneratedPageEditor}
         onClose={handleCloseGeneratedPageEditor}
-        generatedPages={initialGeneratedPagesData}
-        editingGeneratedPageIndex={editingGeneratedPageIndex}
-        csvHeaders={csvHeaders}
-        fieldPositions={fieldPositions}
+        pageData={initialGeneratedPagesData.find(p => p.index === editingGeneratedPageIndex)}
+        globalCsvHeaders={csvHeaders}
+        initialFieldPositions={fieldPositions}
         fieldStyles={fieldStyles}
         brandElements={brandElements}
         handleSaveIndividualModifications={handleSaveIndividualModifications}


### PR DESCRIPTION
This commit fixes two critical bugs:
1. An infinite render loop in `PageGeneratorFrontendOnly.jsx` that caused the generated pages to 'blink'.
2. The page editor modal not opening when a thumbnail was clicked.

The infinite loop was caused by a state management anti-pattern where the component held a local copy of data that was also being passed as a prop, creating a feedback loop in the `useEffect` hooks. This was resolved by refactoring the component to only use the prop as the source of truth.

The editor failed to open because it was being passed the wrong data. It expected a single `pageData` object but was receiving the entire array of pages and an index. The call site in `PageGeneratorFrontendOnly.jsx` has been fixed to find the correct page object and pass it directly.

These two fixes together should resolve all outstanding issues with the page generation and editing flow.