### PR TITLE
fix(editor): Load custom page styles when opening editor

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -540,6 +540,13 @@ const PageGeneratorFrontendOnly = ({
     }
   };
 
+  // Logic to determine props for the PageEditor
+  const pageToEdit = initialGeneratedPagesData.find(p => p.index === editingGeneratedPageIndex);
+  const editorPositions = pageToEdit?.customFieldPositions || fieldPositions;
+  const editorStyles = pageToEdit?.customFieldStyles || fieldStyles;
+  const editorBrandElements = pageToEdit?.customBrandElements !== undefined ? pageToEdit.customBrandElements : brandElements;
+  const editorBackgroundElement = pageToEdit?.customBackgroundElement || backgroundElement;
+
   return (
     <Box sx={{ mt: 3 }}>
       <Card>
@@ -804,16 +811,16 @@ const PageGeneratorFrontendOnly = ({
       <PageEditor
         open={showGeneratedPageEditor}
         onClose={handleCloseGeneratedPageEditor}
-        pageData={initialGeneratedPagesData.find(p => p.index === editingGeneratedPageIndex)}
+        pageData={pageToEdit}
         globalCsvHeaders={csvHeaders}
-        initialFieldPositions={fieldPositions}
-        initialFieldStyles={fieldStyles}
-        brandElements={brandElements}
+        initialFieldPositions={editorPositions}
+        initialFieldStyles={editorStyles}
+        brandElements={editorBrandElements}
         handleSaveIndividualModifications={handleSaveIndividualModifications}
         colorPalette={colorPalette}
         originalImageSize={originalImageSize}
         standardsColors={standardsColors}
-        backgroundElement={backgroundElement}
+        globalBackgroundElement={editorBackgroundElement}
         aspectRatio={aspectRatio}
       />
 


### PR DESCRIPTION
This commit fixes a critical architectural flaw where the page editor would always load the global campaign styles, discarding any previously saved individual page edits.

The logic in `PageGeneratorFrontendOnly.jsx` has been updated. When opening the editor for a specific page, it now checks if that page has its own `customFieldPositions` and `customFieldStyles`. If it does, those are passed to the editor. If not, it falls back to the global campaign settings.

This ensures that individual page customizations are correctly preserved and reloaded, matching the user's expected behavior.