### PR TITLE
Fix editor visibility and sizing issues in the "Image and Formatting"…

### DIFF
--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -72,11 +72,14 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
         onChange={(e, newMode) => {
           if (newMode) {
             setColorMode(newMode);
+            const newBackgroundType = newMode === 'solid' ? 'color' : 'gradient';
             // When user selects a color/gradient, we remove the image src
-            // so the background image disappears.
-            if (backgroundElement?.src) {
-              onUpdate({ ...backgroundElement, src: null });
-            }
+            // so the background image disappears, and set the correct type.
+            onUpdate({
+              ...backgroundElement,
+              src: null,
+              backgroundType: newBackgroundType,
+            });
           }
         }}
         aria-label="color mode"

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -262,56 +262,50 @@ const PageEditor = ({
         </IconButton>
       </DialogTitle>
       <DialogContent dividers sx={{ overflowY: 'auto' }}>
-        {!stylesAreInitialized ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '300px' }}>
-            <Typography>Carregando editor...</Typography>
-          </Box>
-        ) : (
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={isMobile ? 12 : 8}>
-              <FieldPositioner
-                aspectRatio={aspectRatio}
-                csvHeaders={editorCsvHeaders} // Headers relevantes para esta imagem
-                fieldPositions={editedPositions}
-                setFieldPositions={setEditedPositions}
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={isMobile ? 12 : 8}>
+            <FieldPositioner
+              aspectRatio={aspectRatio}
+              csvHeaders={editorCsvHeaders} // Headers relevantes para esta imagem
+              fieldPositions={editedPositions}
+              setFieldPositions={setEditedPositions}
+              fieldStyles={editedStyles}
+              setFieldStyles={setEditedStyles}
+              csvData={editorCsvData} // Dados CSV desta imagem para preview
+              colorPalette={colorPalette}
+              selectedField={selectedFieldInternal}
+              setSelectedField={handleInternalFieldSelection}
+              onCsvDataUpdate={handleFieldPositionerCsvDataUpdate}
+              originalImageSize={originalImageSize}
+              onFontScaleChange={setFontScale}
+              brandElements={editedBrandElements}
+              setBrandElements={setEditedBrandElements}
+              backgroundElement={editedBackgroundElement}
+              setBackgroundElement={setEditedBackgroundElement}
+              currentPreviewIndex={0}
+            />
+          </Grid>
+          {!isMobile && (
+            <Grid item xs={12} md={4}>
+              <FormattingPanel
+                selectedField={selectedFieldInternal} // Usar o estado interno
                 fieldStyles={editedStyles}
                 setFieldStyles={setEditedStyles}
-                csvData={editorCsvData} // Dados CSV desta imagem para preview
-                colorPalette={colorPalette}
-                selectedField={selectedFieldInternal}
-                setSelectedField={handleInternalFieldSelection}
-                onCsvDataUpdate={handleFieldPositionerCsvDataUpdate}
-                originalImageSize={originalImageSize}
-                onFontScaleChange={setFontScale}
-                brandElements={editedBrandElements}
-                setBrandElements={setEditedBrandElements}
+                fieldPositions={editedPositions}
+                setFieldPositions={setEditedPositions}
+                csvHeaders={editorCsvHeaders}
                 backgroundElement={editedBackgroundElement}
                 setBackgroundElement={setEditedBackgroundElement}
-                currentPreviewIndex={0}
+                brandElements={editedBrandElements}
+                setBrandElements={setEditedBrandElements}
+                onDeselectField={handleDeselectField}
+                onOpenHtmlEditor={handleOpenHtmlEditor}
+                fontScale={fontScale}
+                standardsColors={standardsColors || colorPalette}
               />
             </Grid>
-            {!isMobile && (
-              <Grid item xs={12} md={4}>
-                <FormattingPanel
-                  selectedField={selectedFieldInternal} // Usar o estado interno
-                  fieldStyles={editedStyles}
-                  setFieldStyles={setEditedStyles}
-                  fieldPositions={editedPositions}
-                  setFieldPositions={setEditedPositions}
-                  csvHeaders={editorCsvHeaders}
-                  backgroundElement={editedBackgroundElement}
-                  setBackgroundElement={setEditedBackgroundElement}
-                  brandElements={editedBrandElements}
-                  setBrandElements={setEditedBrandElements}
-                  onDeselectField={handleDeselectField}
-                  onOpenHtmlEditor={handleOpenHtmlEditor}
-                  fontScale={fontScale}
-                  standardsColors={standardsColors || colorPalette}
-                />
-              </Grid>
-            )}
-          </Grid>
-        )}
+          )}
+        </Grid>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancelar</Button>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -105,6 +105,8 @@ const defaultBackgroundElement = {
   shadowOffsetY: 5,
 };
 
+const DEFAULT_IMAGE_SIZE = { width: 720, height: 720 };
+
 function HomePage() {
   const { user, googleAccessToken, setGoogleAccessToken } = useUserAuth();
   const { settings, updateSetting, saveSettings } = useSettings();
@@ -167,7 +169,7 @@ function HomePage() {
   const [initialFieldStyles, setInitialFieldStyles] = useState({});
   const [templateFieldStyles, setTemplateFieldStyles] = useState({});
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
-  const [originalImageSize, setOriginalImageSize] = useState({ width: 1920, height: 1080 });
+  const [originalImageSize, setOriginalImageSize] = useState(DEFAULT_IMAGE_SIZE);
   const [generatedPagesData, setGeneratedPagesData] = useState([]);
   const [generatedAudioData, setGeneratedAudioData] = useState([]);
   const [generatedVideosData, setGeneratedVideosData] = useState([]);
@@ -341,7 +343,7 @@ function HomePage() {
     setInitialFieldStyles(completeStyles);
 
     setDisplayedImageSize(state.displayedImageSize ?? { width: 0, height: 0 });
-    setOriginalImageSize(state.originalImageSize ?? { width: 1920, height: 1080 });
+    setOriginalImageSize(state.originalImageSize ?? DEFAULT_IMAGE_SIZE);
   };
 
   const handleSaveCampaign = async (name) => {
@@ -538,7 +540,7 @@ function HomePage() {
     // reset the originalImageSize to the default. This prevents the editor
     // from retaining the dimensions of the old image, which would break the layout.
     if (backgroundElement?.src === null) {
-      setOriginalImageSize({ width: 1920, height: 1080 });
+      setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     }
   }, [backgroundElement]);
 
@@ -606,7 +608,7 @@ function HomePage() {
     setCurrentCampaign(null);
     // Also explicitly reset the background element and image size to the default state for a new campaign
     setBackgroundElement(defaultBackgroundElement);
-    setOriginalImageSize({ width: 1920, height: 1080 });
+    setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     setActiveStep(1);
   };
   const handleEditCampaign = (campaign) => {
@@ -689,7 +691,7 @@ function HomePage() {
       setColorPalette([]);
       // Reset to a functional default state on image load error
       setBackgroundElement(defaultBackgroundElement);
-      setOriginalImageSize({ width: 1920, height: 1080 });
+      setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     };
     img.src = imageUrl;
   }, []);


### PR DESCRIPTION
… step.

This commit addresses several bugs that affected the usability of the page editor:

- In `PageEditor.jsx`, the conditional rendering that could hide the editor has been removed. This ensures the editor is always visible and interactive, preventing a situation where it would not appear if certain props were not ready.

- In `HomePage.jsx`, the `originalImageSize` state is now initialized with a default of { width: 720, height: 720 }. This default is consistently used when creating new campaigns, loading old campaigns, or when a background image is removed or fails to load. This prevents layout issues and ensures a stable editor experience even without an image.

- In `BackgroundColorEditor.jsx`, changing the background mode to a solid color or gradient now correctly sets the `backgroundElement.src` to `null` and updates the `backgroundType`. This ensures a clean switch from an image-based background to a color-based one.

The original request also mentioned changes to `FieldPositioner.jsx` and `DraggableElement.jsx`. After multiple implementation attempts and code reviews, it was determined that the original code in these files was correct and that the user-facing bug was caused by the issues resolved in the other files. Therefore, no changes were made to `FieldPositioner.jsx` and `DraggableElement.jsx`.