### PR TITLE
fix: Final layout, sizing, and overflow fixes

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -428,14 +428,12 @@ const FieldPositioner = ({
 
   return (
     <Box>
-      <Box
-        ref={containerRef}
-        className="text-container"
+      <Box sx={{ position: 'relative', overflow: 'hidden', borderRadius: 2 }}>
+        <Box
+          ref={containerRef}
+          className="text-container"
               sx={{
-                position: 'relative',
                 border: '2px solid #ddd',
-                borderRadius: 2,
-                overflow: 'hidden',
                 ...getBackgroundStyle(backgroundElement), // Apply dynamic background here
                 cursor: 'default',
                 touchAction: 'pan-x pan-y',
@@ -511,6 +509,7 @@ const FieldPositioner = ({
                 </>
               )}
             </Box>
+        </Box>
 
             {colorPalette && colorPalette.length > 0 && (
               <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>


### PR DESCRIPTION
This commit addresses a series of issues to finalize the background and page editor refactoring, including a persistent visual layout bug.

Key Changes:

1.  **Image Resizing on Upload:**
    - The `handleBackgroundImageUpload` function in `HomePage.jsx` now uses an HTML canvas to resize uploaded background images to a maximum of 720px on their longest side.

2.  **Editor Page Layout Correction:**
    - The layout of `ImageStep.jsx` has been refactored using a simpler `Stack`-based approach to correctly arrange the title, canvas, and navigation controls, preventing overlap with main page navigation.
    - The `FieldPositioner` component has been simplified to be responsible only for the canvas area.

3.  **Content Overflow Fix:**
    - A bug where draggable text elements could render outside the canvas and overlap the navigation controls has been fixed.
    - The canvas container in `FieldPositioner.jsx` is now wrapped in an additional `Box` with `overflow: hidden` to properly enforce its boundaries and clip overflowing child elements.

4.  **Improved Mobile UX:**
    - The mobile formatting drawer now defaults to showing the page background controls if opened when no other element is selected.