### PR TITLE
refactor!: Separate background color and image layers

### DIFF
--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -14,6 +14,9 @@ import {
 import { Add, Delete, Gradient } from '@mui/icons-material';
 
 const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
+  // Internal state to switch between solid and gradient editors
+  const [colorMode, setColorMode] = React.useState('solid');
+
   if (!backgroundElement) return null;
 
   const handleUpdate = (property, value) => {
@@ -50,41 +53,19 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
   return (
     <Box>
       <Typography variant="caption" display="block" gutterBottom>
-        Tipo de Fundo
+        Cor de Fundo
       </Typography>
       <ToggleButtonGroup
-        value={backgroundElement.backgroundType || 'image'}
+        value={colorMode}
         exclusive
         fullWidth
         size="small"
-        onChange={(e, newType) => {
-          if (!newType) return;
-
-          const updatedState = { ...backgroundElement, backgroundType: newType };
-
-          if (newType === 'gradient' && !updatedState.gradient) {
-            updatedState.gradient = {
-              type: 'linear',
-              angle: 90,
-              stops: [
-                { color: '#ffffff', position: 0 },
-                { color: '#000000', position: 100 },
-              ],
-            };
-          }
-
-          if (newType === 'color' && !updatedState.backgroundColor) {
-            updatedState.backgroundColor = '#ffffff';
-          }
-
-          onUpdate(updatedState);
+        onChange={(e, newMode) => {
+          if (newMode) setColorMode(newMode);
         }}
-        aria-label="background type"
+        aria-label="color mode"
       >
-        <ToggleButton value="image" aria-label="image background">
-          Imagem
-        </ToggleButton>
-        <ToggleButton value="color" aria-label="solid color background">
+        <ToggleButton value="solid" aria-label="solid color background">
           Cor Sólida
         </ToggleButton>
         <ToggleButton value="gradient" aria-label="gradient background">
@@ -92,9 +73,9 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
         </ToggleButton>
       </ToggleButtonGroup>
 
-      {backgroundElement.backgroundType === 'color' && (
+      {colorMode === 'solid' && (
         <Box sx={{ mt: 2 }}>
-          <Typography gutterBottom>Cor de Fundo</Typography>
+          <Typography gutterBottom>Cor</Typography>
           <TextField
             type="color"
             value={backgroundElement.backgroundColor || '#ffffff'}
@@ -104,7 +85,7 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate }) => {
         </Box>
       )}
 
-      {backgroundElement.backgroundType === 'gradient' && (
+      {colorMode === 'gradient' && (
         <Box sx={{ mt: 2 }}>
           <Grid container spacing={2}>
             <Grid item xs={12}>

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -284,6 +284,35 @@ const FieldPositioner = ({
 
   const aspectRatio = aspectRatioProp ? String(aspectRatioProp).replace(':', ' / ') : '16 / 9';
 
+  const getBackgroundStyle = (bgElement) => {
+    if (!bgElement) return { backgroundColor: '#FFFFFF' }; // Default white background
+
+    const style = {
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      top: 0,
+      left: 0,
+      zIndex: -2, // Ensure it's the bottom-most layer
+    };
+
+    if (bgElement.gradient) {
+      const stops = bgElement.gradient.stops.map(s => `${s.color} ${s.position}%`).join(', ');
+      if (bgElement.gradient.type === 'radial') {
+        style.backgroundImage = `radial-gradient(circle, ${stops})`;
+      } else {
+        style.backgroundImage = `linear-gradient(${bgElement.gradient.angle || 0}deg, ${stops})`;
+      }
+    } else if (bgElement.backgroundColor) {
+      style.backgroundColor = bgElement.backgroundColor;
+    } else {
+      style.backgroundColor = '#FFFFFF'; // Fallback
+    }
+
+    return style;
+  };
+
+
   // Effect to calculate font scale based on the actual rendered image size
   useEffect(() => {
     if (renderedImageMetrics.width > 0 && effectiveImageSize?.width > 0) {
@@ -329,14 +358,15 @@ const FieldPositioner = ({
 
   const renderableElements = React.useMemo(() => {
     const elements = [
-      // Add background element first so it's at the bottom
-      ...(backgroundElement ? [{
+      // Background IMAGE is now a separate element, rendered only if src exists.
+      // The color/gradient layer is handled separately.
+      ...(backgroundElement?.src ? [{
         id: '__background__',
         type: 'background',
         position: backgroundElement,
-        style: { ...backgroundElement.filters, ...backgroundElement },
+        style: { ...backgroundElement.filters }, // Only filters apply to the image
         content: backgroundElement.src,
-        zIndex: -1, // Ensure it's always at the back
+        zIndex: -1, // Above color layer, behind content
         rotation: backgroundElement.rotation,
         fontScale: 1,
         enableHtmlRendering: false,
@@ -482,6 +512,10 @@ const FieldPositioner = ({
                       }
                     }}
                   >
+                    {/* Layer 1: Solid Color or Gradient Background */}
+                    <Box sx={getBackgroundStyle(backgroundElement)} />
+
+                    {/* Layer 2: Draggable Elements (including BG image) */}
                     {renderedImageMetrics.width > 0 && renderableElements.map(element => (
                       <DraggableElement
                         key={element.id}


### PR DESCRIPTION
This commit implements a major refactoring of the background system to correctly separate the color/gradient layer from the image layer, per user feedback. The previous implementation treated them as mutually exclusive alternatives.

Key Changes:

- **`BackgroundColorEditor.jsx` Refactored:**
  - The exclusive "Tipo de Fundo" (Background Type) selector has been removed.
  - Users can now edit properties for both solid color and gradients at all times. The UI now uses a local toggle to switch between the color and gradient editors without affecting the data model in an exclusive way.

- **`FieldPositioner.jsx` Rendering Logic Updated:**
  - The background is now rendered in two distinct layers:
    1. A base `div` is rendered with the solid `backgroundColor` or `gradient` style.
    2. The background image (`backgroundElement.src`), if it exists, is rendered as a separate element on top of the color layer.
  - This allows for combinations, such as a semi-transparent PNG image over a gradient background.

- **Data Model Simplification:**
  - The `backgroundType` property on the `backgroundElement` state object has been removed, as the color and image layers are no longer mutually exclusive.

This change completes the user's vision for a flexible, layered background system.