### PR TITLE
feat: Add background color and gradient editor

### DIFF
--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -11,7 +11,7 @@ import {
   ToggleButtonGroup,
   Tooltip,
 } from '@mui/material';
-import { Add, Delete, RadialGradient, LinearGradient } from '@mui/icons-material';
+import { Add, Delete, Gradient } from '@mui/icons-material';
 
 const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
   if (!backgroundElement) return null;
@@ -98,10 +98,10 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
                     }}
                 >
                     <Tooltip title="Gradiente Linear">
-                        <ToggleButton value="linear"><LinearGradient /></ToggleButton>
+                        <ToggleButton value="linear"><Gradient /></ToggleButton>
                     </Tooltip>
                     <Tooltip title="Gradiente Radial">
-                        <ToggleButton value="radial"><RadialGradient /></ToggleButton>
+                        <ToggleButton value="radial"><Gradient /></ToggleButton>
                     </Tooltip>
                 </ToggleButtonGroup>
             </Grid>

--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Grid,
+  TextField,
+  Slider,
+  Button,
+  IconButton,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+} from '@mui/material';
+import { Add, Delete, RadialGradient, LinearGradient } from '@mui/icons-material';
+
+const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
+  if (!backgroundElement) return null;
+
+  const handleUpdate = (property, value) => {
+    onUpdate({ ...backgroundElement, [property]: value });
+  };
+
+  const handleGradientUpdate = (property, value) => {
+    onUpdate({
+      ...backgroundElement,
+      gradient: { ...backgroundElement.gradient, [property]: value },
+    });
+  };
+
+  const handleStopUpdate = (index, property, value) => {
+    const newStops = [...backgroundElement.gradient.stops];
+    newStops[index] = { ...newStops[index], [property]: value };
+    handleGradientUpdate('stops', newStops);
+  };
+
+  const addStop = () => {
+    const newStops = [
+      ...backgroundElement.gradient.stops,
+      { color: '#ffffff', position: 100 },
+    ];
+    handleGradientUpdate('stops', newStops);
+  };
+
+  const removeStop = (index) => {
+    const newStops = backgroundElement.gradient.stops.filter((_, i) => i !== index);
+    handleGradientUpdate('stops', newStops);
+  };
+
+  return (
+    <Box>
+      <Typography variant="caption" display="block" gutterBottom>
+        Tipo de Fundo
+      </Typography>
+      <ToggleButtonGroup
+        value={backgroundElement.backgroundType || 'image'}
+        exclusive
+        fullWidth
+        size="small"
+        onChange={(e, newType) => {
+          if (newType) handleUpdate('backgroundType', newType);
+        }}
+        aria-label="background type"
+      >
+        <ToggleButton value="image" aria-label="image background">
+          Imagem
+        </ToggleButton>
+        <ToggleButton value="color" aria-label="solid color background">
+          Cor Sólida
+        </ToggleButton>
+        <ToggleButton value="gradient" aria-label="gradient background">
+          Gradiente
+        </ToggleButton>
+      </ToggleButtonGroup>
+
+      {backgroundElement.backgroundType === 'color' && (
+        <Box sx={{ mt: 2 }}>
+          <Typography gutterBottom>Cor de Fundo</Typography>
+          <TextField
+            type="color"
+            value={backgroundElement.backgroundColor || '#ffffff'}
+            onChange={(e) => handleUpdate('backgroundColor', e.target.value)}
+            fullWidth
+          />
+        </Box>
+      )}
+
+      {backgroundElement.backgroundType === 'gradient' && (
+        <Box sx={{ mt: 2 }}>
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+                <ToggleButtonGroup
+                    value={backgroundElement.gradient?.type || 'linear'}
+                    exclusive
+                    fullWidth
+                    size="small"
+                    onChange={(e, newType) => {
+                        if (newType) handleGradientUpdate('type', newType);
+                    }}
+                >
+                    <Tooltip title="Gradiente Linear">
+                        <ToggleButton value="linear"><LinearGradient /></ToggleButton>
+                    </Tooltip>
+                    <Tooltip title="Gradiente Radial">
+                        <ToggleButton value="radial"><RadialGradient /></ToggleButton>
+                    </Tooltip>
+                </ToggleButtonGroup>
+            </Grid>
+
+            {backgroundElement.gradient?.type === 'linear' && (
+              <Grid item xs={12}>
+                <Typography gutterBottom>Ângulo do Gradiente</Typography>
+                <Slider
+                  value={backgroundElement.gradient.angle || 0}
+                  onChange={(e, value) => handleGradientUpdate('angle', value)}
+                  min={0}
+                  max={360}
+                  step={1}
+                  valueLabelDisplay="auto"
+                />
+              </Grid>
+            )}
+
+            <Grid item xs={12}>
+              <Typography gutterBottom>Cores do Gradiente</Typography>
+              {backgroundElement.gradient.stops.map((stop, index) => (
+                <Grid container spacing={1} key={index} alignItems="center" sx={{ mb: 1 }}>
+                  <Grid item xs={3}>
+                    <TextField
+                      type="color"
+                      value={stop.color}
+                      onChange={(e) => handleStopUpdate(index, 'color', e.target.value)}
+                      fullWidth
+                      size="small"
+                    />
+                  </Grid>
+                  <Grid item xs={7}>
+                    <Slider
+                      value={stop.position}
+                      onChange={(e, value) => handleStopUpdate(index, 'position', value)}
+                      min={0}
+                      max={100}
+                      step={1}
+                      size="small"
+                    />
+                  </Grid>
+                  <Grid item xs={2}>
+                    <IconButton onClick={() => removeStop(index)} size="small" disabled={backgroundElement.gradient.stops.length <= 2}>
+                      <Delete />
+                    </IconButton>
+                  </Grid>
+                </Grid>
+              ))}
+              <Button startIcon={<Add />} onClick={addStop} size="small" variant="outlined" fullWidth>
+                Adicionar Cor
+              </Button>
+            </Grid>
+          </Grid>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default BackgroundColorEditor;

--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -46,12 +46,12 @@ const DraggableElementInternal = ({
   const [initialPosition, setInitialPosition] = useState({ x: 0, y: 0 });
   const [initialSize, setInitialSize] = useState({ width: 0, height: 0 });
   const [initialRotation, setInitialRotation] = useState(0);
-  const [isCanvasLoading, setIsCanvasLoading] = useState(true);
+  // const [isCanvasLoading, setIsCanvasLoading] = useState(true); // Removido
 
   const textBoxRef = useRef(null);
   const textareaRef = useRef(null);
   const htmlContentRef = useRef(null);
-  const canvasRef = useRef(null);
+  // const canvasRef = useRef(null); // Removido
 
   // Função para sanitizar HTML básico
   const sanitizeHtml = (html) => {
@@ -75,72 +75,13 @@ const DraggableElementInternal = ({
     return `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturate}%) blur(${blur}px) opacity(${opacity}%)`;
   };
 
-  useEffect(() => {
-    if (element.type === 'background' && canvasRef.current) {
-      setIsCanvasLoading(true);
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      const img = new Image();
-      img.crossOrigin = 'Anonymous';
-
-      img.onload = () => {
-        canvas.width = img.naturalWidth || img.width;
-        canvas.height = img.naturalHeight || img.height;
-        const filters = style || {};
-        ctx.filter = getFilterString(filters);
-        ctx.drawImage(img, 0, 0);
-        ctx.filter = 'none';
-        applyColorHighlight(
-          ctx,
-          canvas.width,
-          canvas.height,
-          filters.highlightColor,
-          filters.highlightAmount
-        );
-        setIsCanvasLoading(false);
-      };
-
-      img.onerror = () => {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        setIsCanvasLoading(false);
-      }
-
-      img.src = content;
-    }
-  }, [
-    content,
-    style?.brightness,
-    style?.contrast,
-    style?.saturate,
-    style?.blur,
-    style?.opacity,
-    style?.highlightColor,
-    style?.highlightAmount,
-    element.type
-  ]);
+  // useEffect para renderização do canvas foi REMOVIDO
 
   // Função para renderizar conteúdo HTML ou texto simples
   const renderContent = () => {
+    // A lógica de renderização do fundo foi movida para o estilo do Box principal.
     if (element.type === 'background') {
-      return (
-        <>
-          {isCanvasLoading && (
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
-              <CircularProgress size={24} />
-            </Box>
-          )}
-          <canvas
-            ref={canvasRef}
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'fill',
-              pointerEvents: 'none',
-              display: isCanvasLoading ? 'none' : 'block',
-            }}
-          />
-        </>
-      );
+      return null;
     }
     if (element.type === 'image') {
       return (
@@ -650,29 +591,76 @@ const DraggableElementInternal = ({
     handleTouchStart(e, type, handle);
   };
 
+  const getBackgroundStyle = (style, content) => {
+    const { backgroundType, backgroundColor, gradient, src } = style;
+    const imageUrl = content || src;
+    const css = {
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+    };
+
+    switch (backgroundType) {
+        case 'color':
+            css.backgroundColor = backgroundColor;
+            css.backgroundImage = 'none';
+            break;
+        case 'gradient':
+            if (gradient && gradient.stops) {
+                const stops = gradient.stops.map(s => `${s.color} ${s.position}%`).join(', ');
+                if (gradient.type === 'linear') {
+                    css.backgroundImage = `linear-gradient(${gradient.angle || 90}deg, ${stops})`;
+                } else {
+                    css.backgroundImage = `radial-gradient(circle, ${stops})`;
+                }
+            } else {
+                 css.backgroundImage = 'none';
+            }
+            break;
+        case 'image':
+        default:
+            if (imageUrl) {
+                css.backgroundImage = `url("${imageUrl}")`;
+            } else {
+                css.backgroundImage = 'none';
+            }
+            // A cor de fundo pode ser usada como um "tint" ou fallback
+            css.backgroundColor = style.backgroundColor || 'transparent';
+            break;
+    }
+    return css;
+  };
+
+  const boxSx = {
+    left: `${position.x}%`,
+    top: `${position.y}%`,
+    width: `${position.width}%`,
+    height: `${position.height}%`,
+    transform: `rotate(${rotation || 0}deg)`,
+    zIndex: position.zIndex || 'auto',
+    filter: (element.type === 'image' || element.type === 'background') ? getFilterString(style) : 'none',
+    boxShadow: (element.type === 'image' || element.type === 'background') ? getBoxShadowString(style) : 'none',
+  };
+
+  if (element.type === 'background') {
+    Object.assign(boxSx, getBackgroundStyle(style, content));
+  } else if (element.type === 'image' || element.type === 'cropbox') {
+    boxSx.backgroundColor = 'transparent';
+    boxSx.border = 'none';
+    boxSx.padding = 0;
+  } else { // Text element
+    boxSx.backgroundColor = hexToRgba(style.backgroundColor || '#000000', style.backgroundOpacity !== undefined ? style.backgroundOpacity : 1);
+    boxSx.border = `${(style.borderWidth || 0) * fontScale}px solid ${style.borderColor || '#000000'}`;
+    boxSx.borderRadius = `${(style.borderRadius || 0) * fontScale}px`;
+    boxSx.padding = `${(style.padding || 0) * fontScale}px`;
+  }
+
   return (
     <>
       <Box
         ref={textBoxRef}
         className={`${styles.textBox} ${isDragging ? styles.dragging : ''} ${isSelected && element.type !== 'background' ? styles.selected : ''}`}
-        sx={{
-          left: `${position.x}%`,
-          top: `${position.y}%`,
-          width: `${position.width}%`,
-          height: `${position.height}%`,
-          transform: `rotate(${rotation || 0}deg)`,
-          zIndex: position.zIndex || 'auto',
-          backgroundColor: element.type === 'image' || element.type === 'background' || element.type === 'cropbox'
-            ? 'transparent'
-            : hexToRgba(style.backgroundColor || '#000000', style.backgroundOpacity !== undefined ? style.backgroundOpacity : 1),
-          border: element.type === 'image' || element.type === 'background' || element.type === 'cropbox'
-            ? 'none'
-            : `${(style.borderWidth || 0) * fontScale}px solid ${style.borderColor || '#000000'}`,
-          borderRadius: `${(style.borderRadius || 0) * fontScale}px`,
-          padding: element.type === 'image' || element.type === 'background' || element.type === 'cropbox' ? 0 : `${(style.padding || 0) * fontScale}px`,
-          filter: (element.type === 'image') ? getFilterString(style) : 'none',
-          boxShadow: (element.type === 'image' || element.type === 'background') ? getBoxShadowString(style) : 'none',
-        }}
+        sx={boxSx}
         onMouseDown={(e) => effectiveHandleMouseDown(e, 'drag')}
         onTouchStart={(e) => effectiveHandleTouchStart(e, 'drag')}
         onClick={() => onSelect(element.id)}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -51,6 +51,7 @@ import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 
 import { BrandingWatermark, Edit } from '@mui/icons-material';
 import BrandElementManager from './BrandElementManager';
+import BackgroundColorEditor from './BackgroundColorEditor'; // Importar o novo componente
 
 // Helper function to convert an RGB color string to a hex string.
 const rgbStringToHex = (colorString) => {
@@ -619,6 +620,19 @@ const FormattingPanel = ({
               const filters = currentElement.filters || { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100, highlightColor: '#FFFFFF', highlightAmount: 0 };
               return (
                 <>
+                  {/* Cor de Fundo e Gradiente */}
+                  <Accordion expanded={expandedPanel === 'backgroundColor'} onChange={handleAccordionChange('backgroundColor')}>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                      <Typography variant="subtitle1">🎨 Cor de Fundo</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <BackgroundColorEditor
+                        backgroundElement={currentElement}
+                        onUpdate={setBackgroundElement}
+                      />
+                    </AccordionDetails>
+                  </Accordion>
+
                   {/* Filtros do Fundo */}
                   <Accordion expanded={expandedPanel === 'backgroundFilters'} onChange={handleAccordionChange('backgroundFilters')}>
                     <AccordionSummary expandIcon={<ExpandMore />}>
@@ -638,35 +652,7 @@ const FormattingPanel = ({
                     </AccordionDetails>
                   </Accordion>
 
-                  {/* Destaque de Cor */}
-                  <Accordion expanded={expandedPanel === 'backgroundHighlight'} onChange={handleAccordionChange('backgroundHighlight')}>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="subtitle1">🎨 Destaque de Cor</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Grid container spacing={2} alignItems="center">
-                        <Grid item xs={4}>
-                          <Typography gutterBottom>Cor</Typography>
-                          <TextField
-                            type="color"
-                            value={filters.highlightColor || '#FFFFFF'}
-                            onChange={(e) => updateBackgroundFilter('highlightColor', e.target.value)}
-                            fullWidth
-                          />
-                        </Grid>
-                        <Grid item xs={8}>
-                          <Typography gutterBottom>Intensidade: {filters.highlightAmount || 0}%</Typography>
-                          <Slider
-                            value={filters.highlightAmount || 0}
-                            onChange={(e, v) => updateBackgroundFilter('highlightAmount', v)}
-                            min={0}
-                            max={100}
-                            step={1}
-                          />
-                        </Grid>
-                      </Grid>
-                    </AccordionDetails>
-                  </Accordion>
+                  {/* Destaque de Cor (REMOVED) - This was a canvas-only feature */}
 
                   {/* Sombra do Fundo */}
                 <Accordion expanded={expandedPanel === 'backgroundShadow'} onChange={handleAccordionChange('backgroundShadow')}>

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -81,6 +81,35 @@ const PageEditor = ({
   const defaultFilters = { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 };
   const [editedBackgroundElement, setEditedBackgroundElement] = useState(null);
 
+  // Definir um objeto de fundo padrão mais abrangente
+  const defaultBackground = {
+    id: 'background',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    rotation: 0,
+    visible: true,
+    filters: defaultFilters,
+    crop: null,
+    shadow: false,
+    shadowColor: '#000000',
+    shadowBlur: 10,
+    shadowOffsetX: 0,
+    shadowOffsetY: 5,
+    // Novas propriedades para cor de fundo e gradiente
+    backgroundType: 'image', // 'image', 'color', 'gradient'
+    backgroundColor: 'rgba(255, 255, 255, 0)', // Cor sólida de fundo
+    gradient: {
+      type: 'linear', // 'linear' ou 'radial'
+      angle: 90,
+      stops: [
+        { color: 'rgba(255, 255, 255, 0)', position: 0 },
+        { color: 'rgba(0, 0, 0, 0)', position: 100 },
+      ],
+    },
+  };
+
   const handleInternalFieldSelection = useCallback((fieldToSelect) => {
     setSelectedFieldInternal(fieldToSelect);
   }, []); // setSelectedFieldInternal is stable
@@ -156,17 +185,26 @@ const PageEditor = ({
       setEditedStyles(newEditedStyles);
       setStylesAreInitialized(true);
 
-      const backgroundToUse = pageData.customBackgroundElement || globalBackgroundElement || {
-        id: 'background',
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 100,
-        rotation: 0,
-        visible: true,
-        filters: defaultFilters,
-        crop: null,
+      // Lógica de merge aprimorada para o elemento de fundo
+      const backgroundToUse = {
+        ...defaultBackground,
+        ...(globalBackgroundElement || {}),
+        ...(pageData.customBackgroundElement || {}),
+        // Garante que os objetos aninhados (filters, gradient) sejam mesclados corretamente
+        filters: {
+          ...defaultBackground.filters,
+          ...(globalBackgroundElement?.filters || {}),
+          ...(pageData.customBackgroundElement?.filters || {}),
+        },
+        gradient: {
+          ...defaultBackground.gradient,
+          ...(globalBackgroundElement?.gradient || {}),
+          ...(pageData.customBackgroundElement?.gradient || {}),
+          // Garante uma cópia profunda do array de stops para evitar mutações indesejadas
+          stops: (pageData.customBackgroundElement?.gradient?.stops || globalBackgroundElement?.gradient?.stops || defaultBackground.gradient.stops).map(stop => ({ ...stop })),
+        }
       };
+
       setEditedBackgroundElement(backgroundToUse);
       setFontScale(pageData.fontScale || 1); // Initialize font scale from pageData
     } else {


### PR DESCRIPTION
This commit introduces a new feature allowing users to set the background of a page to a solid color or a gradient in the page editor.

Key changes:
- Adds a new `BackgroundColorEditor` component with UI controls for selecting and configuring the background type (image, color, or gradient).
- Integrates this editor into the `FormattingPanel` within a new "Cor de Fundo" accordion.
- Refactors the background rendering in `DraggableElement` from a `<canvas>` element to a more flexible and appropriate CSS-based `div`. This allows for the application of standard CSS `background` properties.
- Extends the `backgroundElement` state in `PageEditor` to store the new background properties.
- Removes the canvas-only "Color Highlight" feature, which was incompatible with the new CSS rendering approach.