### PR TITLE
fix: Correct page background selection and crash

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -400,12 +400,12 @@ const FieldPositioner = ({
                     }}
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
-                        setSelectedField(null); // Deselect all
+                        setSelectedField('__page_background__');
                       }
                     }}
                     onTouchStart={(e) => {
                       if (e.target === e.currentTarget) {
-                        setSelectedField('__background__');
+                        setSelectedField('__page_background__');
                       }
                     }}
                   >


### PR DESCRIPTION
This commit fixes a bug where clicking on the page background in the editor would cause a crash and fail to bring up the background color/gradient editor.

The issue was in `FieldPositioner.jsx`, where the `onClick` and `onTouchStart` event handlers were setting the `selectedField` state to an incorrect or null value (`__background__` or `null`). This caused the `FormattingPanel` to fail when trying to access properties of a null `currentElement`.

The fix updates these handlers to set the `selectedField` state to the correct identifier, `__page_background__`, which is now used consistently to represent the page background entity for editing.