### PR TITLE
fix(editor): Fix editor stuck on loading screen

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -807,7 +807,7 @@ const PageGeneratorFrontendOnly = ({
         pageData={initialGeneratedPagesData.find(p => p.index === editingGeneratedPageIndex)}
         globalCsvHeaders={csvHeaders}
         initialFieldPositions={fieldPositions}
-        fieldStyles={fieldStyles}
+        initialFieldStyles={fieldStyles}
         brandElements={brandElements}
         handleSaveIndividualModifications={handleSaveIndividualModifications}
         colorPalette={colorPalette}


### PR DESCRIPTION
This commit fixes a bug where the Page Editor would open but remain stuck on a 'Loading Editor...' message.

The cause was an incorrect prop name. The `PageEditor` component was expecting a prop named `initialFieldStyles`, but the parent component (`PageGeneratorFrontendOnly`) was passing it as `fieldStyles`. This caused a condition within the editor's `useEffect` hook to fail, preventing the editor from ever initializing.

This commit renames the prop to the correct `initialFieldStyles`, which allows the editor to initialize its state correctly and render. This should resolve all remaining issues with the page editing feature.