### PR TITLE
feat: Add color highlight filter for background images

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+
+> midiator-google-drive-frontend@0.0.0 dev
+> vite

--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -16,6 +16,41 @@ const hexToRgba = (hex, alpha) => {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 };
 
+const hexToRgb = (hex) => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? { r: parseInt(result[1], 16), g: parseInt(result[2], 16), b: parseInt(result[3], 16) } : null;
+};
+
+const colorDistance = (rgb1, rgb2) => {
+  const dr = rgb1.r - rgb2.r;
+  const dg = rgb1.g - rgb2.g;
+  const db = rgb1.b - rgb2.b;
+  return dr * dr + dg * dg + db * db;
+};
+
+const applyColorHighlight = (ctx, width, height, highlightColorHex, highlightAmount) => {
+  if (!highlightColorHex || highlightAmount === 0) return;
+  const highlightRgb = hexToRgb(highlightColorHex);
+  if (!highlightRgb) return;
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  const maxDistSq = 3 * 255 * 255;
+  const toleranceSq = maxDistSq * (1 - (highlightAmount / 100));
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2];
+    const distSq = colorDistance({ r, g, b }, highlightRgb);
+    if (distSq > toleranceSq) {
+      const gray = 0.299 * r + 0.587 * g + 0.114 * b;
+      data[i] = gray;
+      data[i + 1] = gray;
+      data[i + 2] = gray;
+    }
+  }
+  ctx.putImageData(imageData, 0, 0);
+};
+
 const DraggableElementInternal = ({
   element, // Combined object for field/element data
   position,
@@ -49,6 +84,7 @@ const DraggableElementInternal = ({
   const textBoxRef = useRef(null);
   const textareaRef = useRef(null);
   const htmlContentRef = useRef(null);
+  const canvasRef = useRef(null);
 
   // Função para sanitizar HTML básico
   const sanitizeHtml = (html) => {
@@ -66,9 +102,73 @@ const DraggableElementInternal = ({
     return sanitized;
   };
 
+  const getFilterString = (filters) => {
+    if (!filters) return 'none';
+    const { brightness = 100, contrast = 100, saturate = 100, blur = 0, opacity = 100 } = filters;
+    return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturate}%) blur(${blur}px) opacity(${opacity}%)`;
+  };
+
+  useEffect(() => {
+    if (element.type === 'background' && canvasRef.current) {
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext('2d');
+      const img = new Image();
+      img.crossOrigin = 'Anonymous';
+
+      img.onload = () => {
+        canvas.width = img.width;
+        canvas.height = img.height;
+
+        const filters = style || {};
+        ctx.filter = getFilterString(filters);
+
+        ctx.drawImage(img, 0, 0);
+
+        // Reset filter before pixel manipulation
+        ctx.filter = 'none';
+
+        applyColorHighlight(
+          ctx,
+          canvas.width,
+          canvas.height,
+          filters.highlightColor,
+          filters.highlightAmount
+        );
+      };
+
+      img.onerror = () => {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = 'red';
+        ctx.textAlign = 'center';
+        ctx.font = '20px Arial';
+        ctx.fillText('Erro', canvas.width/2, canvas.height/2);
+      }
+
+      img.src = content;
+    }
+  }, [
+    content,
+    style?.brightness,
+    style?.contrast,
+    style?.saturate,
+    style?.blur,
+    style?.opacity,
+    style?.highlightColor,
+    style?.highlightAmount,
+    element.type
+  ]);
+
   // Função para renderizar conteúdo HTML ou texto simples
   const renderContent = () => {
-    if (element.type === 'image' || element.type === 'background') {
+    if (element.type === 'background') {
+      return (
+        <canvas
+          ref={canvasRef}
+          style={{ width: '100%', height: '100%', objectFit: 'fill' }}
+        />
+      );
+    }
+    if (element.type === 'image') {
       return (
         <img
           src={content}
@@ -76,7 +176,7 @@ const DraggableElementInternal = ({
           style={{
             width: '100%',
             height: '100%',
-            objectFit: element.type === 'background' ? 'fill' : 'cover',
+            objectFit: 'cover',
             pointerEvents: 'none',
           }}
         />
@@ -548,12 +648,6 @@ const DraggableElementInternal = ({
 
   const handleSize = isMobile ? 24 : 12;
 
-  const getFilterString = (filters) => {
-    if (!filters) return 'none';
-    const { brightness = 100, contrast = 100, saturate = 100, blur = 0, opacity = 100 } = filters;
-    return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturate}%) blur(${blur}px) opacity(${opacity}%)`;
-  };
-
   const getBoxShadowString = (style) => {
     if (!style || !style.shadow) return 'none';
     const { shadowColor = '#000000', shadowBlur = 4, shadowOffsetX = 2, shadowOffsetY = 2 } = style;
@@ -602,7 +696,7 @@ const DraggableElementInternal = ({
             : `${(style.borderWidth || 0) * fontScale}px solid ${style.borderColor || '#000000'}`,
           borderRadius: `${(style.borderRadius || 0) * fontScale}px`,
           padding: element.type === 'image' || element.type === 'background' || element.type === 'cropbox' ? 0 : `${(style.padding || 0) * fontScale}px`,
-          filter: (element.type === 'image' || element.type === 'background') ? getFilterString(style) : 'none',
+          filter: (element.type === 'image') ? getFilterString(style) : 'none',
           boxShadow: (element.type === 'image' || element.type === 'background') ? getBoxShadowString(style) : 'none',
         }}
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -616,7 +616,7 @@ const FormattingPanel = ({
 
             {/* Background Specific Controls */}
             {selectedField === '__background__' && currentElement && (() => {
-              const filters = currentElement.filters || { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 };
+              const filters = currentElement.filters || { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100, highlightColor: '#FFFFFF', highlightAmount: 0 };
               return (
                 <>
                   {/* Filtros do Fundo */}
@@ -635,6 +635,36 @@ const FormattingPanel = ({
                       <Slider value={filters.blur} onChange={(e, v) => updateBackgroundFilter('blur', v)} min={0} max={20} step={1} />
                       <Typography gutterBottom>Opacidade: {filters.opacity}%</Typography>
                       <Slider value={filters.opacity} onChange={(e, v) => updateBackgroundFilter('opacity', v)} min={0} max={100} step={1} />
+                    </AccordionDetails>
+                  </Accordion>
+
+                  {/* Destaque de Cor */}
+                  <Accordion expanded={expandedPanel === 'backgroundHighlight'} onChange={handleAccordionChange('backgroundHighlight')}>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                      <Typography variant="subtitle1">🎨 Destaque de Cor</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <Grid container spacing={2} alignItems="center">
+                        <Grid item xs={4}>
+                          <Typography gutterBottom>Cor</Typography>
+                          <TextField
+                            type="color"
+                            value={filters.highlightColor || '#FFFFFF'}
+                            onChange={(e) => updateBackgroundFilter('highlightColor', e.target.value)}
+                            fullWidth
+                          />
+                        </Grid>
+                        <Grid item xs={8}>
+                          <Typography gutterBottom>Intensidade: {filters.highlightAmount || 0}%</Typography>
+                          <Slider
+                            value={filters.highlightAmount || 0}
+                            onChange={(e, v) => updateBackgroundFilter('highlightAmount', v)}
+                            min={0}
+                            max={100}
+                            step={1}
+                          />
+                        </Grid>
+                      </Grid>
                     </AccordionDetails>
                   </Accordion>
 

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -1,6 +1,73 @@
 import { containsHtml, renderHtmlToCanvas } from './htmlRenderer';
 import { isHtmlField } from '../lib/utils';
 
+// --- Color Highlight Filter ---
+
+// Helper to parse hex color string to an RGB object
+const hexToRgb = (hex) => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? {
+    r: parseInt(result[1], 16),
+    g: parseInt(result[2], 16),
+    b: parseInt(result[3], 16)
+  } : null;
+};
+
+// Helper to calculate the distance between two colors in the RGB space
+const colorDistance = (rgb1, rgb2) => {
+  const dr = rgb1.r - rgb2.r;
+  const dg = rgb1.g - rgb2.g;
+  const db = rgb1.b - rgb2.b;
+  // Using the squared distance to avoid a square root, for performance.
+  return dr * dr + dg * dg + db * db;
+};
+
+/**
+ * Applies a color highlight effect to a canvas context.
+ * Pixels that are not within the tolerance of the highlight color are desaturated.
+ * @param {CanvasRenderingContext2D} ctx - The canvas context to modify.
+ * @param {number} width - The width of the canvas area to process.
+ * @param {number} height - The height of the canvas area to process.
+ * @param {string} highlightColorHex - The hex string of the color to highlight.
+ * @param {number} highlightAmount - The intensity of the effect (0-100).
+ */
+const applyColorHighlight = (ctx, width, height, highlightColorHex, highlightAmount) => {
+  if (highlightAmount === 0) return;
+
+  const highlightRgb = hexToRgb(highlightColorHex);
+  if (!highlightRgb) return;
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+
+  // The tolerance is inversely related to the highlightAmount.
+  // A higher amount means a smaller tolerance, thus highlighting a more specific color range.
+  // The max distance in RGB space is sqrt(3 * 255^2) ~= 441. We use squared distance.
+  const maxDistSq = 3 * 255 * 255;
+  const toleranceSq = maxDistSq * (1 - (highlightAmount / 100));
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const g = data[i + 1];
+    const b = data[i + 2];
+
+    const pixelRgb = { r, g, b };
+    const distSq = colorDistance(pixelRgb, highlightRgb);
+
+    if (distSq > toleranceSq) {
+      // Not the highlight color, so convert to grayscale.
+      const gray = 0.299 * r + 0.587 * g + 0.114 * b;
+      data[i] = gray;
+      data[i + 1] = gray;
+      data[i + 2] = gray;
+    }
+    // If it is the highlight color, we leave it as is.
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+};
+
+
 // Helper functions moved from PageGeneratorFrontendOnly.jsx and adapted for utility use
 
 export const dataURLtoBlob = (dataurl) => {
@@ -213,6 +280,15 @@ export const composeSingleImage = async ({
               ctx.drawImage(bgImg, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
             } else {
               ctx.drawImage(bgImg, dx, dy, dWidth, dHeight);
+            }
+
+            // The main filters have been applied by ctx.filter. Now, apply the custom highlight filter.
+            // We must do this before restoring the context if we want it to be contained within the rotated/scaled element.
+            // However, it's easier to apply to the whole canvas and let the drawImage contain it.
+            // So we apply it AFTER the drawing, but before restoring the main context.
+            ctx.filter = 'none'; // Reset standard filters before pixel manipulation
+            if (filters.highlightAmount && filters.highlightAmount > 0) {
+              applyColorHighlight(ctx, canvasWidth, canvasHeight, filters.highlightColor, filters.highlightAmount);
             }
 
             ctx.restore();


### PR DESCRIPTION
This feature adds a new 'Color Highlight' filter to the background image formatting panel.

- Adds a color picker and an intensity slider to the UI in `FormattingPanel.jsx`.
- Implements the filter logic using canvas pixel manipulation in `imageComposer.js` for the final image generation.
- The `DraggableElement.jsx` component has been refactored to use a canvas for the background image preview, ensuring that the preview accurately reflects the final output.
- The filter desaturates colors that are not within a tolerance range of the selected highlight color. The intensity slider controls this tolerance.