### PR TITLE
fix: Allow field editing on blank canvas

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -396,26 +396,6 @@ const FieldPositioner = ({
     return elements;
   }, [backgroundElement, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
-  if (!backgroundElement?.src) {
-    return (
-      <Box
-        sx={{
-          height: 400,
-          border: '2px dashed #ccc',
-          borderRadius: 2,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: '#f5f5f5'
-        }}
-      >
-        <Typography color="textSecondary" variant="h6">
-          Carregue uma imagem de fundo para posicionar os campos
-        </Typography>
-      </Box>
-    );
-  }
-
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} lg={9}>


### PR DESCRIPTION
This commit removes a check in `FieldPositioner.jsx` that was preventing users from interacting with fields when no background image was present.

Although the canvas was correctly displayed, an overlay was blocking the selection and movement of text and brand elements. This change removes the overlay, completing the "blank canvas" workflow.