### PR TITLE
debug: Add console logs to trace background selection

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -400,11 +400,13 @@ const FieldPositioner = ({
                     }}
                     onClick={(e) => {
                       if (e.target === e.currentTarget) {
+                        console.log('[FieldPositioner] Background clicked. Setting selected field to __page_background__');
                         setSelectedField('__page_background__');
                       }
                     }}
                     onTouchStart={(e) => {
                       if (e.target === e.currentTarget) {
+                        console.log('[FieldPositioner] Background touched. Setting selected field to __page_background__');
                         setSelectedField('__page_background__');
                       }
                     }}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -105,7 +105,10 @@ const FormattingPanel = ({
     setExpandedPanel(isExpanded ? panel : false);
   };
 
+  console.log(`[FormattingPanel] Rendering. Selected field prop: ${selectedField}`);
+
   React.useEffect(() => {
+    console.log(`[FormattingPanel] useEffect running. selectedField: ${selectedField}`);
     setIsTextField(false);
     setIsPageImage(false);
     setIsBrandElement(false);
@@ -114,9 +117,11 @@ const FormattingPanel = ({
 
     if (selectedField) {
       if (selectedField === '__page_background__') {
+        console.log('[FormattingPanel] useEffect: Matched __page_background__');
         setIsPageBackground(true);
         setCurrentElement(pageTemplate);
       } else if (fieldPositions[selectedField]) {
+        console.log('[FormattingPanel] useEffect: Matched a text field.');
         setIsTextField(true);
         setCurrentElement({
           ...fieldPositions[selectedField],
@@ -125,18 +130,26 @@ const FormattingPanel = ({
       } else {
         const pageImg = pageTemplate?.images?.find(img => img.id === selectedField);
         if (pageImg) {
+          console.log('[FormattingPanel] useEffect: Matched a page image.');
           setIsPageImage(true);
           setCurrentElement(pageImg);
         } else {
           const brandEl = brandElements?.find(el => el.id === selectedField);
           if (brandEl) {
+            console.log('[FormattingPanel] useEffect: Matched a brand element.');
             setIsBrandElement(true);
             setCurrentElement(brandEl);
+          } else {
+            console.log('[FormattingPanel] useEffect: selectedField has value but no element was matched.');
           }
         }
       }
+    } else {
+        console.log('[FormattingPanel] useEffect: No selectedField.');
     }
   }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
+
+  console.log(`[FormattingPanel] State before render: isPageBackground=${isPageBackground}, currentElement is ${currentElement ? 'set' : 'null'}`);
 
   const updateFieldStyle = (property, value) => {
     if (!isTextField) return;


### PR DESCRIPTION



This commit adds extensive console logging to `FieldPositioner.jsx` and `FormattingPanel.jsx`. The purpose of these logs is to trace the flow of state when the user attempts to select the page background for editing.

This is in response to a persistent bug where the background color/gradient editor does not appear as expected. The logs will track:
1.  The `onClick` event in `FieldPositioner`.
2.  The `selectedField` prop received by `FormattingPanel`.
3.  The logic execution within the `useEffect` hook in `FormattingPanel`.
4.  The final state of `currentElement` and `isPageBackground` before render.

This is a temporary debugging step and the logs should be removed once the root cause of the bug is identified and fixed.