### PR TITLE
fix: Prevent crash when selecting elements in editor

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -193,7 +193,7 @@ const FormattingPanel = ({
   return (
     <Card>
       <CardContent>
-        {!selectedField ? (
+        {!currentElement ? (
           <Typography variant="h6" color="textSecondary" align="center" gutterBottom sx={{ mt: 4 }}>
             Selecione um elemento para editar
           </Typography>


### PR DESCRIPTION
This commit fixes a critical crash that occurred when selecting any element (textbox, image, or background) in the page editor.

The root cause was an incorrect conditional check in `FormattingPanel.jsx`. The code was checking for the existence of `selectedField` to render the editor panel, but it should have been checking for `currentElement`. If an invalid ID was passed as `selectedField`, `currentElement` would become `null`, and the subsequent attempt to read `currentElement.visible` would cause a crash.

The fix changes the conditional check from `!selectedField` to `!currentElement`, ensuring that the editor panel only attempts to render if a valid element has been found and its data is available. This resolves all reported crashes.