### PR TITLE
fix(FieldPositioner): Ensure elements render without background image

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -367,7 +367,7 @@ const FieldPositioner = ({
                       }
                     }}
                   >
-                    {renderedImageMetrics.width > 0 && renderableElements.map(element => (
+                    {renderableElements.map(element => (
                       <DraggableElement
                         key={element.id}
                         element={element.type === 'image' || element.type === 'background' || element.type === 'cropbox' ? { ...element.position, type: element.type } : { id: element.id, type: 'text' }}


### PR DESCRIPTION
Removed the `renderedImageMetrics.width > 0` condition that was preventing the rendering of text fields and other elements inside the `FieldPositioner` component.

This condition created a catch-22 where the component would not render its children until its container had a size, but the container's size depended on its content. Removing this check ensures that the editor canvas and its elements are always rendered, using the `pageState.backgroundColor` as a backdrop, regardless of whether a background image is present.

This change resolves the core issue of the editor being blank by default.