### PR TITLE
refactor(ImageStep): Rework layout to use pure Flexbox

### DIFF
--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -1,27 +1,21 @@
 import React, { useState } from 'react';
 import {
-  Card,
-  CardContent,
   Typography,
-  Grid,
   Box,
   Button,
   Fab,
+  Stack,
+  Tooltip,
+  IconButton,
 } from '@mui/material';
 import {
   Image as ImageIcon,
-  Visibility,
   Edit as EditIcon,
   SkipPrevious,
   ArrowLeft,
   ArrowRight,
   SkipNext,
 } from '@mui/icons-material';
-import {
-  Stack,
-  Tooltip,
-  IconButton,
-} from '@mui/material';
 import FieldPositioner from './FieldPositioner';
 import FormattingPanel from './FormattingPanel';
 import FormattingDrawer from './FormattingDrawer';
@@ -89,120 +83,97 @@ const ImageStep = ({
   };
 
   return (
-    <Box sx={{ height: '100%' }}>
-      <Grid container spacing={isMobile ? 2 : 4} sx={{ height: '100%' }}>
-        <Grid item xs={12} md={8} sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-          <Typography variant="h6" sx={{ flexShrink: 0, textAlign: 'center' }}>
-            Editor de Página
-          </Typography>
-          <Box
-            sx={{
-              flexGrow: 1,
-              minHeight: 0, // Allow shrinking
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              my: 2,
-            }}
-          >
-            <FieldPositioner
-              aspectRatio={aspectRatio}
-              csvHeaders={csvHeaders}
-              fieldPositions={fieldPositions}
-              setFieldPositions={setFieldPositions}
-              fieldStyles={fieldStyles}
-              setFieldStyles={setFieldStyles}
-              csvData={csvData}
-              onImageDisplayedSizeChange={onImageDisplayedSizeChange}
-              colorPalette={colorPalette}
-              standardsColors={standardsColors}
-              onCsvDataUpdate={onCsvDataUpdate}
-              selectedField={selectedField}
-              setSelectedField={setSelectedField}
-              originalImageSize={originalImageSize}
-              brandElements={brandElements}
-              setBrandElements={setBrandElements}
-              backgroundElement={backgroundElement}
-              setBackgroundElement={setBackgroundElement}
-              pageState={pageState}
-              onZIndexChange={onZIndexChange}
-              onOpenHtmlEditor={onOpenHtmlEditor}
-              currentPreviewIndex={currentPreviewIndex}
-              setCurrentPreviewIndex={setCurrentPreviewIndex}
-              onFontScaleChange={setFontScale}
-              isCropping={isCropping}
-              setIsCropping={setIsCropping}
-            />
-          </Box>
-          {csvData && csvData.length > 1 && (
-            <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ flexShrink: 0 }} flexWrap="wrap">
-              <Tooltip title="Primeiro Registro"><span><IconButton onClick={handleFirstPreview} disabled={currentPreviewIndex === 0} size="small"><SkipPrevious /></IconButton></span></Tooltip>
-              <Tooltip title="Registro Anterior"><span><IconButton onClick={handlePreviousPreview} disabled={currentPreviewIndex === 0} size="small"><ArrowLeft /></IconButton></span></Tooltip>
-              <Typography variant="body2" sx={{ minWidth: '100px', textAlign: 'center' }}>Registro: {currentPreviewIndex + 1} / {csvData.length}</Typography>
-              <Tooltip title="Próximo Registro"><span><IconButton onClick={handleNextPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><ArrowRight /></IconButton></span></Tooltip>
-              <Tooltip title="Último Registro"><span><IconButton onClick={handleLastPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><SkipNext /></IconButton></span></Tooltip>
-            </Stack>
-          )}
-        </Grid>
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
 
-        {!isMobile ? (
-          <Grid item xs={12} md={4}>
-            <Stack spacing={2}>
-              <Box sx={{ display: 'flex', gap: 2 }}>
-                <Button
-                  variant="contained"
-                  component="label"
-                  startIcon={<ImageIcon />}
-                  fullWidth
-                >
-                  Carregar
-                  <input type="file" accept=".png,.jpg,.jpeg" hidden ref={imageInputRef} onChange={handleImageUpload} />
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={onChangeBackgroundImage}
-                  fullWidth
-                >
-                  Galeria
-                </Button>
-              </Box>
-              <FormattingPanel
-                selectedField={selectedField}
-                fieldStyles={fieldStyles}
-                initialFieldStyles={initialFieldStyles}
-                setFieldStyles={setFieldStyles}
-                fieldPositions={fieldPositions}
-                setFieldPositions={setFieldPositions}
-                csvHeaders={csvHeaders}
-                brandElements={brandElements}
-                setBrandElements={setBrandElements}
-                backgroundElement={backgroundElement}
-                setBackgroundElement={setBackgroundElement}
-                onZIndexChange={onZIndexChange}
-                onDeselectField={onDeselectField}
-                onOpenHtmlEditor={onOpenHtmlEditor}
-                standardsColors={standardsColors}
-                pageState={pageState}
-                setPageState={setPageState}
-                fontScale={fontScale}
-                templateFieldStyles={templateFieldStyles}
-                activeStep={activeStep}
-                isCropping={isCropping}
-                setIsCropping={setIsCropping}
-              />
-            </Stack>
-          </Grid>
-        ) : (
-          <>
-            <Fab color="primary" aria-label="edit" sx={{ position: 'fixed', bottom: 16, right: 16, zIndex: 1300 }} onClick={() => {
-              if (!selectedField) {
-                setSelectedField('__background__');
-              }
-              setIsDrawerOpen(true);
-            }}><EditIcon /></Fab>
-            <FormattingDrawer
-              open={isDrawerOpen}
-              onClose={() => setIsDrawerOpen(false)}
+      {/* Main Content: Editor Area */}
+      <Box sx={{
+        flex: '1 1 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0, // Crucial for flex child to shrink
+        p: 1,
+      }}>
+        <Typography variant="h6" sx={{ flexShrink: 0, textAlign: 'center', mb: 2 }}>
+          Editor de Página
+        </Typography>
+        <Box
+          sx={{
+            flexGrow: 1,
+            minHeight: 0, // Allow shrinking
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <FieldPositioner
+            aspectRatio={aspectRatio}
+            csvHeaders={csvHeaders}
+            fieldPositions={fieldPositions}
+            setFieldPositions={setFieldPositions}
+            fieldStyles={fieldStyles}
+            setFieldStyles={setFieldStyles}
+            csvData={csvData}
+            onImageDisplayedSizeChange={onImageDisplayedSizeChange}
+            colorPalette={colorPalette}
+            standardsColors={standardsColors}
+            onCsvDataUpdate={onCsvDataUpdate}
+            selectedField={selectedField}
+            setSelectedField={setSelectedField}
+            originalImageSize={originalImageSize}
+            brandElements={brandElements}
+            setBrandElements={setBrandElements}
+            backgroundElement={backgroundElement}
+            setBackgroundElement={setBackgroundElement}
+            pageState={pageState}
+            onZIndexChange={onZIndexChange}
+            onOpenHtmlEditor={onOpenHtmlEditor}
+            currentPreviewIndex={currentPreviewIndex}
+            setCurrentPreviewIndex={setCurrentPreviewIndex}
+            onFontScaleChange={setFontScale}
+            isCropping={isCropping}
+            setIsCropping={setIsCropping}
+          />
+        </Box>
+        {csvData && csvData.length > 1 && (
+          <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ flexShrink: 0, mt: 2 }} flexWrap="wrap">
+            <Tooltip title="Primeiro Registro"><span><IconButton onClick={handleFirstPreview} disabled={currentPreviewIndex === 0} size="small"><SkipPrevious /></IconButton></span></Tooltip>
+            <Tooltip title="Registro Anterior"><span><IconButton onClick={handlePreviousPreview} disabled={currentPreviewIndex === 0} size="small"><ArrowLeft /></IconButton></span></Tooltip>
+            <Typography variant="body2" sx={{ minWidth: '100px', textAlign: 'center' }}>Registro: {currentPreviewIndex + 1} / {csvData.length}</Typography>
+            <Tooltip title="Próximo Registro"><span><IconButton onClick={handleNextPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><ArrowRight /></IconButton></span></Tooltip>
+            <Tooltip title="Último Registro"><span><IconButton onClick={handleLastPreview} disabled={currentPreviewIndex === csvData.length - 1} size="small"><SkipNext /></IconButton></span></Tooltip>
+          </Stack>
+        )}
+      </Box>
+
+      {/* Sidebar: Formatting Panel (Desktop Only) */}
+      {!isMobile && (
+        <Box sx={{
+          flex: '0 0 320px', // Don't grow, don't shrink, base width 320px
+          p: 1,
+          borderLeft: 1,
+          borderColor: 'divider',
+          overflowY: 'auto'
+        }}>
+          <Stack spacing={2}>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Button
+                variant="contained"
+                component="label"
+                startIcon={<ImageIcon />}
+                fullWidth
+              >
+                Carregar
+                <input type="file" accept=".png,.jpg,.jpeg" hidden ref={imageInputRef} onChange={handleImageUpload} />
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={onChangeBackgroundImage}
+                fullWidth
+              >
+                Galeria
+              </Button>
+            </Box>
+            <FormattingPanel
               selectedField={selectedField}
               fieldStyles={fieldStyles}
               initialFieldStyles={initialFieldStyles}
@@ -218,15 +189,53 @@ const ImageStep = ({
               onDeselectField={onDeselectField}
               onOpenHtmlEditor={onOpenHtmlEditor}
               standardsColors={standardsColors}
+              pageState={pageState}
+              setPageState={setPageState}
               fontScale={fontScale}
               templateFieldStyles={templateFieldStyles}
               activeStep={activeStep}
               isCropping={isCropping}
               setIsCropping={setIsCropping}
             />
-          </>
-        )}
-      </Grid>
+          </Stack>
+        </Box>
+      )}
+
+      {/* Mobile FAB and Drawer */}
+      {isMobile && (
+        <>
+          <Fab color="primary" aria-label="edit" sx={{ position: 'fixed', bottom: 16, right: 16, zIndex: 1300 }} onClick={() => {
+            if (!selectedField) {
+              setSelectedField('__background__');
+            }
+            setIsDrawerOpen(true);
+          }}><EditIcon /></Fab>
+          <FormattingDrawer
+            open={isDrawerOpen}
+            onClose={() => setIsDrawerOpen(false)}
+            selectedField={selectedField}
+            fieldStyles={fieldStyles}
+            initialFieldStyles={initialFieldStyles}
+            setFieldStyles={setFieldStyles}
+            fieldPositions={fieldPositions}
+            setFieldPositions={setFieldPositions}
+            csvHeaders={csvHeaders}
+            brandElements={brandElements}
+            setBrandElements={setBrandElements}
+            backgroundElement={backgroundElement}
+            setBackgroundElement={setBackgroundElement}
+            onZIndexChange={onZIndexChange}
+            onDeselectField={onDeselectField}
+            onOpenHtmlEditor={onOpenHtmlEditor}
+            standardsColors={standardsColors}
+            fontScale={fontScale}
+            templateFieldStyles={templateFieldStyles}
+            activeStep={activeStep}
+            isCropping={isCropping}
+            setIsCropping={setIsCropping}
+          />
+        </>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
Replaced the Material-UI Grid-based layout in `ImageStep` with a pure Flexbox implementation using `Box` components. This creates a more robust and predictable responsive layout, resolving the issue where the editor canvas would collapse on mobile viewports.

- The main layout is now a flex container that switches direction based on screen size.
- The editor area (`FieldPositioner`) is set to grow and fill available space (`flexGrow: 1`), ensuring it is always visible.
- The right-side formatting panel is now a fixed-width flex item on desktop and is not rendered on mobile, replaced by the FAB/Drawer.

This change, combined with the previous data model refactoring, fully resolves the layout and visibility issues in the page editor. All tests continue to pass.