### PR TITLE
fix: Correctly render page background color

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -467,7 +467,7 @@ const FieldPositioner = ({
                 border: '2px solid #ddd',
                 borderRadius: 2,
                 overflow: 'hidden',
-                backgroundColor: '#fff',
+                ...getBackgroundStyle(backgroundElement), // Apply dynamic background here
                 cursor: 'default',
                 touchAction: 'pan-x pan-y',
                 WebkitOverflowScrolling: 'touch',
@@ -512,10 +512,7 @@ const FieldPositioner = ({
                       }
                     }}
                   >
-                    {/* Layer 1: Solid Color or Gradient Background */}
-                    <Box sx={getBackgroundStyle(backgroundElement)} />
-
-                    {/* Layer 2: Draggable Elements (including BG image) */}
+                    {/* All elements, including the background image, are rendered here */}
                     {renderedImageMetrics.width > 0 && renderableElements.map(element => (
                       <DraggableElement
                         key={element.id}


### PR DESCRIPTION
This commit fixes a bug where the page background color was not being displayed after being selected in the UI.

The issue was caused by a hardcoded `backgroundColor: '#fff'` on the main canvas container, which was obscuring the dynamically generated background color/gradient layer.

The fix involves:
- Removing the hardcoded white background.
- Applying the dynamic background styles (solid color or gradient) directly to the main canvas container in `FieldPositioner.jsx`.
- Removing the now-redundant inner `div` that was previously used for the background layer.