### PR TITLE
fix(HomePage): Initialize page with a default size

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -167,7 +167,7 @@ function HomePage() {
   const [initialFieldStyles, setInitialFieldStyles] = useState({});
   const [templateFieldStyles, setTemplateFieldStyles] = useState({});
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
-  const [originalImageSize, setOriginalImageSize] = useState({ width: 0, height: 0 });
+  const [originalImageSize, setOriginalImageSize] = useState({ width: 1080, height: 1080 });
   const [generatedPagesData, setGeneratedPagesData] = useState([]);
   const [generatedAudioData, setGeneratedAudioData] = useState([]);
   const [generatedVideosData, setGeneratedVideosData] = useState([]);


### PR DESCRIPTION
Set the initial state of `originalImageSize` in `HomePage.jsx` to a non-zero default value (`{ width: 1080, height: 1080 }`).

This resolves a critical bug where the `FieldPositioner` component would not render until a background image was loaded. The component had an implicit dependency on `originalImageSize` for its internal scaling calculations. By providing a default size, the editor canvas can now be rendered immediately with all its elements, as per the user's requirement.

This change ensures the editor is always functional, with or without a background image.