### PR TITLE
refactor: Rework page editor layout and add image resizing

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -428,34 +428,6 @@ const FieldPositioner = ({
 
   return (
     <Box>
-      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, sm: 2 }} justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-        <Typography variant="h6">
-          Editor de Campos
-        </Typography>
-        <Stack direction="row" spacing={1}>
-          <Button
-            size="small"
-            onClick={centerAllFields}
-            startIcon={<CenterFocusStrong />}
-          >
-            Centralizar
-          </Button>
-          <Button
-            size="small"
-            onClick={autoArrangeFields}
-            startIcon={<Add />}
-          >
-            Auto Organizar
-          </Button>
-        </Stack>
-      </Stack>
-
-      {csvData.length === 0 && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          Carregue um arquivo CSV para ver o preview dos dados
-        </Alert>
-      )}
-
       <Box
         ref={containerRef}
         className="text-container"
@@ -539,16 +511,6 @@ const FieldPositioner = ({
                 </>
               )}
             </Box>
-
-            {csvData && csvData.length > 1 && (
-              <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 2 }} flexWrap="wrap">
-                <Tooltip title="Primeiro Registro"><span><IconButton onClick={handleFirstPreview} disabled={currentPreviewIndex === 0} size="small"><SkipPrevious /></IconButton></span></Tooltip>
-                <Tooltip title="Registro Anterior"><span><IconButton onClick={handlePreviousPreview} disabled={currentPreviewIndex === 0} size="small"><ArrowLeft /></IconButton></span></Tooltip>
-                <Typography variant="body2" sx={{ minWidth: '100px', textAlign: 'center' }}>Registro: {currentPreviewIndex + 1} / {csvData.length}</Typography>
-                <Tooltip title="Próximo Registro"><span><IconButton onClick={handleNextPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><ArrowRight /></IconButton></span></Tooltip>
-                <Tooltip title="Último Registro"><span><IconButton onClick={handleLastPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><SkipNext /></IconButton></span></Tooltip>
-              </Stack>
-            )}
 
             {colorPalette && colorPalette.length > 0 && (
               <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -12,7 +12,16 @@ import {
   Image as ImageIcon,
   Visibility,
   Edit as EditIcon,
+  SkipPrevious,
+  ArrowLeft,
+  ArrowRight,
+  SkipNext,
 } from '@mui/icons-material';
+import {
+  Stack,
+  Tooltip,
+  IconButton,
+} from '@mui/material';
 import FieldPositioner from './FieldPositioner';
 import FormattingPanel from './FormattingPanel';
 import FormattingDrawer from './FormattingDrawer';
@@ -61,35 +70,31 @@ const ImageStep = ({
   const [fontScale, setFontScale] = useState(1);
   const [isCropping, setIsCropping] = useState(false);
 
+  const handleNextPreview = () => {
+    setCurrentPreviewIndex(prevIndex => Math.min(prevIndex + 1, csvData.length - 1));
+  };
+
+  const handlePreviousPreview = () => {
+    setCurrentPreviewIndex(prevIndex => Math.max(prevIndex - 1, 0));
+  };
+
+  const handleFirstPreview = () => {
+    setCurrentPreviewIndex(0);
+  };
+
+  const handleLastPreview = () => {
+    setCurrentPreviewIndex(csvData.length - 1);
+  };
+
   return (
     <Box>
-      <Box sx={{ mb: 2, display: 'flex', gap: 2 }}>
-        <Button
-          variant="contained"
-          component="label"
-          startIcon={<ImageIcon />}
-        >
-          Carregar Imagem
-          <input
-            type="file"
-            accept=".png,.jpg,.jpeg"
-            hidden
-            ref={imageInputRef}
-            onChange={handleImageUpload}
-          />
-        </Button>
-        <Button
-          variant="outlined"
-          onClick={onChangeBackgroundImage}
-        >
-          Escolher da Galeria
-        </Button>
-      </Box>
-      <Grid container spacing={isMobile ? 0 : 2}>
+      <Grid container spacing={isMobile ? 2 : 4}>
         <Grid item xs={12} md={8}>
-          <FieldPositioner
-            aspectRatio={aspectRatio}
-            csvHeaders={csvHeaders}
+          <Stack spacing={2}>
+            <Typography variant="h6">Editor de Página</Typography>
+            <FieldPositioner
+              aspectRatio={aspectRatio}
+              csvHeaders={csvHeaders}
             fieldPositions={fieldPositions}
             setFieldPositions={setFieldPositions}
             fieldStyles={fieldStyles}
@@ -114,11 +119,40 @@ const ImageStep = ({
             isCropping={isCropping}
             setIsCropping={setIsCropping}
           />
+          {csvData && csvData.length > 1 && (
+            <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 2 }} flexWrap="wrap">
+              <Tooltip title="Primeiro Registro"><span><IconButton onClick={handleFirstPreview} disabled={currentPreviewIndex === 0} size="small"><SkipPrevious /></IconButton></span></Tooltip>
+              <Tooltip title="Registro Anterior"><span><IconButton onClick={handlePreviousPreview} disabled={currentPreviewIndex === 0} size="small"><ArrowLeft /></IconButton></span></Tooltip>
+              <Typography variant="body2" sx={{ minWidth: '100px', textAlign: 'center' }}>Registro: {currentPreviewIndex + 1} / {csvData.length}</Typography>
+              <Tooltip title="Próximo Registro"><span><IconButton onClick={handleNextPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><ArrowRight /></IconButton></span></Tooltip>
+              <Tooltip title="Último Registro"><span><IconButton onClick={handleLastPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><SkipNext /></IconButton></span></Tooltip>
+            </Stack>
+          )}
+          </Stack>
         </Grid>
         {!isMobile ? (
           <Grid item xs={12} md={4}>
-            <FormattingPanel
-              selectedField={selectedField}
+            <Stack spacing={2}>
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                <Button
+                  variant="contained"
+                  component="label"
+                  startIcon={<ImageIcon />}
+                  fullWidth
+                >
+                  Carregar
+                  <input type="file" accept=".png,.jpg,.jpeg" hidden ref={imageInputRef} onChange={handleImageUpload} />
+                </Button>
+                <Button
+                  variant="outlined"
+                  onClick={onChangeBackgroundImage}
+                  fullWidth
+                >
+                  Galeria
+                </Button>
+              </Box>
+              <FormattingPanel
+                selectedField={selectedField}
               fieldStyles={fieldStyles}
               initialFieldStyles={initialFieldStyles}
               setFieldStyles={setFieldStyles}


### PR DESCRIPTION
This commit implements a significant refactoring of the "Image and Formatting" step to address layout issues, improve user experience, and add a new image resizing feature.

Key Changes:

1.  **Image Resizing on Upload:**
    - The `handleBackgroundImageUpload` function in `HomePage.jsx` now uses an HTML canvas to resize uploaded background images.
    - The longest side of the image is scaled down to a maximum of 720 pixels while maintaining the original aspect ratio, ensuring consistent image dimensions.

2.  **Corrected Page Layout:**
    - The layout of the editor has been fixed to prevent the canvas from overlapping surrounding UI controls like the title and record navigator.
    - The `FieldPositioner` component was simplified to only be responsible for the canvas itself.
    - The `ImageStep` component now manages the overall page layout, arranging the title, canvas, and navigation controls correctly around the main editor area.

3.  **Improved Mobile UX:**
    - The mobile formatting drawer now defaults to showing the page background controls if it's opened when no other element is selected. This provides a more intuitive experience for editing the page itself.