### PR TITLE
feat: Refatoração para múltiplas imagens e fundo customizável

### DIFF
--- a/GUIA_FUNCIONALIDADES.md
+++ b/GUIA_FUNCIONALIDADES.md
@@ -65,13 +65,12 @@ SW ---- S ---- SE
 
 #### **Stepper Visual**
 1. **Upload do CSV**: Carregamento e validação
-2. **Upload da Imagem**: Seleção do background
-3. **Posicionar e Formatar**: Editor principal
-4. **Gerar Páginas**: Processamento final
+2. **Modelo de Página**: Definição do template base
+3. **Edição de Páginas**: Customização e geração final
 
 #### **Indicadores de Status**
 - **Registros CSV**: Quantidade de dados carregados
-- **Imagem de fundo**: Status do background
+- **Imagem**: Status da imagem
 - **Campos visíveis**: Contagem de campos ativos
 - **Estilos configurados**: Quantidade de formatações
 
@@ -90,12 +89,11 @@ SW ---- S ---- SE
 2. Escolha arquivo com cabeçalhos na primeira linha
 3. Aguarde confirmação de carregamento
 
-### **Passo 2: Upload da Imagem de Fundo**
-1. Clique em "Selecionar Imagem PNG/JPG"
-2. Escolha imagem de fundo
-3. Visualize preview da imagem de fundo
-
-### **Passo 3: Posicionar e Formatar**
+### **Passo 2: Modelo de Página**
+1. **Cor de Fundo**: Defina uma cor sólida ou um gradiente para o fundo da página.
+2. **Adicionar Imagens**: Clique em "Carregar" para adicionar uma ou mais imagens ao modelo.
+3. **Gerenciar Imagens**: Selecione, posicione, redimensione, aplique filtros e organize a ordem das imagens.
+4. **Posicionar Campos de Texto**: Arraste e posicione os campos de texto (ex: Título, Mensagem) sobre o modelo.
 
 #### **Seleção de Campo**
 - Clique em qualquer campo de texto para selecioná-lo
@@ -122,11 +120,11 @@ SW ---- S ---- SE
 - **Resetar Estilo**: Volta configurações padrão
 - **Visibilidade**: Toggle para mostrar/ocultar campo
 
-### **Passo 4: Gerar Páginas**
-1. Revise configurações no resumo
-2. Clique em "Gerar X Páginas"
-3. Aguarde processamento
-4. Faça download individual ou em lote
+### **Passo 3: Edição de Páginas**
+1. **Visualização**: Navegue por todas as páginas que serão geradas.
+2. **Customização Individual**: Selecione uma página para editar seu fundo, imagens ou texto de forma individual.
+3. **Geração**: Clique em "Gerar Páginas" para criar as imagens finais.
+4. **Download**: Baixe as imagens individualmente ou em lote.
 
 ## 🔧 **Funcionalidades Técnicas**
 
@@ -195,7 +193,7 @@ const wrapText = (text, maxWidth) => {
 
 Após dominar estas funcionalidades, considere explorar:
 - Templates personalizados
-- Múltiplas imagens de fundo
+- Múltiplas imagens
 - Exportação em diferentes formatos
 - Integração com APIs externas
 

--- a/INSTRUCOES_USO.md
+++ b/INSTRUCOES_USO.md
@@ -11,7 +11,7 @@ Este componente permite transformar dados de um arquivo CSV em imagens personali
 - Separador: vírgula (,)
 - Campos com texto longo devem estar entre aspas
 
-### Imagem de Fundo
+### Imagem
 - Formatos suportados: PNG, JPG, JPEG
 - Resolução recomendada: 1080x1080px ou superior
 - Qualidade alta para melhor resultado final
@@ -30,7 +30,7 @@ Título,Mensagem,CTA,Descrição
 - Verifique se todos os campos foram detectados
 
 ### 3️⃣ Upload da Imagem
-- Clique em "Selecionar Imagem PNG/JPG"
+- Clique em "Selecionar Imagem"
 - Escolha uma imagem com boa resolução
 - Verifique o preview
 

--- a/README_FRONTEND_ONLY.md
+++ b/README_FRONTEND_ONLY.md
@@ -100,7 +100,7 @@ npm run dev
 ### Fluxo Completo
 
 1. **Upload CSV**: Carregue arquivo com dados
-2. **Upload Imagem de Fundo**: Defina imagem de fundo
+2. **Upload de Imagem**: Defina a imagem para a página
 3. **Configurar Campos**: Posicione e formate textos
 4. **Configurar Google Drive**:
    - Ative a integração

--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -13,57 +13,45 @@ import {
 } from '@mui/material';
 import { Add, Delete, Gradient } from '@mui/icons-material';
 
-const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageStateUpdate }) => {
-  // Determine the initial mode. If the backgroundElement has a gradient, default to gradient mode.
-  const initialMode = backgroundElement?.gradient ? 'gradient' : 'solid';
+const BackgroundColorEditor = ({ pageTemplate, onUpdate }) => {
+  const initialMode = pageTemplate?.gradient ? 'gradient' : 'solid';
   const [colorMode, setColorMode] = React.useState(initialMode);
 
-  // When the component opens, if the mode is gradient, clear the solid page color to avoid confusion.
   React.useEffect(() => {
-    if (initialMode === 'gradient' && pageState?.backgroundColor) {
-       // onPageStateUpdate({ ...pageState, backgroundColor: 'rgba(0,0,0,0)' });
-    }
-  }, [initialMode]);
+    setColorMode(pageTemplate?.gradient ? 'gradient' : 'solid');
+  }, [pageTemplate?.gradient]);
 
-
-  if (!backgroundElement) return null;
-
-  const handlePageStateUpdate = (property, value) => {
-    onPageStateUpdate({ ...pageState, [property]: value });
-  };
+  if (!pageTemplate) return null;
 
   const handleGradientUpdate = (property, value) => {
-    const currentGradient = backgroundElement.gradient || {};
+    const currentGradient = pageTemplate.gradient || {};
     onUpdate({
-      ...backgroundElement,
+      ...pageTemplate,
       gradient: { ...currentGradient, [property]: value },
     });
   };
 
   const handleStopUpdate = (index, property, value) => {
-    const newStops = [...(backgroundElement.gradient?.stops || [])];
+    const newStops = [...(pageTemplate.gradient?.stops || [])];
     newStops[index] = { ...newStops[index], [property]: value };
     handleGradientUpdate('stops', newStops);
   };
 
   const addStop = () => {
     const newStops = [
-      ...(backgroundElement.gradient?.stops || []),
+      ...(pageTemplate.gradient?.stops || []),
       { color: '#ffffff', position: 100 },
     ];
     handleGradientUpdate('stops', newStops);
   };
 
   const removeStop = (index) => {
-    const newStops = (backgroundElement.gradient?.stops || []).filter((_, i) => i !== index);
+    const newStops = (pageTemplate.gradient?.stops || []).filter((_, i) => i !== index);
     handleGradientUpdate('stops', newStops);
   };
 
   return (
     <Box>
-      <Typography variant="caption" display="block" gutterBottom>
-        Cor de Fundo
-      </Typography>
       <ToggleButtonGroup
         value={colorMode}
         exclusive
@@ -72,14 +60,21 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
         onChange={(e, newMode) => {
           if (newMode) {
             setColorMode(newMode);
-            const newBackgroundType = newMode === 'solid' ? 'color' : 'gradient';
-            // When user selects a color/gradient, we remove the image src
-            // so the background image disappears, and set the correct type.
-            onUpdate({
-              ...backgroundElement,
-              src: null,
-              backgroundType: newBackgroundType,
-            });
+            if (newMode === 'solid') {
+                onUpdate({ ...pageTemplate, gradient: null });
+            } else {
+                onUpdate({
+                    ...pageTemplate,
+                    gradient: pageTemplate.gradient || {
+                        type: 'linear',
+                        angle: 90,
+                        stops: [
+                            { color: '#ffffff', position: 0 },
+                            { color: '#000000', position: 100 },
+                        ]
+                    }
+                });
+            }
           }
         }}
         aria-label="color mode"
@@ -97,19 +92,19 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
           <Typography gutterBottom>Cor</Typography>
           <TextField
             type="color"
-            value={pageState?.backgroundColor || '#ffffff'}
-            onChange={(e) => handlePageStateUpdate('backgroundColor', e.target.value)}
+            value={pageTemplate.backgroundColor || '#ffffff'}
+            onChange={(e) => onUpdate({ ...pageTemplate, backgroundColor: e.target.value })}
             fullWidth
           />
         </Box>
       )}
 
-      {colorMode === 'gradient' && (
+      {colorMode === 'gradient' && pageTemplate.gradient && (
         <Box sx={{ mt: 2 }}>
           <Grid container spacing={2}>
             <Grid item xs={12}>
                 <ToggleButtonGroup
-                    value={backgroundElement.gradient?.type || 'linear'}
+                    value={pageTemplate.gradient.type || 'linear'}
                     exclusive
                     fullWidth
                     size="small"
@@ -126,11 +121,11 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
                 </ToggleButtonGroup>
             </Grid>
 
-            {backgroundElement.gradient?.type === 'linear' && (
+            {pageTemplate.gradient.type === 'linear' && (
               <Grid item xs={12}>
                 <Typography gutterBottom>Ângulo do Gradiente</Typography>
                 <Slider
-                  value={backgroundElement.gradient?.angle || 0}
+                  value={pageTemplate.gradient.angle || 0}
                   onChange={(e, value) => handleGradientUpdate('angle', value)}
                   min={0}
                   max={360}
@@ -142,7 +137,7 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
 
             <Grid item xs={12}>
               <Typography gutterBottom>Cores do Gradiente</Typography>
-              {backgroundElement.gradient?.stops?.map((stop, index) => (
+              {pageTemplate.gradient.stops?.map((stop, index) => (
                 <Grid container spacing={1} key={index} alignItems="center" sx={{ mb: 1 }}>
                   <Grid item xs={3}>
                     <TextField
@@ -164,7 +159,7 @@ const BackgroundColorEditor = ({ backgroundElement, onUpdate, pageState, onPageS
                     />
                   </Grid>
                   <Grid item xs={2}>
-                    <IconButton onClick={() => removeStop(index)} size="small" disabled={(backgroundElement.gradient?.stops?.length || 0) <= 2}>
+                    <IconButton onClick={() => removeStop(index)} size="small" disabled={(pageTemplate.gradient.stops?.length || 0) <= 2}>
                       <Delete />
                     </IconButton>
                   </Grid>

--- a/src/components/BackgroundImageSelector.jsx
+++ b/src/components/BackgroundImageSelector.jsx
@@ -119,7 +119,7 @@ const BackgroundImageSelector = ({ open, onClose, onSelect, onLocalUpload }) => 
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Selecionar Imagem de Fundo</DialogTitle>
+      <DialogTitle>Selecionar Imagem</DialogTitle>
       <DialogContent sx={{ p: 0 }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={tab} onChange={(e, newValue) => setTab(newValue)} centered>

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -69,17 +69,16 @@ const FieldPositioner = ({
   darkMode,
   brandElements,
   setBrandElements,
-  backgroundElement,
-  setBackgroundElement,
+  pageTemplate,
+  setPageTemplate,
   onOpenHtmlEditor,
   currentPreviewIndex,
   setCurrentPreviewIndex,
   onFontScaleChange,
   isCropping,
   setIsCropping,
-  pageState,
 }) => {
-  console.log('[FieldPositioner] props:', { backgroundElement, fieldStyles, pageState });
+  console.log('[FieldPositioner] props:', { pageTemplate, fieldStyles });
   const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
   const [fontScale, setFontScale] = useState(1);
   const [isInteracting, setIsInteracting] = useState(false);
@@ -126,10 +125,15 @@ const FieldPositioner = ({
   }, [onImageDisplayedSizeChange]);
 
   const handlePositionChange = (id, newPosition) => {
-    if (id === '__background__') {
-      setBackgroundElement(prev => ({ ...prev, ...newPosition }));
-    } else if (id === '__cropbox__') {
-      setBackgroundElement(prev => ({ ...prev, crop: { ...prev.crop, ...newPosition } }));
+    if (id === '__cropbox__') {
+      // This logic needs to be tied to a specific image, assuming the first one for now.
+      setPageTemplate(prev => {
+        const newImages = [...prev.images];
+        if (newImages[0]) {
+          newImages[0].crop = { ...(newImages[0].crop || {}), ...newPosition };
+        }
+        return { ...prev, images: newImages };
+      });
     } else if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
         ...prev,
@@ -139,17 +143,32 @@ const FieldPositioner = ({
         }
       }));
     } else {
-      setBrandElements(prev => prev.map(el =>
-        el.id === id ? { ...el, ...newPosition } : el
-      ));
+      // Check if it's a brand element or a page image
+      const imageIndex = pageTemplate.images.findIndex(img => img.id === id);
+      if (imageIndex > -1) {
+        setPageTemplate(prev => {
+          const newImages = [...prev.images];
+          newImages[imageIndex] = { ...newImages[imageIndex], ...newPosition };
+          return { ...prev, images: newImages };
+        });
+      } else {
+        setBrandElements(prev => prev.map(el =>
+          el.id === id ? { ...el, ...newPosition } : el
+        ));
+      }
     }
   };
 
   const handleSizeChange = (id, newSize) => {
-    if (id === '__background__') {
-      setBackgroundElement(prev => ({ ...prev, ...newSize }));
-    } else if (id === '__cropbox__') {
-      setBackgroundElement(prev => ({ ...prev, crop: { ...prev.crop, ...newSize } }));
+    if (id === '__cropbox__') {
+      // This logic needs to be tied to a specific image, assuming the first one for now.
+      setPageTemplate(prev => {
+        const newImages = [...prev.images];
+        if (newImages[0]) {
+          newImages[0].crop = { ...(newImages[0].crop || {}), ...newSize };
+        }
+        return { ...prev, images: newImages };
+      });
     } else if (Object.prototype.hasOwnProperty.call(fieldPositions, id)) {
       setFieldPositions(prev => ({
         ...prev,
@@ -159,9 +178,18 @@ const FieldPositioner = ({
         }
       }));
     } else {
-      setBrandElements(prev => prev.map(el =>
-        el.id === id ? { ...el, ...newSize } : el
-      ));
+       const imageIndex = pageTemplate.images.findIndex(img => img.id === id);
+      if (imageIndex > -1) {
+        setPageTemplate(prev => {
+          const newImages = [...prev.images];
+          newImages[imageIndex] = { ...newImages[imageIndex], ...newSize };
+          return { ...prev, images: newImages };
+        });
+      } else {
+        setBrandElements(prev => prev.map(el =>
+          el.id === id ? { ...el, ...newSize } : el
+        ));
+      }
     }
   };
 
@@ -257,52 +285,42 @@ const FieldPositioner = ({
   }, [csvHeaders, fieldStyles]);
 
   const renderableElements = React.useMemo(() => {
-    // Fallback to a default object to ensure the editor is always visible,
-    // even if the parent component fails to provide a backgroundElement.
-    const effectiveBackgroundElement = backgroundElement || {
-      id: '__background__',
-      type: 'background',
-      x: 0, y: 0, width: 100, height: 100,
-      filters: {},
-      rotation: 0,
-      src: null,
-    };
+    const elements = [];
 
-    const elements = [
-      {
-        id: '__background__',
-        type: 'background',
-        position: effectiveBackgroundElement,
-        style: {
-          // Explicitly pass properties needed for styling by DraggableElement
-          backgroundType: effectiveBackgroundElement.backgroundType,
-          backgroundColor: effectiveBackgroundElement.backgroundColor,
-          gradient: effectiveBackgroundElement.gradient,
-          filters: effectiveBackgroundElement.filters,
-          shadow: effectiveBackgroundElement.shadow,
-          shadowColor: effectiveBackgroundElement.shadowColor,
-          shadowBlur: effectiveBackgroundElement.shadowBlur,
-          shadowOffsetX: effectiveBackgroundElement.shadowOffsetX,
-          shadowOffsetY: effectiveBackgroundElement.shadowOffsetY,
-        },
-        content: effectiveBackgroundElement.src || '',
-        zIndex: -1,
-        rotation: effectiveBackgroundElement.rotation || 0,
-        fontScale: 1,
-        enableHtmlRendering: false,
-      },
-      ...(isCropping && backgroundElement ? [{
-        id: '__cropbox__',
-        type: 'cropbox',
-        position: backgroundElement.crop || { x: 10, y: 10, width: 80, height: 80 },
-        style: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
-        content: '',
-        zIndex: 1000,
-        rotation: 0,
-        fontScale: 1,
-        enableHtmlRendering: false,
-      }] : []),
-      ...(csvHeaders || [])
+    // Add page images
+    (pageTemplate.images || []).forEach(image => {
+        if (!image.visible) return;
+        elements.push({
+            id: image.id,
+            type: 'image',
+            position: image,
+            style: { ...image.filters, ...image },
+            content: image.src || '',
+            zIndex: image.zIndex || 0,
+            rotation: image.rotation || 0,
+            fontScale: 1,
+            enableHtmlRendering: false,
+        });
+    });
+
+    // Add cropbox if needed (for the first image for now)
+    const firstImage = pageTemplate.images?.[0];
+    if (isCropping && firstImage) {
+        elements.push({
+            id: '__cropbox__',
+            type: 'cropbox',
+            position: firstImage.crop || { x: 10, y: 10, width: 80, height: 80 },
+            style: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
+            content: '',
+            zIndex: 1000, // Should be on top of everything
+            rotation: 0,
+            fontScale: 1,
+            enableHtmlRendering: false,
+        });
+    }
+
+    // Add text fields
+    (csvHeaders || [])
         .map(header => {
           const position = fieldPositions[header];
           const style = completeFieldStyles[header];
@@ -311,7 +329,7 @@ const FieldPositioner = ({
           const record = csvData[currentPreviewIndex] || {};
           const sampleData = record[header] !== undefined ? record[header] : `[${header}]`;
 
-          return {
+          elements.push({
             id: header,
             type: 'text',
             position,
@@ -321,13 +339,13 @@ const FieldPositioner = ({
             rotation: position.rotation,
             fontScale: fontScale,
             enableHtmlRendering: isHtmlField(header),
-          };
-        })
-        .filter(Boolean),
-      ...(brandElements || [])
-        .map(element => {
-          if (element.visible === false) return null;
-          return {
+          });
+        });
+
+    // Add brand elements
+    (brandElements || []).forEach(element => {
+          if (element.visible === false) return;
+          elements.push({
             id: element.id,
             type: 'image',
             position: element,
@@ -337,14 +355,12 @@ const FieldPositioner = ({
             rotation: element.rotation,
             fontScale: 1,
             enableHtmlRendering: false,
-          };
-        })
-        .filter(Boolean)
-    ];
+          });
+        });
 
     elements.sort((a, b) => (a.zIndex || 0) - (b.zIndex || 0));
     return elements;
-  }, [backgroundElement, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
+  }, [pageTemplate, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
   return (
     <Box>
@@ -354,7 +370,7 @@ const FieldPositioner = ({
           className="text-container"
               sx={{
                 border: '2px solid #ddd',
-                backgroundColor: pageState?.backgroundColor || '#FFFFFF',
+                background: pageTemplate.gradient ? pageTemplate.gradient : pageTemplate.backgroundColor || '#FFFFFF',
                 position: 'relative', // Needed for absolute positioning of children
                 cursor: 'default',
                 touchAction: 'pan-x pan-y',
@@ -381,19 +397,19 @@ const FieldPositioner = ({
                     }}
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
-                        setSelectedField('__background__');
+                        setSelectedField(null); // Deselect all
                       }
                     }}
                     onTouchStart={(e) => {
                       if (e.target === e.currentTarget) {
-                        setSelectedField('__background__');
+                        setSelectedField(null); // Deselect all
                       }
                     }}
                   >
                     {renderableElements.map(element => (
                       <DraggableElement
                         key={element.id}
-                        element={element.type === 'image' || element.type === 'background' || element.type === 'cropbox' ? { ...element.position, type: element.type } : { id: element.id, type: 'text' }}
+                        element={{ ...element.position, type: element.type, id: element.id }}
                         position={element.position}
                         style={element.style}
                         content={element.content}

--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -7,6 +7,7 @@ const FormattingDrawer = ({
   open,
   onClose,
   selectedField,
+  setSelectedField,
   fieldStyles,
   initialFieldStyles,
   setFieldStyles,
@@ -15,8 +16,8 @@ const FormattingDrawer = ({
   csvHeaders,
   brandElements,
   setBrandElements,
-  backgroundElement,
-  setBackgroundElement,
+  pageTemplate,
+  setPageTemplate,
   onZIndexChange,
   onDeselectField,
   onOpenHtmlEditor,
@@ -37,6 +38,7 @@ const FormattingDrawer = ({
         </Box>
         <FormattingPanel
           selectedField={selectedField}
+          setSelectedField={setSelectedField}
           fieldStyles={fieldStyles}
           initialFieldStyles={initialFieldStyles}
           setFieldStyles={setFieldStyles}
@@ -45,8 +47,8 @@ const FormattingDrawer = ({
           csvHeaders={csvHeaders}
           brandElements={brandElements}
           setBrandElements={setBrandElements}
-          backgroundElement={backgroundElement}
-          setBackgroundElement={setBackgroundElement}
+          pageTemplate={pageTemplate}
+          setPageTemplate={setPageTemplate}
           onZIndexChange={onZIndexChange}
           onDeselectField={onDeselectField}
           onOpenHtmlEditor={onOpenHtmlEditor}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -45,21 +45,21 @@ import {
   AspectRatio,
   Tune,
   CheckBoxOutlineBlank,
-  FormatLineSpacing
+  FormatLineSpacing,
+  Delete
 } from '@mui/icons-material';
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 
 import { BrandingWatermark, Edit } from '@mui/icons-material';
 import BrandElementManager from './BrandElementManager';
-import BackgroundColorEditor from './BackgroundColorEditor'; // Importar o novo componente
+import BackgroundColorEditor from './BackgroundColorEditor';
 
-// Helper function to convert an RGB color string to a hex string.
 const rgbStringToHex = (colorString) => {
   if (!colorString || !colorString.startsWith('rgb')) {
-    return colorString; // Return as is if not a valid rgb string.
+    return colorString;
   }
   const rgb = colorString.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
-  if (!rgb) return colorString; // Return original if parsing fails
+  if (!rgb) return colorString;
 
   const r = parseInt(rgb[1], 10);
   const g = parseInt(rgb[2], 10);
@@ -74,6 +74,7 @@ const rgbStringToHex = (colorString) => {
 
 const FormattingPanel = ({
   selectedField,
+  setSelectedField,
   fieldStyles,
   initialFieldStyles,
   setFieldStyles,
@@ -82,35 +83,27 @@ const FormattingPanel = ({
   csvHeaders,
   brandElements,
   setBrandElements,
-  backgroundElement,
-  setBackgroundElement,
+  pageTemplate,
+  setPageTemplate,
   onZIndexChange,
   onDeselectField,
   onOpenHtmlEditor,
   standardsColors,
-  pageState,
-  setPageState,
   templateFieldStyles,
   activeStep,
   isCropping,
   setIsCropping,
 }) => {
   const fonts = [
-    // Sans-serif
     'Arial', 'Helvetica', 'Verdana', 'Inter', 'Lato', 'Montserrat', 'Noto Sans',
     'Open Sans', 'Poppins', 'Raleway', 'Roboto', 'Source Sans Pro',
-    // Serif
     'Georgia', 'Times New Roman', 'Lora', 'Merriweather', 'Playfair Display', 'Roboto Slab',
-    // Display
     'Anton', 'Bebas Neue', 'Oswald', 'Impact',
-    // Handwriting
     'Caveat', 'Courgette', 'Dancing Script',
-    // Monospace
     'Courier New',
   ];
 
   const updateFieldStyle = (field, property, value) => {
-    // Per user feedback, all style updates should apply only to the selected field.
     setFieldStyles(prev => ({
       ...prev,
       [field]: { ...(prev[field] || {}), [property]: value }
@@ -121,135 +114,111 @@ const FormattingPanel = ({
     setFieldPositions(prev => ({ ...prev, [field]: { ...prev[field], [property]: value } }));
   };
 
-  const copyStyleToAll = (sourceField) => {
-    const sourceStyle = fieldStyles[sourceField];
-    if (!sourceStyle) return;
-    const newStyles = {};
-    csvHeaders.forEach(header => {
-      if (header !== sourceField) { newStyles[header] = { ...sourceStyle }; }
-    });
-    setFieldStyles(prev => ({ ...prev, ...newStyles }));
-  };
-
   const resetFieldStyle = (field) => {
     let styleToApply = null;
-
-    // Se estamos em um passo posterior à formatação (step 3), usamos o template salvo.
     if (activeStep > 3 && templateFieldStyles && Object.keys(templateFieldStyles).length > 0) {
       styleToApply = templateFieldStyles[field];
-      if (!styleToApply) {
-        console.warn(`[FormattingPanel] Estilo de template para o campo "${field}" não encontrado. Usando fallback para estilo inicial.`);
-      }
     }
-
-    // Se não aplicamos o estilo do template (ou se falhou), usamos o estilo inicial.
-    // Isso cobre o caso de estarmos no passo 3, ou o fallback do passo > 3.
     if (!styleToApply) {
       styleToApply = initialFieldStyles?.[field];
     }
-
     if (styleToApply) {
       setFieldStyles(prev => ({ ...prev, [field]: styleToApply }));
-    } else {
-      // Se nenhum estilo foi encontrado, loga um erro.
-      console.error(`[FormattingPanel] Nenhum estilo (inicial ou de template) encontrado para o campo "${field}". O reset não pode ser executado.`);
     }
   };
 
-  const updateBrandElementFilter = (elementId, filterProperty, value) => {
-    if (elementId === '__background__') {
-      setBackgroundElement(prev => ({
-        ...prev,
-        filters: { ...prev.filters, [filterProperty]: value },
-      }));
-    } else {
-      setBrandElements(prev =>
-        prev.map(el =>
-          el.id === elementId
-            ? { ...el, filters: { ...el.filters, [filterProperty]: value } }
-            : el
-        )
-      );
-    }
+  const updateImageElement = (elementId, property, value) => {
+    setPageTemplate(prev => {
+      const newImages = prev.images.map(img => {
+        if (img.id === elementId) {
+          return { ...img, [property]: value };
+        }
+        return img;
+      });
+      return { ...prev, images: newImages };
+    });
   };
 
-  const updateBackgroundElement = (property, value) => {
-    setBackgroundElement(prev => ({ ...prev, [property]: value }));
-  };
-
-  const updateBackgroundFilter = (filter, value) => {
-    setBackgroundElement(prev => ({
-      ...prev,
-      filters: { ...prev.filters, [filter]: value },
-    }));
+  const updateImageElementFilter = (elementId, filterProperty, value) => {
+    setPageTemplate(prev => {
+      const newImages = prev.images.map(img => {
+        if (img.id === elementId) {
+          return { ...img, filters: { ...(img.filters || {}), [filterProperty]: value } };
+        }
+        return img;
+      });
+      return { ...prev, images: newImages };
+    });
   };
 
   const [isTextField, setIsTextField] = React.useState(false);
   const [currentElement, setCurrentElement] = React.useState(null);
-  const [expandedPanel, setExpandedPanel] = React.useState(false);
+  const [expandedPanel, setExpandedPanel] = React.useState('pageSettings');
 
   const handleAccordionChange = (panel) => (event, isExpanded) => {
     setExpandedPanel(isExpanded ? panel : false);
   };
 
   React.useEffect(() => {
-    // Handles selection of any element, including the background
     if (selectedField) {
-      if (selectedField === '__background__') {
-        setCurrentElement(backgroundElement);
+      const imageEl = pageTemplate.images?.find(el => el.id === selectedField);
+      const brandEl = brandElements?.find(el => el.id === selectedField);
+
+      if (imageEl) {
+        setCurrentElement(imageEl);
         setIsTextField(false);
+      } else if (brandEl) {
+        const elementWithFilters = {
+          ...brandEl,
+          filters: brandEl.filters || { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 },
+        };
+        setCurrentElement(elementWithFilters);
+        setIsTextField(false);
+      } else if (fieldPositions[selectedField]) {
+        setCurrentElement({
+          ...fieldPositions[selectedField],
+          style: fieldStyles[selectedField] || {},
+        });
+        setIsTextField(true);
       } else {
-        const brandEl = brandElements?.find(el => el.id === selectedField);
-        if (brandEl) {
-          // Defensively add filters if they are missing
-          const elementWithFilters = {
-            ...brandEl,
-            filters: brandEl.filters || {
-              brightness: 100,
-              contrast: 100,
-              saturate: 100,
-              blur: 0,
-              opacity: 100,
-            },
-          };
-          setCurrentElement(elementWithFilters);
-          setIsTextField(false);
-        } else if (fieldPositions[selectedField]) {
-          setCurrentElement({
-            ...fieldPositions[selectedField],
-            style: fieldStyles[selectedField] || {},
-          });
-          setIsTextField(true);
-        } else {
-          setCurrentElement(null);
-        }
+        setCurrentElement(null);
       }
     } else {
       setCurrentElement(null);
     }
-  }, [selectedField, fieldPositions, fieldStyles, brandElements, backgroundElement]);
+  }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
 
   const handlePositionPropertyChange = (property, value) => {
     const numericValue = parseFloat(value);
     if (isNaN(numericValue)) return;
 
-    if (selectedField === '__background__') {
-      setBackgroundElement(prev => ({ ...prev, [property]: numericValue }));
-    } else if (isTextField) {
+    if (isTextField) {
       updateFieldPosition(selectedField, property, numericValue);
     } else {
-      setBrandElements(prev =>
-        prev.map(el =>
-          el.id === selectedField ? { ...el, [property]: numericValue } : el
-        )
-      );
+      const isBrandEl = brandElements.some(el => el.id === selectedField);
+      if (isBrandEl) {
+         setBrandElements(prev =>
+          prev.map(el =>
+            el.id === selectedField ? { ...el, [property]: numericValue } : el
+          )
+        );
+      } else {
+        updateImageElement(selectedField, property, numericValue);
+      }
     }
   };
 
-  const handleDeleteBrandElement = (elementId) => {
-    setBrandElements(prev => prev.filter(el => el.id !== elementId));
-    // Also deselect the element
-    setCurrentElement(null);
+  const handleDeleteElement = (elementId) => {
+    const isBrandEl = brandElements.some(el => el.id === elementId);
+    if (isBrandEl) {
+      setBrandElements(prev => prev.filter(el => el.id !== elementId));
+    } else {
+      setPageTemplate(prev => ({
+        ...prev,
+        images: prev.images.filter(img => img.id !== elementId)
+      }));
+    }
+
     if (onDeselectField) {
       onDeselectField();
     }
@@ -258,11 +227,43 @@ const FormattingPanel = ({
   return (
     <Card>
       <CardContent>
+        <Accordion expanded={expandedPanel === 'pageSettings'} onChange={handleAccordionChange('pageSettings')}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="subtitle1">🎨 Cor de Fundo</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <BackgroundColorEditor
+              pageTemplate={pageTemplate}
+              onUpdate={setPageTemplate}
+            />
+          </AccordionDetails>
+        </Accordion>
+
+        <Accordion expanded={expandedPanel === 'images'} onChange={handleAccordionChange('images')}>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="subtitle1">🖼️ Imagens</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            {(pageTemplate.images || []).map(image => (
+              <Box key={image.id} onClick={() => setSelectedField(image.id)} sx={{ cursor: 'pointer', p: 1, mb: 1, border: selectedField === image.id ? '2px solid' : '1px solid', borderColor: selectedField === image.id ? 'primary.main' : 'divider', borderRadius: 1 }}>
+                 <img src={image.src} width="100%" alt="template" />
+                 <IconButton size="small" color="error" onClick={(e) => { e.stopPropagation(); handleDeleteElement(image.id); }}>
+                    <Delete />
+                 </IconButton>
+              </Box>
+            ))}
+            {(!pageTemplate.images || pageTemplate.images.length === 0) && (
+                <Typography variant="body2" color="textSecondary">Nenhuma imagem adicionada.</Typography>
+            )}
+          </AccordionDetails>
+        </Accordion>
+
         {currentElement ? (
           <>
+            <Divider sx={{ my: 2 }} />
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
               <Chip
-                label={selectedField}
+                label={isTextField ? selectedField : 'Imagem Selecionada'}
                 color="primary"
                 sx={{ mr: 2 }}
               />
@@ -275,10 +276,7 @@ const FormattingPanel = ({
                       if (isTextField) {
                         updateFieldPosition(selectedField, 'visible', isVisible);
                       } else {
-                        // For brand elements, hiding means deleting.
-                        if (!isVisible) {
-                          handleDeleteBrandElement(selectedField);
-                        }
+                        updateImageElement(selectedField, 'visible', isVisible);
                       }
                     }}
                     size="small"
@@ -607,97 +605,58 @@ const FormattingPanel = ({
                 </Grid>
               </>
             ) : (
-              <Box>
-                {/* Brand Element specific controls will go here, if any, in the future */}
-                {selectedField !== '__background__' && (
-                  <Button variant="outlined" color="error" size="small" onClick={() => handleDeleteBrandElement(selectedField)} sx={{ mt: 2 }} fullWidth>
-                    Excluir Elemento
+              <>
+                <Accordion expanded={expandedPanel === 'imageFilters'} onChange={handleAccordionChange('imageFilters')}>
+                  <AccordionSummary expandIcon={<ExpandMore />}>
+                    <Typography variant="subtitle1">🖼️ Filtros</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Typography gutterBottom>Brilho: {currentElement.filters?.brightness ?? 100}%</Typography>
+                    <Slider value={currentElement.filters?.brightness ?? 100} onChange={(e, v) => updateImageElementFilter(selectedField, 'brightness', v)} min={0} max={200} step={1} />
+                    <Typography gutterBottom>Contraste: {currentElement.filters?.contrast ?? 100}%</Typography>
+                    <Slider value={currentElement.filters?.contrast ?? 100} onChange={(e, v) => updateImageElementFilter(selectedField, 'contrast', v)} min={0} max={200} step={1} />
+                    <Typography gutterBottom>Saturação: {currentElement.filters?.saturate ?? 100}%</Typography>
+                    <Slider value={currentElement.filters?.saturate ?? 100} onChange={(e, v) => updateImageElementFilter(selectedField, 'saturate', v)} min={0} max={200} step={1} />
+                    <Typography gutterBottom>Desfoque: {currentElement.filters?.blur ?? 0}px</Typography>
+                    <Slider value={currentElement.filters?.blur ?? 0} onChange={(e, v) => updateImageElementFilter(selectedField, 'blur', v)} min={0} max={20} step={1} />
+                    <Typography gutterBottom>Opacidade: {currentElement.filters?.opacity ?? 100}%</Typography>
+                    <Slider value={currentElement.filters?.opacity ?? 100} onChange={(e, v) => updateImageElementFilter(selectedField, 'opacity', v)} min={0} max={100} step={1} />
+                  </AccordionDetails>
+                </Accordion>
+
+                <Accordion expanded={expandedPanel === 'imageShadow'} onChange={handleAccordionChange('imageShadow')}>
+                  <AccordionSummary expandIcon={<ExpandMore />}>
+                    <Typography variant="subtitle1">🎨 Sombra</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <FormControlLabel
+                      control={<Switch checked={currentElement.shadow || false} onChange={(e) => updateImageElement(selectedField, 'shadow', e.target.checked)} size="small" />}
+                      label="Sombra na Imagem"
+                    />
+                    {currentElement.shadow && (
+                      <Grid container spacing={2} sx={{ mt: 1 }}>
+                        <Grid item xs={6}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.shadowColor || '#000000')} onChange={(e) => updateImageElement(selectedField, 'shadowColor', e.target.value)} fullWidth size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Desfoque</Typography><Slider value={currentElement.shadowBlur || 4} onChange={(e, v) => updateImageElement(selectedField, 'shadowBlur', v)} min={0} max={50} size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Offset X</Typography><Slider value={currentElement.shadowOffsetX || 2} onChange={(e, v) => updateImageElement(selectedField, 'shadowOffsetX', v)} min={-50} max={50} size="small" /></Grid>
+                        <Grid item xs={6}><Typography gutterBottom>Offset Y</Typography><Slider value={currentElement.shadowOffsetY || 2} onChange={(e, v) => updateImageElement(selectedField, 'shadowOffsetY', v)} min={-50} max={50} size="small" /></Grid>
+                      </Grid>
+                    )}
+                  </AccordionDetails>
+                </Accordion>
+
+                <Box sx={{ mt: 2 }}>
+                  <Button
+                    variant={isCropping ? "contained" : "outlined"}
+                    color="primary"
+                    onClick={() => setIsCropping(!isCropping)}
+                    fullWidth
+                  >
+                    {isCropping ? 'Salvar Corte' : 'Cortar Imagem'}
                   </Button>
-                )}
-              </Box>
+                </Box>
+              </>
             )}
 
-            {/* Background Specific Controls */}
-            {selectedField === '__background__' && currentElement && (() => {
-              const filters = currentElement.filters || { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100, highlightColor: '#FFFFFF', highlightAmount: 0 };
-              return (
-                <>
-                  {/* Cor de Fundo e Gradiente (Sempre visível para o fundo) */}
-                  <Accordion expanded={expandedPanel === 'backgroundColor'} onChange={handleAccordionChange('backgroundColor')}>
-                    <AccordionSummary expandIcon={<ExpandMore />}>
-                      <Typography variant="subtitle1">🎨 Cor de Fundo da Página</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <BackgroundColorEditor
-                        backgroundElement={currentElement}
-                        onUpdate={setBackgroundElement}
-                        pageState={pageState}
-                        onPageStateUpdate={setPageState}
-                      />
-                    </AccordionDetails>
-                  </Accordion>
-
-                  {/* Controles que só aparecem se houver uma imagem de fundo */}
-                  {currentElement.src && (
-                    <>
-                      {/* Filtros da Imagem de Fundo */}
-                      <Accordion expanded={expandedPanel === 'backgroundFilters'} onChange={handleAccordionChange('backgroundFilters')}>
-                        <AccordionSummary expandIcon={<ExpandMore />}>
-                          <Typography variant="subtitle1">🖼️ Filtros da Imagem</Typography>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                          <Typography gutterBottom>Brilho: {filters.brightness}%</Typography>
-                          <Slider value={filters.brightness} onChange={(e, v) => updateBackgroundFilter('brightness', v)} min={0} max={200} step={1} />
-                          <Typography gutterBottom>Contraste: {filters.contrast}%</Typography>
-                          <Slider value={filters.contrast} onChange={(e, v) => updateBackgroundFilter('contrast', v)} min={0} max={200} step={1} />
-                          <Typography gutterBottom>Saturação: {filters.saturate}%</Typography>
-                          <Slider value={filters.saturate} onChange={(e, v) => updateBackgroundFilter('saturate', v)} min={0} max={200} step={1} />
-                          <Typography gutterBottom>Desfoque: {filters.blur}px</Typography>
-                          <Slider value={filters.blur} onChange={(e, v) => updateBackgroundFilter('blur', v)} min={0} max={20} step={1} />
-                          <Typography gutterBottom>Opacidade: {filters.opacity}%</Typography>
-                          <Slider value={filters.opacity} onChange={(e, v) => updateBackgroundFilter('opacity', v)} min={0} max={100} step={1} />
-                        </AccordionDetails>
-                      </Accordion>
-
-                      {/* Sombra da Imagem de Fundo */}
-                      <Accordion expanded={expandedPanel === 'backgroundShadow'} onChange={handleAccordionChange('backgroundShadow')}>
-                        <AccordionSummary expandIcon={<ExpandMore />}>
-                          <Typography variant="subtitle1">🎨 Sombra da Imagem</Typography>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                          <FormControlLabel
-                            control={<Switch checked={currentElement.shadow || false} onChange={(e) => updateBackgroundElement('shadow', e.target.checked)} size="small" />}
-                            label="Sombra na Imagem"
-                          />
-                          {currentElement.shadow && (
-                            <Grid container spacing={2} sx={{ mt: 1 }}>
-                              <Grid item xs={6}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.shadowColor || '#000000')} onChange={(e) => updateBackgroundElement('shadowColor', e.target.value)} fullWidth size="small" /></Grid>
-                              <Grid item xs={6}><Typography gutterBottom>Desfoque: {currentElement.shadowBlur || 4}px</Typography><Slider value={currentElement.shadowBlur || 4} onChange={(e, v) => updateBackgroundElement('shadowBlur', v)} min={0} max={50} size="small" /></Grid>
-                              <Grid item xs={6}><Typography gutterBottom>Offset X: {currentElement.shadowOffsetX || 2}px</Typography><Slider value={currentElement.shadowOffsetX || 2} onChange={(e, v) => updateBackgroundElement('shadowOffsetX', v)} min={-50} max={50} size="small" /></Grid>
-                              <Grid item xs={6}><Typography gutterBottom>Offset Y: {currentElement.shadowOffsetY || 2}px</Typography><Slider value={currentElement.shadowOffsetY || 2} onChange={(e, v) => updateBackgroundElement('shadowOffsetY', v)} min={-50} max={50} size="small" /></Grid>
-                            </Grid>
-                          )}
-                        </AccordionDetails>
-                      </Accordion>
-
-                      {/* Cortar Imagem */}
-                      <Box sx={{ mt: 2 }}>
-                        <Button
-                          variant={isCropping ? "contained" : "outlined"}
-                          color="primary"
-                          onClick={() => setIsCropping(!isCropping)}
-                          fullWidth
-                        >
-                          {isCropping ? 'Salvar Corte' : 'Cortar Imagem'}
-                        </Button>
-                      </Box>
-                    </>
-                  )}
-                </>
-              );
-            })()}
-
-            {/* Common Controls for all elements */}
             <Accordion expanded={expandedPanel === 'positionSize'} onChange={handleAccordionChange('positionSize')}>
               <AccordionSummary expandIcon={<ExpandMore />}>
                 <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center' }}>
@@ -817,27 +776,24 @@ const FormattingPanel = ({
           </>
         ) : (
           <Typography variant="h6" color="textSecondary" align="center" gutterBottom sx={{ mt: 4 }}>
-            Selecione um elemento para editar suas propriedades
+            Selecione uma imagem ou campo de texto para editar.
           </Typography>
         )}
 
         <Divider sx={{ my: 2 }} />
 
-        {/* Brand Elements */}
         <Accordion expanded={expandedPanel === 'brandElements'} onChange={handleAccordionChange('brandElements')}>
           <AccordionSummary expandIcon={<ExpandMore />}>
-            <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography variant="subtitle1">
               <BrandingWatermark sx={{ mr: 1 }} /> Elementos da Marca
             </Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-              <BrandElementManager
-                onElementSelect={(newElement) => {
-                  setBrandElements(prev => [...prev, newElement]);
-                }}
-              />
-            </Box>
+            <BrandElementManager
+              onElementSelect={(newElement) => {
+                setBrandElements(prev => [...prev, newElement]);
+              }}
+            />
           </AccordionDetails>
         </Accordion>
       </CardContent>

--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -45,10 +45,8 @@ const ImageStep = ({
   originalImageSize,
   brandElements,
   setBrandElements,
-  backgroundElement,
-  setBackgroundElement,
-  pageState,
-  setPageState,
+  pageTemplate,
+  setPageTemplate,
   onZIndexChange,
   isMobile,
   selectedField,
@@ -61,7 +59,7 @@ const ImageStep = ({
   templateFieldStyles,
   activeStep,
 }) => {
-  console.log('[ImageStep] props:', { backgroundElement, fieldStyles });
+  console.log('[ImageStep] props:', { pageTemplate, fieldStyles });
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [fontScale, setFontScale] = useState(1);
   const [isCropping, setIsCropping] = useState(false);
@@ -122,9 +120,8 @@ const ImageStep = ({
             originalImageSize={originalImageSize}
             brandElements={brandElements}
             setBrandElements={setBrandElements}
-            backgroundElement={backgroundElement}
-            setBackgroundElement={setBackgroundElement}
-            pageState={pageState}
+            pageTemplate={pageTemplate}
+            setPageTemplate={setPageTemplate}
             onZIndexChange={onZIndexChange}
             onOpenHtmlEditor={onOpenHtmlEditor}
             currentPreviewIndex={currentPreviewIndex}
@@ -175,6 +172,7 @@ const ImageStep = ({
             </Box>
             <FormattingPanel
               selectedField={selectedField}
+              setSelectedField={setSelectedField}
               fieldStyles={fieldStyles}
               initialFieldStyles={initialFieldStyles}
               setFieldStyles={setFieldStyles}
@@ -183,14 +181,12 @@ const ImageStep = ({
               csvHeaders={csvHeaders}
               brandElements={brandElements}
               setBrandElements={setBrandElements}
-              backgroundElement={backgroundElement}
-              setBackgroundElement={setBackgroundElement}
+              pageTemplate={pageTemplate}
+              setPageTemplate={setPageTemplate}
               onZIndexChange={onZIndexChange}
               onDeselectField={onDeselectField}
               onOpenHtmlEditor={onOpenHtmlEditor}
               standardsColors={standardsColors}
-              pageState={pageState}
-              setPageState={setPageState}
               fontScale={fontScale}
               templateFieldStyles={templateFieldStyles}
               activeStep={activeStep}
@@ -206,7 +202,7 @@ const ImageStep = ({
         <>
           <Fab color="primary" aria-label="edit" sx={{ position: 'fixed', bottom: 16, right: 16, zIndex: 1300 }} onClick={() => {
             if (!selectedField) {
-              setSelectedField('__background__');
+              setSelectedField(pageTemplate.images[0]?.id || '__background__');
             }
             setIsDrawerOpen(true);
           }}><EditIcon /></Fab>
@@ -214,6 +210,7 @@ const ImageStep = ({
             open={isDrawerOpen}
             onClose={() => setIsDrawerOpen(false)}
             selectedField={selectedField}
+            setSelectedField={setSelectedField}
             fieldStyles={fieldStyles}
             initialFieldStyles={initialFieldStyles}
             setFieldStyles={setFieldStyles}
@@ -222,8 +219,8 @@ const ImageStep = ({
             csvHeaders={csvHeaders}
             brandElements={brandElements}
             setBrandElements={setBrandElements}
-            backgroundElement={backgroundElement}
-            setBackgroundElement={setBackgroundElement}
+            pageTemplate={pageTemplate}
+            setPageTemplate={setPageTemplate}
             onZIndexChange={onZIndexChange}
             onDeselectField={onDeselectField}
             onOpenHtmlEditor={onOpenHtmlEditor}

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -59,7 +59,7 @@ const PageEditor = ({
   originalImageSize,
   brandElements,
   standardsColors,
-  globalBackgroundElement,
+  globalPageTemplate,
   aspectRatio,
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
@@ -77,38 +77,7 @@ const PageEditor = ({
     setEditingField(fieldId);
   };
 
-  // Local state for image filters and toggles
-  const defaultFilters = { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 };
-  const [editedBackgroundElement, setEditedBackgroundElement] = useState(null);
-
-  // Definir um objeto de fundo padrão mais abrangente
-  const defaultBackground = {
-    id: 'background',
-    x: 0,
-    y: 0,
-    width: 100,
-    height: 100,
-    rotation: 0,
-    visible: true,
-    filters: defaultFilters,
-    crop: null,
-    shadow: false,
-    shadowColor: '#000000',
-    shadowBlur: 10,
-    shadowOffsetX: 0,
-    shadowOffsetY: 5,
-    // Novas propriedades para cor de fundo e gradiente
-    backgroundType: 'image', // 'image', 'color', 'gradient'
-    backgroundColor: 'rgba(255, 255, 255, 0)', // Cor sólida de fundo
-    gradient: {
-      type: 'linear', // 'linear' ou 'radial'
-      angle: 90,
-      stops: [
-        { color: 'rgba(255, 255, 255, 0)', position: 0 },
-        { color: 'rgba(0, 0, 0, 0)', position: 100 },
-      ],
-    },
-  };
+  const [editedPageTemplate, setEditedPageTemplate] = useState(null);
 
   const handleInternalFieldSelection = useCallback((fieldToSelect) => {
     setSelectedFieldInternal(fieldToSelect);
@@ -185,32 +154,14 @@ const PageEditor = ({
       setEditedStyles(newEditedStyles);
       setStylesAreInitialized(true);
 
-      // Lógica de merge aprimorada para o elemento de fundo
-      const backgroundToUse = {
-        ...defaultBackground,
-        ...(globalBackgroundElement || {}),
-        ...(pageData.customBackgroundElement || {}),
-        // Garante que os objetos aninhados (filters, gradient) sejam mesclados corretamente
-        filters: {
-          ...defaultBackground.filters,
-          ...(globalBackgroundElement?.filters || {}),
-          ...(pageData.customBackgroundElement?.filters || {}),
-        },
-        gradient: {
-          ...defaultBackground.gradient,
-          ...(globalBackgroundElement?.gradient || {}),
-          ...(pageData.customBackgroundElement?.gradient || {}),
-          // Garante uma cópia profunda do array de stops para evitar mutações indesejadas
-          stops: (pageData.customBackgroundElement?.gradient?.stops || globalBackgroundElement?.gradient?.stops || defaultBackground.gradient.stops).map(stop => ({ ...stop })),
-        }
-      };
+      const templateToUse = pageData.customPageTemplate || globalPageTemplate;
+      setEditedPageTemplate(JSON.parse(JSON.stringify(templateToUse))); // Deep copy
 
-      setEditedBackgroundElement(backgroundToUse);
-      setFontScale(pageData.fontScale || 1); // Initialize font scale from pageData
+      setFontScale(pageData.fontScale || 1);
     } else {
       setStylesAreInitialized(false);
     }
-  }, [open, pageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, brandElements, globalBackgroundElement]);
+  }, [open, pageData, initialFieldPositions, initialFieldStyles, globalCsvHeaders, brandElements, globalPageTemplate]);
 
   if (!pageData) {
     return null;
@@ -231,7 +182,7 @@ const PageEditor = ({
       fieldStyles: editedStyles,
       brandElements: editedBrandElements,
       fontScale: fontScale,
-      customBackgroundElement: editedBackgroundElement,
+      customPageTemplate: editedPageTemplate,
     };
     onSave(savedData);
     onClose();
@@ -280,8 +231,8 @@ const PageEditor = ({
               onFontScaleChange={setFontScale}
               brandElements={editedBrandElements}
               setBrandElements={setEditedBrandElements}
-              backgroundElement={editedBackgroundElement}
-              setBackgroundElement={setEditedBackgroundElement}
+              pageTemplate={editedPageTemplate}
+              setPageTemplate={setEditedPageTemplate}
               currentPreviewIndex={0}
             />
           </Grid>
@@ -294,8 +245,8 @@ const PageEditor = ({
                 fieldPositions={editedPositions}
                 setFieldPositions={setEditedPositions}
                 csvHeaders={editorCsvHeaders}
-                backgroundElement={editedBackgroundElement}
-                setBackgroundElement={setEditedBackgroundElement}
+                pageTemplate={editedPageTemplate}
+                setPageTemplate={setEditedPageTemplate}
                 brandElements={editedBrandElements}
                 setBrandElements={setEditedBrandElements}
                 onDeselectField={handleDeselectField}
@@ -334,8 +285,8 @@ const PageEditor = ({
             setFieldPositions={setEditedPositions}
             csvHeaders={editorCsvHeaders}
             onOpenHtmlEditor={handleOpenHtmlEditor}
-            backgroundElement={editedBackgroundElement}
-            setBackgroundElement={setEditedBackgroundElement}
+            pageTemplate={editedPageTemplate}
+            setPageTemplate={setEditedPageTemplate}
             brandElements={editedBrandElements}
             setBrandElements={setEditedBrandElements}
             fontScale={fontScale}

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -58,8 +58,9 @@ const PageGeneratorFrontendOnly = ({
   fontScale = 1,
   standardsColors,
   handleGenerateSinglePage, // Nova prop
-  backgroundElement,
+  pageTemplate,
   aspectRatio,
+  generatedPagesData,
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -79,8 +80,8 @@ const PageGeneratorFrontendOnly = ({
   const [fontsLoaded, setFontsLoaded] = useState(false);
 
   useEffect(() => {
-    console.log('[PageGeneratorFrontendOnly] PROPS RECEIVED', { fieldStyles, backgroundElement });
-  }, [fieldStyles, backgroundElement]);
+    console.log('[PageGeneratorFrontendOnly] PROPS RECEIVED', { fieldStyles, pageTemplate });
+  }, [fieldStyles, pageTemplate]);
 
   useEffect(() => {
     const loadFonts = async () => {
@@ -116,14 +117,12 @@ const PageGeneratorFrontendOnly = ({
           const stylesToUse = pageData.customFieldStyles || fieldStyles;
           const elementsToUse = pageData.customBrandElements !== undefined ? pageData.customBrandElements : brandElements;
 
-          // The source of truth for the background is the element object.
-          // It may have a custom `src` if the user replaced the background for that specific page.
-          const backgroundElementToUse = pageData.customBackgroundElement || backgroundElement;
+          const pageTemplateToUse = pageData.customPageTemplate || pageTemplate;
 
           return composeSingleImage({
             record: pageData.record,
             index: pageData.index,
-            backgroundElement: backgroundElementToUse,
+            pageTemplate: pageTemplateToUse,
             brandElements: elementsToUse,
             fieldPositions: positionsToUse,
             fieldStyles: stylesToUse,
@@ -152,7 +151,7 @@ const PageGeneratorFrontendOnly = ({
 
       regenerateMissingThumbnails();
     }
-  }, [initialGeneratedPagesData, fontsLoaded, fieldPositions, fieldStyles, backgroundElement, brandElements, setGeneratedPagesData]);
+  }, [initialGeneratedPagesData, fontsLoaded, fieldPositions, fieldStyles, pageTemplate, brandElements, setGeneratedPagesData]);
 
 
   const generatePages = async () => {
@@ -163,8 +162,8 @@ const PageGeneratorFrontendOnly = ({
       return;
     }
 
-    if (!backgroundElement?.src) {
-      alert('Por favor, carregue uma imagem de fundo global para a campanha.');
+    if (!pageTemplate.images || pageTemplate.images.length === 0) {
+      alert('Por favor, adicione pelo menos uma imagem ao modelo de página.');
       return;
     }
     if (csvData.length === 0) {
@@ -183,8 +182,6 @@ const PageGeneratorFrontendOnly = ({
     const pagePromises = csvData.map((record, i) => {
       if (isCancelledRef.current) return Promise.resolve(null);
 
-      // For the first generation, we only use the global background element.
-      // Per-page customizations happen in the editor.
       return composeSingleImage({
         record,
         index: i,
@@ -192,7 +189,7 @@ const PageGeneratorFrontendOnly = ({
         fieldPositions,
         fieldStyles,
         fontScale,
-        backgroundElement: backgroundElement, // Pass the global element
+        pageTemplate: pageTemplate,
         aspectRatio,
       })
       .then(pageData => {
@@ -250,22 +247,41 @@ const PageGeneratorFrontendOnly = ({
 
   const handleCancelGeneration = () => { isCancelledRef.current = true; };
 
-  const handleResetPage = (index) => {
-    const pageToReset = initialGeneratedPagesData.find(img => img.index === index);
-    if (pageToReset && backgroundElement?.src) {
-      // Use a cópia mais recente dos estilos/posições globais, não os customizados.
-      regenerateSinglePage(
-        index,
-        pageToReset.record,
-        backgroundElement, // Passa o elemento de fundo global
-        fieldPositions, // Usando as posições de campo globais
-        fieldStyles, // Usando os estilos de campo globais
-        originalImageSize,
-        brandElements,
-        fontScale
-      );
+  const handleResetPage = async (index) => {
+    const pageToUpdate = generatedPagesData.find(p => p.index === index);
+    if (!pageToUpdate) return;
+
+    const templateFirstImage = pageTemplate.images?.[0];
+    if (!templateFirstImage) {
+        alert("Não há imagem no modelo para resetar.");
+        return;
+    }
+
+    const customPageTemplate = pageToUpdate.customPageTemplate || pageTemplate;
+    let newImages = [...(customPageTemplate.images || [])];
+
+    if (newImages.length > 0) {
+        newImages[0] = { ...templateFirstImage };
     } else {
-      alert("Não foi possível resetar a página. A imagem de fundo principal não está disponível.");
+        newImages.push({ ...templateFirstImage });
+    }
+
+    const newPageTemplate = { ...customPageTemplate, images: newImages };
+
+    try {
+        const newPageImageData = await regenerateSinglePage(
+            index,
+            pageToUpdate.record,
+            newPageTemplate,
+            pageToUpdate.customFieldPositions || fieldPositions,
+            pageToUpdate.customFieldStyles || fieldStyles,
+            null,
+            pageToUpdate.customBrandElements || brandElements,
+            pageToUpdate.fontScale || 1
+        );
+        setGeneratedPagesData(prev => prev.map(p => p.index === index ? { ...p, ...newPageImageData, customPageTemplate: newPageTemplate } : p));
+    } catch (error) {
+        toast.error(`Falha ao resetar a página: ${error.message}`);
     }
   };
 
@@ -329,39 +345,25 @@ const PageGeneratorFrontendOnly = ({
   };
 
   const handleSaveIndividualModifications = async (modifiedPageData) => {
-    const { index: pageIndex } = modifiedPageData;
+    const { index: pageIndex, customPageTemplate } = modifiedPageData;
     handleCloseGeneratedPageEditor();
 
     try {
-      const backgroundToUse = modifiedPageData.customBackgroundElement || backgroundElement;
-
-      const newPageImageData = await regenerateSinglePage(
-        pageIndex,
-        modifiedPageData.record,
-        backgroundToUse,
-        modifiedPageData.fieldPositions,
-        modifiedPageData.fieldStyles,
-        null,
-        modifiedPageData.brandElements,
-        1
-      );
+       const newPageImageData = await composeSingleImage({
+            record: modifiedPageData.record,
+            index: pageIndex,
+            pageTemplate: customPageTemplate,
+            brandElements: modifiedPageData.brandElements,
+            fieldPositions: modifiedPageData.fieldPositions,
+            fieldStyles: modifiedPageData.fieldStyles,
+            fontScale: modifiedPageData.fontScale,
+            aspectRatio,
+        });
 
       setGeneratedPagesData(currentPages =>
-        currentPages.map(page => {
-          if (page.index !== pageIndex) {
-            return page;
-          }
-          return {
-            ...page,
-            record: modifiedPageData.record,
-            customFieldPositions: modifiedPageData.fieldPositions,
-            customFieldStyles: modifiedPageData.fieldStyles,
-            customBrandElements: modifiedPageData.brandElements,
-            fontScale: modifiedPageData.fontScale,
-            customBackgroundElement: modifiedPageData.customBackgroundElement,
-            ...newPageImageData,
-          };
-        })
+        currentPages.map(page =>
+            page.index === pageIndex ? { ...page, ...modifiedPageData, ...newPageImageData } : page
+        )
       );
 
       if (onThumbnailRecordTextUpdate) {
@@ -373,16 +375,15 @@ const PageGeneratorFrontendOnly = ({
     }
   };
 
-  const regenerateSinglePage = async (index, record, backgroundElementToUse, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
-    if (!backgroundElementToUse?.src || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
-      console.error('Pré-requisitos para regeneração não atendidos. Fontes, dados ou configurações faltando.');
+  const regenerateSinglePage = async (index, record, pageTemplateToUse, positionsToUse, stylesToUse, customSize = null, elementsToUse = brandElements, fontScale = 1) => {
+    if (!pageTemplateToUse || !record || !positionsToUse || !stylesToUse || !fontsLoaded) {
+      console.error('Pré-requisitos para regeneração não atendidos.');
       throw new Error('Pré-requisitos para regeneração não atendidos.');
     }
-    // This function is now pure and returns the data, it does not set state.
     return composeSingleImage({
       record,
       index,
-      backgroundElement: backgroundElementToUse,
+      pageTemplate: pageTemplateToUse,
       brandElements: elementsToUse,
       fieldPositions: positionsToUse,
       fieldStyles: stylesToUse,
@@ -400,52 +401,46 @@ const PageGeneratorFrontendOnly = ({
 
   const handleIndividualImageUpload = (event) => {
     const file = event.target.files[0];
-    if (file && replacingImageIndex !== null) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const newBgUrl = e.target.result;
-        const pageToUpdate = initialGeneratedPagesData.find(img => img.index === replacingImageIndex);
-        if (pageToUpdate) {
-          // Clone the existing background element (custom or global) and just update the source.
-          // This preserves all other properties like filters, shadows, etc.
-          const baseElement = pageToUpdate.customBackgroundElement || backgroundElement;
-          const newBackgroundElement = {
-            ...baseElement,
-            src: newBgUrl,
-          };
+    if (!file || replacingImageIndex === null) return;
 
-          // Regenerate the page with the new background element object.
-          regenerateSinglePage(
-            replacingImageIndex,
-            pageToUpdate.record,
-            newBackgroundElement, // Pass the correct object
-            pageToUpdate.customFieldPositions || fieldPositions,
-            pageToUpdate.customFieldStyles || fieldStyles,
-            null, // Let composer determine size from new image
-            pageToUpdate.customBrandElements || brandElements,
-            fontScale
-          ).then(newlyGeneratedPage => {
-             // After regeneration, update the state
-             setGeneratedPagesData(currentPages => currentPages.map(p => {
-               if (p.index === replacingImageIndex) {
-                 // We need to merge the new URL/blob with the existing data,
-                 // and critically, store the new custom background element.
-                 return {
-                   ...p,
-                   ...newlyGeneratedPage,
-                   customBackgroundElement: newBackgroundElement,
-                 };
-               }
-               return p;
-             }));
-          }).catch(error => {
-            console.error(`Error regenerating page ${replacingImageIndex} with new background:`, error);
-            alert(`Falha ao substituir o fundo da página: ${error.message}`);
-          });
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+        const newImageUrl = e.target.result;
+        const pageToUpdate = generatedPagesData.find(p => p.index === replacingImageIndex);
+        if (!pageToUpdate) return;
+
+        const customPageTemplate = pageToUpdate.customPageTemplate || pageTemplate;
+        let newImages = [...(customPageTemplate.images || [])];
+        const newImageElement = { ...(pageTemplate.images[0] || {}), src: newImageUrl, id: `img_${Date.now()}` };
+
+        if (newImages.length > 0) {
+            newImages[0] = newImageElement;
+        } else {
+            newImageElement.width = 100;
+            newImageElement.height = 100;
+            newImages.push(newImageElement);
         }
-      };
-      reader.readAsDataURL(file);
-    }
+
+        const newPageTemplate = { ...customPageTemplate, images: newImages };
+
+        try {
+            const newPageImageData = await regenerateSinglePage(
+                replacingImageIndex,
+                pageToUpdate.record,
+                newPageTemplate,
+                pageToUpdate.customFieldPositions || fieldPositions,
+                pageToUpdate.customFieldStyles || fieldStyles,
+                null,
+                pageToUpdate.customBrandElements || brandElements,
+                pageToUpdate.fontScale || 1
+            );
+            setGeneratedPagesData(prev => prev.map(p => p.index === replacingImageIndex ? { ...p, ...newPageImageData, customPageTemplate: newPageTemplate } : p));
+        } catch (error) {
+            toast.error(`Falha ao substituir imagem: ${error.message}`);
+        }
+    };
+    reader.readAsDataURL(file);
+
     if (individualImageInputRef.current) {
       individualImageInputRef.current.value = "";
     }
@@ -519,11 +514,11 @@ const PageGeneratorFrontendOnly = ({
   };
 
   // Logic to determine props for the PageEditor
-  const pageToEdit = initialGeneratedPagesData.find(p => p.index === editingGeneratedPageIndex);
+  const pageToEdit = generatedPagesData.find(p => p.index === editingGeneratedPageIndex);
   const editorPositions = pageToEdit?.customFieldPositions || fieldPositions;
   const editorStyles = pageToEdit?.customFieldStyles || fieldStyles;
   const editorBrandElements = pageToEdit?.customBrandElements !== undefined ? pageToEdit.customBrandElements : brandElements;
-  const editorBackgroundElement = pageToEdit?.customBackgroundElement || backgroundElement;
+  const editorPageTemplate = pageToEdit?.customPageTemplate || pageTemplate;
 
   return (
     <Box sx={{ mt: 3 }}>
@@ -785,7 +780,7 @@ const PageGeneratorFrontendOnly = ({
         </DialogActions>
       </Dialog>
 
-      {console.log('[PageGeneratorFrontendOnly] rendering PageEditor with props:', { showGeneratedPageEditor, initialGeneratedPagesData, editingGeneratedPageIndex, csvHeaders, fieldPositions, fieldStyles, brandElements, colorPalette, originalImageSize, standardsColors, backgroundElement })}
+      {console.log('[PageGeneratorFrontendOnly] rendering PageEditor with props:', { showGeneratedPageEditor, generatedPagesData, editingGeneratedPageIndex, csvHeaders, fieldPositions, fieldStyles, brandElements, colorPalette, originalImageSize, standardsColors, pageTemplate })}
       <PageEditor
         open={showGeneratedPageEditor}
         onClose={handleCloseGeneratedPageEditor}
@@ -798,7 +793,7 @@ const PageGeneratorFrontendOnly = ({
         colorPalette={colorPalette}
         originalImageSize={originalImageSize}
         standardsColors={standardsColors}
-        globalBackgroundElement={editorBackgroundElement}
+        globalPageTemplate={editorPageTemplate}
         aspectRatio={aspectRatio}
       />
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -141,7 +141,7 @@ const Sidebar = ({
             />
             <Chip
               icon={<ImageIcon />}
-              label="Imagem de fundo"
+              label="Imagem"
               color={backgroundImageSrc ? 'success' : 'default'}
               variant={backgroundImageSrc ? 'filled' : 'outlined'}
               size="small"

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -462,8 +462,8 @@ Lembre-se: Sua resposta final deve conter APENAS o bloco \`\`\`csv ... \`\`\` co
 
     const { titulo, conteudo, cta, hashtags } = campaignContent;
     const imageHtml = backgroundImage ? `
-      <h2>Imagem de Fundo</h2>
-      <img src="${backgroundImage}" alt="Imagem de Fundo da Campanha" style="max-width: 100%; border-radius: 8px; margin-bottom: 2rem;" />
+      <h2>Imagem Principal</h2>
+      <img src="${backgroundImage}" alt="Imagem Principal da Campanha" style="max-width: 100%; border-radius: 8px; margin-bottom: 2rem;" />
     ` : '';
 
     const followupPostsHtml = followupPosts.length > 0 ? `

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -74,10 +74,10 @@ const rgbToHex = (r, g, b) => '#' + [r, g, b].map(x => {
   return hex.length === 1 ? '0' + hex : hex;
 }).join('');
 
-const defaultBackgroundElement = {
-  id: '__background__',
-  type: 'background',
-  src: null,
+const createNewImageElement = (src) => ({
+  id: `img_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+  type: 'image',
+  src,
   visible: true,
   rotation: 0,
   x: 0,
@@ -85,24 +85,18 @@ const defaultBackgroundElement = {
   width: 100,
   height: 100,
   crop: null,
-  // Background-specific properties
-  backgroundType: 'color', // 'color', 'gradient', or 'image'
-  backgroundColor: '#FFFFFF',
-  gradient: null, // Initialized as null, created on-demand
-  // Filters
-  filters: {
-    brightness: 100,
-    contrast: 100,
-    saturate: 100,
-    blur: 0,
-    opacity: 100
-  },
-  // Shadow
+  filters: { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 },
   shadow: false,
   shadowColor: '#000000',
   shadowBlur: 10,
   shadowOffsetX: 5,
   shadowOffsetY: 5,
+});
+
+const defaultPageTemplate = {
+    backgroundColor: '#FFFFFF',
+    gradient: null,
+    images: [],
 };
 
 const DEFAULT_IMAGE_SIZE = { width: 720, height: 720 };
@@ -176,8 +170,7 @@ function HomePage() {
   const [isDraggingOverImage, setIsDraggingOverImage] = useState(false);
   const [selectedField, setSelectedField] = useState(null);
   const [brandElements, setBrandElements] = useState([]);
-  const [backgroundElement, setBackgroundElement] = useState(defaultBackgroundElement);
-  const [pageState, setPageState] = useState({ backgroundColor: '#FFFFFF' });
+  const [pageTemplate, setPageTemplate] = useState(defaultPageTemplate);
   const [showSetupModal, setShowSetupModal] = useState(false);
   const [showCampaignStandardsModal, setShowCampaignStandardsModal] = useState(false);
   const [showMemorialDescritivoModal, setShowMemorialDescritivoModal] = useState(false);
@@ -260,42 +253,53 @@ function HomePage() {
     setGeneratedVideosData(Array.isArray(state.generatedVideosData) ? state.generatedVideosData : []);
     setBrandElements(Array.isArray(state.brandElements) ? state.brandElements : []);
 
-    // Logic to load background image and its associated element state correctly.
-    const loadedBackground = state.backgroundElement;
-
-    if (loadedBackground) {
-      // Merge loaded data with defaults to ensure all properties exist
-      const mergedBackground = {
-        ...defaultBackgroundElement,
-        ...loadedBackground,
-        filters: {
-          ...defaultBackgroundElement.filters,
-          ...(loadedBackground.filters || {}),
-        },
-        gradient: loadedBackground.gradient ? {
-          ...defaultBackgroundElement.gradient,
-          ...loadedBackground.gradient,
-        } : defaultBackgroundElement.gradient,
-      };
-
-      // Handle legacy campaigns that only had `backgroundImage`
-      if (!mergedBackground.src && state.backgroundImage) {
-        mergedBackground.src = state.backgroundImage;
-      }
-
-      // If there's a src, let updateImageAndPalette handle setting the state
-      // as it needs to load the image to get dimensions, etc.
-      if (mergedBackground.src) {
-        updateImageAndPalette(mergedBackground.src, mergedBackground);
-      } else {
-        setBackgroundElement(mergedBackground);
-      }
-    } else if (state.backgroundImage) {
-      // Legacy case: only backgroundImage is present
-      updateImageAndPalette(state.backgroundImage, { ...defaultBackgroundElement, src: state.backgroundImage });
+    if (state.pageTemplate) {
+        // New format: Deep merge to ensure new properties are not lost on load
+        const loadedTemplate = state.pageTemplate;
+        setPageTemplate({
+            ...defaultPageTemplate,
+            ...loadedTemplate,
+            images: (loadedTemplate.images || []).map(img => ({
+                ...createNewImageElement(null), // Get all default keys
+                ...img
+            }))
+        });
     } else {
-      // No background info in the loaded state, reset to the default
-      setBackgroundElement(defaultBackgroundElement);
+        // Legacy format, convert it
+        const newPageTemplate = { ...defaultPageTemplate };
+        const legacyBg = state.backgroundElement;
+        if (legacyBg) {
+            newPageTemplate.backgroundColor = legacyBg.backgroundColor || '#FFFFFF';
+            newPageTemplate.gradient = legacyBg.gradient || null;
+            if (legacyBg.src) {
+                const image = { ...legacyBg };
+                delete image.backgroundColor;
+                delete image.gradient;
+                delete image.backgroundType;
+                image.type = 'image';
+                if (!image.id || image.id === '__background__') {
+                    image.id = createNewImageElement(null).id;
+                }
+                newPageTemplate.images = [image];
+            }
+        } else if (state.backgroundImage) {
+            // Even older legacy format
+            newPageTemplate.images = [createNewImageElement(state.backgroundImage)];
+        }
+        setPageTemplate(newPageTemplate);
+    }
+
+    // When loading, if there's an image, we need to set the originalImageSize for the editor to work correctly
+    const firstImageSrc = state.pageTemplate?.images?.[0]?.src || state.backgroundElement?.src || state.backgroundImage;
+    if (firstImageSrc) {
+        const img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.onload = () => {
+            setOriginalImageSize({ width: img.width, height: img.height });
+        };
+        img.src = firstImageSrc;
+    } else {
+        setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     }
 
     setProblema(state.problema ?? '');
@@ -376,7 +380,7 @@ function HomePage() {
       fieldStyles,
       templateFieldStyles,
       brandElements,
-      backgroundElement,
+      pageTemplate,
       generatedPageUrl,
       generatedPagesData,
       generatedAudioData,
@@ -535,14 +539,12 @@ function HomePage() {
   }, [darkMode]);
 
   useEffect(() => {
-    console.log('[HomePage] backgroundElement state changed:', backgroundElement);
-    // When the background image is removed (src becomes null),
-    // reset the originalImageSize to the default. This prevents the editor
-    // from retaining the dimensions of the old image, which would break the layout.
-    if (backgroundElement?.src === null) {
+    console.log('[HomePage] pageTemplate state changed:', pageTemplate);
+    // When the last image is removed, reset the originalImageSize.
+    if (!pageTemplate.images || pageTemplate.images.length === 0) {
       setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     }
-  }, [backgroundElement]);
+  }, [pageTemplate]);
 
   useEffect(() => {
     if (isMobile) setSidebarOpen(false);
@@ -602,12 +604,11 @@ function HomePage() {
     handleLinkedInRedirect();
   }, [settings.linkedin, updateSetting, saveSettings]);
 
-  const steps = [ { label: 'Minhas Campanhas', description: 'Gerencie suas campanhas existentes ou crie uma nova.', icon: FolderOpenIcon }, { label: 'Campanha', description: 'Criar o material de referência para a campanha.', icon: CampaignIcon }, { label: 'Posts Curtos', description: 'Gere, carregue ou edite os posts para redes sociais.', icon: InsertDriveFileOutlined }, { label: 'Imagem e Formatação', description: 'Carregue a imagem de fundo, posicione os campos e configure a formatação.', icon: ImageIcon }, { label: 'Gerar Páginas', description: 'Gere as páginas finais.', icon: FormatBold }, { label: 'Gerar Áudio', description: 'Crie a narração para os slides.', icon: Audiotrack }, { label: 'Gerar Vídeo', description: 'Crie um vídeo a partir das imagens geradas.', icon: Movie }, { label: 'Publicar', description: 'Publique o conteúdo no WordPress.', icon: Publish }, { label: 'Monitorar', description: 'Acompanhe as estatísticas de suas publicações.', icon: BarChart } ];
+  const steps = [ { label: 'Minhas Campanhas', description: 'Gerencie suas campanhas existentes ou crie uma nova.', icon: FolderOpenIcon }, { label: 'Campanha', description: 'Criar o material de referência para a campanha.', icon: CampaignIcon }, { label: 'Posts Curtos', description: 'Gere, carregue ou edite os posts para redes sociais.', icon: InsertDriveFileOutlined }, { label: 'Modelo de Página', description: 'Carregue a imagem de fundo, posicione os campos e configure a formatação.', icon: ImageIcon }, { label: 'Edição de Páginas', description: 'Gere as páginas finais.', icon: FormatBold }, { label: 'Gerar Áudio', description: 'Crie a narração para os slides.', icon: Audiotrack }, { label: 'Gerar Vídeo', description: 'Crie um vídeo a partir das imagens geradas.', icon: Movie }, { label: 'Publicar', description: 'Publique o conteúdo no WordPress.', icon: Publish }, { label: 'Monitorar', description: 'Acompanhe as estatísticas de suas publicações.', icon: BarChart } ];
   const handleCreateNewCampaign = () => {
-    applyAppState({});
+    applyAppState({}); // This will reset most state
     setCurrentCampaign(null);
-    // Also explicitly reset the background element and image size to the default state for a new campaign
-    setBackgroundElement(defaultBackgroundElement);
+    setPageTemplate(defaultPageTemplate); // Explicitly reset page template
     setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     setActiveStep(1);
   };
@@ -644,39 +645,25 @@ function HomePage() {
   const handleCSVUpload = (event) => { const file = event.target.files[0]; parseCsvFile(file); };
   const handleDrop = (event) => { event.preventDefault(); event.stopPropagation(); const file = event.dataTransfer.files[0]; parseCsvFile(file); };
   const handleDragOver = (event) => { event.preventDefault(); event.stopPropagation(); };
-  const updateImageAndPalette = useCallback((imageUrl, existingBackgroundElement = null) => {
+  const updateImageAndPalette = useCallback((imageUrl) => {
     console.log('[HomePage] updateImageAndPalette called.', {
-      hasImageUrl: !!imageUrl,
-      hasExistingBackgroundElement: !!existingBackgroundElement
+      hasImageUrl: !!imageUrl
     });
     const img = new Image();
     img.crossOrigin = 'Anonymous';
     img.onload = () => {
       setOriginalImageSize({ width: img.width, height: img.height });
-      if (existingBackgroundElement) {
-        // Ensure the new imageUrl is always set, even on an existing element
-        setBackgroundElement({ ...existingBackgroundElement, src: imageUrl });
-      } else {
-        // FIX: The src property was missing, causing the image not to appear
-        setBackgroundElement({
-          id: '__background__',
-          type: 'background',
-          src: imageUrl,
-          x: 0,
-          y: 0,
-          width: 100,
-          height: 100,
-          rotation: 0,
-          visible: true,
-          filters: { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 },
-          shadow: false,
-          shadowColor: '#000000',
-          shadowBlur: 10,
-          shadowOffsetX: 5,
-          shadowOffsetY: 5,
-          crop: null,
-        });
-      }
+      const newImage = createNewImageElement(imageUrl);
+
+      setPageTemplate(prevTemplate => {
+        // Add the new image to the existing images array
+        const updatedImages = [...(prevTemplate.images || []), newImage];
+        return {
+          ...prevTemplate,
+          images: updatedImages,
+        };
+      });
+
       try {
         const colorThief = new ColorThief();
         const palette = colorThief.getPalette(img, 5);
@@ -689,12 +676,10 @@ function HomePage() {
     img.onerror = (err) => {
       console.error("Error loading image to extract colors:", err);
       setColorPalette([]);
-      // Reset to a functional default state on image load error
-      setBackgroundElement(defaultBackgroundElement);
       setOriginalImageSize(DEFAULT_IMAGE_SIZE);
     };
     img.src = imageUrl;
-  }, []);
+  }, [setPageTemplate]); // Dependency on setPageTemplate
   const parseImageFile = (file) => {
     if (!file) return;
     handleBackgroundImageUpload(file);
@@ -735,7 +720,8 @@ function HomePage() {
 
         const resizedDataUrl = canvas.toDataURL(file.type);
 
-        updateImageAndPalette(resizedDataUrl, null);
+        // Always adds a new image now
+        updateImageAndPalette(resizedDataUrl);
       };
       img.src = dataUrl;
     };
@@ -776,13 +762,8 @@ function HomePage() {
       }
 
       const permanentUrl = `https://lh3.googleusercontent.com/d/${uploadedFile.id}`;
-      setBackgroundImage(permanentUrl);
-      setBackgroundElement(prev => {
-        if (prev) {
-          return { ...prev, src: permanentUrl };
-        }
-        return null; // Should not happen if onload has fired
-      });
+      // This logic needs to be re-evaluated. For now, it adds a new image.
+      updateImageAndPalette(permanentUrl);
 
     } catch (err) {
       console.error("Failed to upload and set background image to Google Drive:", err);
@@ -1052,26 +1033,47 @@ function HomePage() {
   const handleGenerateSinglePage = async (record, index, fontScale = 1) => {
     const imagePrompt = record.prompt_imagem_carrossel;
 
-    let composingElement = backgroundElement;
+    // This function will now be more complex due to the new requirements.
+    // It needs to decide whether to create a new image or update an existing one.
+    let composingTemplate = pageTemplate;
     let pageUpdateData = {};
 
     if (imagePrompt && imagePrompt.trim() !== '') {
-      setGenerationStatus(`Gerando imagem para o post ${index + 1}...`);
-      try {
-        const uniqueImageUrl = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
+        setGenerationStatus(`Gerando imagem para o post ${index + 1}...`);
+        try {
+            const uniqueImageUrl = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
 
-        const tempBackgroundElement = {
-          ...(backgroundElement || {}),
-          id: '__background__',
-          src: uniqueImageUrl,
-        };
-        composingElement = tempBackgroundElement;
+            // New logic based on user requirements
+            const existingPageData = generatedPagesData.find(p => p.index === index);
+            const pageImages = existingPageData?.customPageTemplate?.images || pageTemplate.images;
 
-        pageUpdateData.customBackgroundElement = tempBackgroundElement;
+            const newImage = createNewImageElement(uniqueImageUrl);
+            let finalImages;
 
-      } catch (error) {
-        toast.error(`Falha ao gerar imagem para o post #${index + 1}: ${error.message}`);
-      }
+            if (pageImages.length > 0) {
+                // Replace the first image
+                finalImages = [newImage, ...pageImages.slice(1)];
+            } else {
+                // Add as the first image (and make it fullscreen)
+                newImage.x = 0;
+                newImage.y = 0;
+                newImage.width = 100;
+                newImage.height = 100;
+                finalImages = [newImage];
+            }
+
+            // This will be stored with the generated page data
+            const tempPageTemplate = {
+                ...(existingPageData?.customPageTemplate || pageTemplate),
+                images: finalImages,
+            };
+
+            composingTemplate = tempPageTemplate;
+            pageUpdateData.customPageTemplate = tempPageTemplate;
+
+        } catch (error) {
+            toast.error(`Falha ao gerar imagem para o post #${index + 1}: ${error.message}`);
+        }
     }
 
     setGenerationStatus(`Gerando página para o post ${index + 1}/${csvData.length}...`);
@@ -1083,7 +1085,7 @@ function HomePage() {
         fieldPositions,
         fieldStyles,
         aspectRatio,
-        backgroundElement: composingElement,
+        pageTemplate: composingTemplate,
         fontScale,
       });
 
@@ -1130,7 +1132,7 @@ function HomePage() {
         />
         {currentView === 'campaigns' && (
           <>
-            <Sidebar sidebarOpen={sidebarOpen} darkMode={darkMode} steps={steps} activeStep={activeStep} setActiveStep={setActiveStep} csvData={csvData} backgroundImageSrc={backgroundElement?.src} visibleFields={visibleFields} totalFields={totalFields} styledFields={styledFields} variant={isMobile ? 'temporary' : 'persistent'} onClose={() => setSidebarOpen(false)} onStepClick={handleSidebarStepClick} />
+            <Sidebar sidebarOpen={sidebarOpen} darkMode={darkMode} steps={steps} activeStep={activeStep} setActiveStep={setActiveStep} csvData={csvData} backgroundImageSrc={pageTemplate.images[0]?.src} visibleFields={visibleFields} totalFields={totalFields} styledFields={styledFields} variant={isMobile ? 'temporary' : 'persistent'} onClose={() => setSidebarOpen(false)} onStepClick={handleSidebarStepClick} />
             {!isMobile && <Fab size="small" onClick={() => setSidebarOpen(!sidebarOpen)} aria-label={sidebarOpen ? 'Fechar barra lateral' : 'Abrir barra lateral'} sx={{ position: 'fixed', top: '50%', left: sidebarOpen ? 320 - 20 : 0, transform: 'translateY(-50%)', zIndex: (theme) => theme.zIndex.drawer + 1, transition: 'left 0.2s ease-in-out', backgroundColor: 'background.paper', border: '1px solid', borderColor: 'divider', '&:hover': { backgroundColor: 'background.default' } }} >{sidebarOpen ? <ChevronLeft /> : <ChevronRight />}</Fab>}
           </>
         )}
@@ -1244,10 +1246,8 @@ function HomePage() {
                     originalImageSize={originalImageSize}
                     brandElements={brandElements}
                     setBrandElements={setBrandElements}
-                    backgroundElement={backgroundElement}
-                    setBackgroundElement={setBackgroundElement}
-                    pageState={pageState}
-                    setPageState={setPageState}
+                    pageTemplate={pageTemplate}
+                    setPageTemplate={setPageTemplate}
                     onZIndexChange={handleZIndexChange}
                     isMobile={isMobile}
                     selectedField={selectedField}
@@ -1281,7 +1281,8 @@ function HomePage() {
                     fontScale={fontScale}
                     handleGenerateSinglePage={handleGenerateSinglePage}
                     aspectRatio={aspectRatio}
-                    backgroundElement={backgroundElement}
+                    pageTemplate={pageTemplate}
+                    generatedPagesData={generatedPagesData}
                   />
                 )}
                 {activeStep === 5 && (

--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -51,8 +51,8 @@ export const exportHtml = (campaignData) => {
 
   const { titulo, conteudo, cta, hashtags, conteudoMedio, conteudoPequeno, conteudoFormatado } = campaignContent;
   const imageHtml = backgroundImage ? `
-    <h2>Imagem de Fundo</h2>
-    <img src="${backgroundImage}" alt="Imagem de Fundo da Campanha" style="max-width: 100%; border-radius: 8px; margin-bottom: 2rem;" />
+    <h2>Imagem Principal</h2>
+    <img src="${backgroundImage}" alt="Imagem Principal da Campanha" style="max-width: 100%; border-radius: 8px; margin-bottom: 2rem;" />
   ` : '';
 
   const followupPostsHtml = followupPosts.length > 0 ? `

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -146,7 +146,7 @@ export const composeSingleImage = async ({
     fieldPositions = {},
     fieldStyles = {},
     aspectRatio,
-    backgroundElement, // The single source of truth for the background
+    pageTemplate,
     fontScale = 1,
 }) => {
 
@@ -164,80 +164,38 @@ export const composeSingleImage = async ({
         finalCanvas.height = dimensions.height;
     }
 
-    // Default white background in case no image is provided.
-    ctx.fillStyle = 'white';
-    ctx.fillRect(0, 0, finalCanvas.width, finalCanvas.height);
-
-    // 2. Draw the single background image if it exists, applying all transformations.
-    if (backgroundElement?.src) {
-        try {
-            const bgImg = await loadImage(backgroundElement.src);
-            ctx.save();
-            const canvasWidth = finalCanvas.width;
-            const canvasHeight = finalCanvas.height;
-
-            const {
-              x = 0, y = 0, width = 100, height = 100,
-              rotation = 0,
-              filters = { brightness: 100, contrast: 100, saturate: 100, blur: 0, opacity: 100 },
-              crop,
-              shadow, shadowColor, shadowBlur, shadowOffsetX, shadowOffsetY
-            } = backgroundElement;
-
-            if (shadow) {
-              ctx.shadowColor = shadowColor || '#000000';
-              ctx.shadowBlur = shadowBlur || 10;
-              ctx.shadowOffsetX = shadowOffsetX || 5;
-              ctx.shadowOffsetY = shadowOffsetY || 5;
-            }
-
-            const { brightness = 100, contrast = 100, saturate = 100, blur = 0, opacity = 100 } = filters || {};
-            ctx.filter = `brightness(${brightness}%) contrast(${contrast}%) saturate(${saturate}%) blur(${blur}px) opacity(${opacity}%)`;
-
-            const dx = (x / 100) * canvasWidth;
-            const dy = (y / 100) * canvasHeight;
-            const dWidth = (width / 100) * canvasWidth;
-            const dHeight = (height / 100) * canvasHeight;
-
-            if (rotation) {
-              const centerX = dx + dWidth / 2;
-              const centerY = dy + dHeight / 2;
-              ctx.translate(centerX, centerY);
-              ctx.rotate(rotation * Math.PI / 180);
-              ctx.translate(-centerX, -centerY);
-            }
-
-            if (crop && crop.width > 0 && crop.height > 0) {
-              const sx = (crop.x / 100) * bgImg.width;
-              const sy = (crop.y / 100) * bgImg.height;
-              const sWidth = (crop.width / 100) * bgImg.width;
-              const sHeight = (crop.height / 100) * bgImg.height;
-              ctx.drawImage(bgImg, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
-            } else {
-              ctx.drawImage(bgImg, dx, dy, dWidth, dHeight);
-            }
-
-            // The main filters have been applied by ctx.filter. Now, apply the custom highlight filter.
-            // We must do this before restoring the context if we want it to be contained within the rotated/scaled element.
-            // However, it's easier to apply to the whole canvas and let the drawImage contain it.
-            // So we apply it AFTER the drawing, but before restoring the main context.
-            ctx.filter = 'none'; // Reset standard filters before pixel manipulation
-            if (filters.highlightAmount && filters.highlightAmount > 0) {
-              applyColorHighlight(ctx, canvasWidth, canvasHeight, filters.highlightColor, filters.highlightAmount);
-            }
-
-            ctx.restore();
-        } catch (error) {
-            console.error('[imageComposer] Failed to draw background image:', error);
-            ctx.fillStyle = 'red';
-            ctx.font = '20px Arial';
-            ctx.textAlign = 'center';
-            ctx.fillText('Erro ao carregar o fundo', finalCanvas.width / 2, finalCanvas.height / 2);
+    // 2. Draw background color or gradient
+    if (pageTemplate.gradient) {
+        // This is a simplified gradient handling. The editor creates a CSS string.
+        // For canvas, we'd need to parse this or use the structured object.
+        // For now, we assume a simple linear gradient object if not a string.
+        if (typeof pageTemplate.gradient === 'object' && pageTemplate.gradient.stops) {
+            const gradient = ctx.createLinearGradient(0, 0, finalCanvas.width, finalCanvas.height);
+            pageTemplate.gradient.stops.forEach(stop => {
+                gradient.addColorStop(stop.position / 100, stop.color);
+            });
+            ctx.fillStyle = gradient;
+        } else {
+            ctx.fillStyle = 'white'; // Fallback
         }
+    } else {
+        ctx.fillStyle = pageTemplate.backgroundColor || 'white';
     }
+    ctx.fillRect(0, 0, finalCanvas.width, finalCanvas.height);
 
     // 3. Collect and sort all elements (text and brand) by zIndex
     const elementsToDraw = [];
+
+    // Add page images to the drawing queue
+    (pageTemplate.images || []).forEach(image => {
+        if (image.src && image.visible !== false) {
+            elementsToDraw.push({
+                type: 'image',
+                ...image,
+                zIndex: image.zIndex || 0,
+            });
+        }
+    });
 
     Object.keys(record).forEach(field => {
         const position = fieldPositions[field];
@@ -257,7 +215,7 @@ export const composeSingleImage = async ({
     (brandElements || []).forEach(element => {
         if (element.url && element.visible !== false) {
             elementsToDraw.push({
-                type: 'brand',
+                type: 'image', // Treat brand elements as images
                 ...element,
                 zIndex: element.zIndex || 0,
             });
@@ -357,9 +315,9 @@ export const composeSingleImage = async ({
                 }
             }
 
-        } else if (element.type === 'brand') {
+        } else if (element.type === 'image') {
             try {
-                const elementImg = await loadImage(element.url);
+                const elementImg = await loadImage(element.src || element.url);
                 const elX = (element.x / 100) * finalCanvas.width;
                 const elY = (element.y / 100) * finalCanvas.height;
                 const elWidth = (element.width / 100) * finalCanvas.width;
@@ -378,7 +336,7 @@ export const composeSingleImage = async ({
                 }
                 ctx.drawImage(elementImg, elX, elY, elWidth, elHeight);
             } catch (error) {
-                console.error(`[composeSingleImage] Failed to load or draw brand element ${element.id}:`, error);
+                console.error(`[composeSingleImage] Failed to load or draw image element ${element.id}:`, error);
             }
         }
         ctx.restore();
@@ -396,7 +354,7 @@ export const composeSingleImage = async ({
         record,
         index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
-        // Return the state of the background that was actually used for composition
-        customBackgroundElement: backgroundElement,
+        // Return the state of the page template that was actually used for composition
+        customPageTemplate: pageTemplate,
     };
 };

--- a/test/imageComposer.test.js
+++ b/test/imageComposer.test.js
@@ -20,16 +20,25 @@ describe('composeSingleImage', () => {
     // Mocking global.Image to use the Image class from 'canvas'
     global.Image = (await import('canvas')).Image;
 
+    const pageTemplate = {
+        backgroundColor: '#FFFFFF',
+        gradient: null,
+        images: [{
+            src: dummy_background,
+            filters: {},
+            visible: true
+        }]
+    };
+
     const result = await composeSingleImage({
       record: { text: 'Hello' },
       index: 0,
-      itemBackgroundImage: dummy_background,
       brandElements: [],
       fieldPositions: { text: { x: 10, y: 10, width: 80, height: 20, visible: true } },
       fieldStyles: { text: { fontSize: 16, color: '#000000' } },
       fontScale: 1,
       aspectRatio: '1:1',
-      backgroundElement: { filters: {} },
+      pageTemplate: pageTemplate,
     });
 
     expect(result).toHaveProperty('url');
@@ -57,24 +66,31 @@ describe('composeSingleImage', () => {
     // Mocking global.Image to use the Image class from 'canvas'
     global.Image = (await import('canvas')).Image;
 
+    const pageTemplate = {
+        backgroundColor: '#FFFFFF',
+        gradient: null,
+        images: [{
+            src: dummy_background,
+            filters: {
+                brightness: 150,
+                contrast: 120,
+                saturate: 180,
+                blur: 5,
+                opacity: 80,
+            },
+            visible: true
+        }]
+    };
+
     await composeSingleImage({
       record: { text: 'Hello' },
       index: 0,
-      itemBackgroundImage: dummy_background,
       brandElements: [],
       fieldPositions: { text: { x: 10, y: 10, width: 80, height: 20, visible: true } },
       fieldStyles: { text: { fontSize: 16, color: '#000000' } },
       fontScale: 1,
       aspectRatio: '1:1',
-      backgroundElement: {
-        filters: {
-          brightness: 150,
-          contrast: 120,
-          saturate: 180,
-          blur: 5,
-          opacity: 80,
-        },
-      },
+      pageTemplate: pageTemplate,
     });
 
     // The filter is applied before drawing the background image.


### PR DESCRIPTION
Esta mudança refatora a aplicação para permitir múltiplas imagens por página e um fundo de cor sólida ou gradiente customizável, em vez de uma única imagem de fundo.

Principais mudanças:
- Introduzido um novo objeto de estado `pageTemplate` que contém `backgroundColor`, `gradient` e um array `images`.
- Refatorados os componentes `HomePage`, `ImageStep`, `FieldPositioner`, `FormattingPanel`, `PageEditor` e `PageGeneratorFrontendOnly` para usar a nova estrutura `pageTemplate`.
- A lógica de composição de imagem em `imageComposer.js` foi atualizada para renderizar o fundo e múltiplas imagens.
- A interface do usuário no `FormattingPanel` foi atualizada para permitir o gerenciamento de múltiplas imagens e a configuração do fundo.
- As etapas "Imagem e Formatação" e "Gerar Páginas" foram renomeadas para "Modelo de Página" e "Edição de Páginas", respectivamente.
- A documentação foi atualizada para refletir as novas funcionalidades e nomes.
- Adicionada lógica para retrocompatibilidade com campanhas salvas no formato antigo.