### PR TITLE
feat(debug): Display page editor state for diagnostics

### DIFF
--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -140,6 +140,16 @@ const ImageStep = ({
               <Tooltip title="Último Registro"><span><IconButton onClick={handleLastPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><SkipNext /></IconButton></span></Tooltip>
             </Stack>
           )}
+
+          {/* Temporary Debug View */}
+          <Box component="pre" sx={{ bgcolor: 'grey.100', p: 2, mt: 2, overflow: 'auto', maxHeight: 300, border: '1px solid', borderColor: 'grey.300', borderRadius: 1, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            <Typography variant="h6" component="div" sx={{ mb: 1 }}>Debug Info:</Typography>
+            <strong>backgroundElement:</strong>
+            {JSON.stringify(backgroundElement, null, 2)}
+            <hr style={{ margin: '16px 0' }} />
+            <strong>fieldPositions:</strong>
+            {JSON.stringify(fieldPositions, null, 2)}
+          </Box>
         </Grid>
 
         {!isMobile ? (


### PR DESCRIPTION
This commit adds a temporary debugging view to the `ImageStep` component. As requested by the user, this view displays the raw JSON data for the `backgroundElement` and `fieldPositions` props.

The purpose of this change is to diagnose a persistent issue where the editor canvas (`FieldPositioner`) is not visible, even after several layout fixes. By exposing the state on the screen, we can verify if the correct data is being passed to the component and identify potential issues with the data model itself.

This is not a final fix, but a diagnostic step to gather more information. The debugging view should be removed once the root cause is identified and resolved.