### PR TITLE
fix(save): Prevent 'Request Entity Too Large' error on save

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -365,6 +365,11 @@ function HomePage() {
       return;
     }
 
+    const sanitizedPagesData = generatedPagesData.map(page => {
+      const { url, dataUrl, blob, ...rest } = page;
+      return rest;
+    });
+
     const campaignDataToSave = {
       activeStep,
       problema,
@@ -382,7 +387,7 @@ function HomePage() {
       brandElements,
       pageTemplate,
       generatedPageUrl,
-      generatedPagesData,
+      generatedPagesData: sanitizedPagesData,
       generatedAudioData,
       generatedVideosData,
       standardsColors,


### PR DESCRIPTION
This commit fixes a critical error where saving a campaign with many generated pages would fail with a `FUNCTION_PAYLOAD_TOO_LARGE` error.

The cause was that the save function was including the full, base64-encoded `dataUrl` for every generated page in the request payload sent to the server. This quickly exceeded the serverless function's payload size limit.

The fix modifies the `handleSaveCampaign` function in `HomePage.jsx` to sanitize the `generatedPagesData` array before saving. It now removes the large, non-essential `url`, `dataUrl`, and `blob` properties from each page object, sending only the necessary data to reconstruct the campaign state upon loading. The client is already designed to regenerate the page thumbnails when a campaign is loaded, so no functionality is lost.

This change makes the save process more robust, much faster, and prevents the server-side error.