### PR TITLE
fix(PageEditor): Correct props for mobile formatting drawer

### DIFF
--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -13,8 +13,8 @@ const FormattingDrawer = ({
   fieldPositions,
   setFieldPositions,
   csvHeaders,
-  imageFilters,
-  setImageFilters,
+  backgroundElement,
+  setBackgroundElement,
   brandElements,
   setBrandElements,
   onZIndexChange,
@@ -42,8 +42,8 @@ const FormattingDrawer = ({
           fieldPositions={fieldPositions}
           setFieldPositions={setFieldPositions}
           csvHeaders={csvHeaders}
-          imageFilters={imageFilters}
-          setImageFilters={setImageFilters}
+          backgroundElement={backgroundElement}
+          setBackgroundElement={setBackgroundElement}
           brandElements={brandElements}
           setBrandElements={setBrandElements}
           onZIndexChange={onZIndexChange}


### PR DESCRIPTION
This commit fixes a bug where the background editing controls were not available on small screens, and where opening the editor could result in a blank page.

The root cause was that the `FormattingDrawer` component, which is used for the mobile UI, was not correctly accepting and passing down the `backgroundElement` and `setBackgroundElement` props to the `FormattingPanel` component it wraps. It was instead using an obsolete prop structure (`imageFilters`).

This change updates `FormattingDrawer.jsx` to use the correct props, aligning its behavior with the desktop view and ensuring the background editing controls are available on mobile. This also resolves the state inconsistencies that were leading to a blank page preview and subsequent save errors.