### PR TITLE
fix: Rework layout, image sizing, and editor UX

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -427,41 +427,38 @@ const FieldPositioner = ({
   }, [backgroundElement, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
   return (
-    <Grid container spacing={3}>
-      <Grid item xs={12} lg={9}>
-        <Card>
-          <CardContent>
-            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2 }} justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-              <Typography variant="h6">
-                Editor de Campos
-              </Typography>
-              <Stack direction="row" spacing={1}>
-                <Button
-                  size="small"
-                  onClick={centerAllFields}
-                  startIcon={<CenterFocusStrong />}
-                >
-                  Centralizar
-                </Button>
-                <Button
-                  size="small"
-                  onClick={autoArrangeFields}
-                  startIcon={<Add />}
-                >
-                  Auto Organizar
-                </Button>
-              </Stack>
-            </Stack>
+    <Box>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2 }} justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h6">
+          Editor de Campos
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            size="small"
+            onClick={centerAllFields}
+            startIcon={<CenterFocusStrong />}
+          >
+            Centralizar
+          </Button>
+          <Button
+            size="small"
+            onClick={autoArrangeFields}
+            startIcon={<Add />}
+          >
+            Auto Organizar
+          </Button>
+        </Stack>
+      </Stack>
 
-            {csvData.length === 0 && (
-              <Alert severity="info" sx={{ mb: 2 }}>
-                Carregue um arquivo CSV para ver o preview dos dados
-              </Alert>
-            )}
+      {csvData.length === 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Carregue um arquivo CSV para ver o preview dos dados
+        </Alert>
+      )}
 
-            <Box
-              ref={containerRef}
-              className="text-container"
+      <Box
+        ref={containerRef}
+        className="text-container"
               sx={{
                 position: 'relative',
                 border: '2px solid #ddd',
@@ -574,10 +571,9 @@ const FieldPositioner = ({
                 ))}
               </Box>
             )}
-          </CardContent>
-        </Card>
-      </Grid>
-    </Grid>
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -142,7 +142,12 @@ const ImageStep = ({
           </Grid>
         ) : (
           <>
-            <Fab color="primary" aria-label="edit" sx={{ position: 'fixed', bottom: 16, right: 16 }} onClick={() => setIsDrawerOpen(true)}><EditIcon /></Fab>
+            <Fab color="primary" aria-label="edit" sx={{ position: 'fixed', bottom: 16, right: 16 }} onClick={() => {
+              if (!selectedField) {
+                setSelectedField('__background__');
+              }
+              setIsDrawerOpen(true);
+            }}><EditIcon /></Fab>
             <FormattingDrawer
               open={isDrawerOpen}
               onClose={() => setIsDrawerOpen(false)}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -696,17 +696,38 @@ function HomePage() {
   const handleBackgroundImageUpload = async (file) => {
     if (!file) return;
 
-    // --- ROBUST FIX using FileReader and data:URL ---
-    // This converts the file to a self-contained data URL immediately.
-    // This URL does not expire and does not need to be revoked, fixing the
-    // "disappearing image" bug when thumbnails are generated later.
     const reader = new FileReader();
     reader.onload = (e) => {
       const dataUrl = e.target.result;
-      updateImageAndPalette(dataUrl, null);
+
+      const img = new Image();
+      img.onload = () => {
+        const MAX_DIMENSION = 720;
+        let { width, height } = img;
+
+        if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+          if (width > height) {
+            height = Math.round(height * (MAX_DIMENSION / width));
+            width = MAX_DIMENSION;
+          } else {
+            width = Math.round(width * (MAX_DIMENSION / height));
+            height = MAX_DIMENSION;
+          }
+        }
+
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, width, height);
+
+        const resizedDataUrl = canvas.toDataURL(file.type);
+
+        updateImageAndPalette(resizedDataUrl, null);
+      };
+      img.src = dataUrl;
     };
     reader.readAsDataURL(file);
-    // --- End of robust fix ---
 
     // TODO: Move the Google Drive upload to a separate, user-initiated action
     // to avoid unconditional uploads. For now, the logic is disabled.


### PR DESCRIPTION
This commit addresses three distinct issues based on user feedback to complete the background system refactor.

1.  **Image Resizing on Upload:**
    - The `handleBackgroundImageUpload` function in `HomePage.jsx` has been updated.
    - It now uses a canvas to resize uploaded background images, ensuring the longest side is a maximum of 720 pixels while maintaining the aspect ratio.

2.  **Page Layout Correction:**
    - A layout bug was fixed where the main canvas in `FieldPositioner.jsx` was overlapping its surrounding controls (title, navigation).
    - The `FieldPositioner` component was refactored to remove its internal `Card` and `Grid` structure, simplifying the layout and ensuring it no longer overlaps sibling elements in `ImageStep.jsx`.

3.  **Default Editor View on Mobile:**
    - The mobile formatting drawer (`FormattingDrawer`) now defaults to showing the page background controls if it's opened when no other element is selected.
    - This was achieved by updating the `onClick` handler for the drawer's trigger button in `ImageStep.jsx` to set the `selectedField` to `__background__` if it's null.