### PR TITLE
fix: Ensure PageEditor is always visible

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -266,8 +266,6 @@ const PageEditor = ({
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '300px' }}>
             <Typography>Carregando editor...</Typography>
           </Box>
-        ) : !editedBackgroundElement?.src ? (
-          <Typography>Imagem de fundo não disponível para edição.</Typography>
         ) : (
           <Grid container spacing={2}>
             <Grid item xs={12} md={isMobile ? 12 : 8}>


### PR DESCRIPTION
This commit fixes a critical bug where the editor surface in `PageEditor.jsx` would not render unless a background image was present.

The root cause was a conditional rendering check (`!editedBackgroundElement?.src`) that incorrectly hid the entire editor grid. This check has been removed.

The `FieldPositioner` component, which is now always rendered, is already equipped to handle a background element with no `src` by displaying a solid color or gradient, ensuring a functional editor is always available to the user.