### PR TITLE
feat(ux): Improve editor layout to maximize space

### DIFF
--- a/src/components/ImageStep.jsx
+++ b/src/components/ImageStep.jsx
@@ -81,14 +81,14 @@ const ImageStep = ({
   };
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2 }}>
+    <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 2, height: { xs: 'auto', md: 'calc(100vh - 150px)' } }}>
 
       {/* Main Content: Editor Area */}
       <Box sx={{
-        flex: '1 1 auto',
+        flex: 1,
         display: 'flex',
         flexDirection: 'column',
-        minHeight: 0, // Crucial for flex child to shrink
+        minHeight: 0,
         p: 1,
       }}>
         <Typography variant="h6" sx={{ flexShrink: 0, textAlign: 'center', mb: 2 }}>

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -113,9 +113,9 @@ const PageEditor = ({
         Editar Página Gerada #{pageData.index + 1}
         <IconButton onClick={onClose} sx={{ position: 'absolute', right: 8, top: 8 }}><Close /></IconButton>
       </DialogTitle>
-      <DialogContent dividers sx={{ overflowY: 'auto' }}>
-        <Grid container spacing={2}>
-          <Grid item xs={12} md={isMobile ? 12 : 8}>
+      <DialogContent dividers sx={{ display: 'flex', flexDirection: 'column' }}>
+        <Grid container spacing={2} sx={{ flexGrow: 1 }}>
+          <Grid item xs={12} md={isMobile ? 12 : 8} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <FieldPositioner
               aspectRatio={aspectRatio}
               csvHeaders={globalCsvHeaders}


### PR DESCRIPTION
This commit addresses user feedback regarding the inefficient use of space in the page editing views. The editing canvas was perceived as too small, despite available screen real estate.

The layout of the following components has been refactored to better utilize available space:
- **ImageStep.jsx**: The root container now uses viewport height units (`vh`) to ensure it takes up the maximum available vertical space on desktop.
- **PageEditor.jsx**: The layout of the dialog content has been changed to use Flexbox, allowing the grid container and the editor cell to grow and fill the available space in the modal.

These changes result in a significantly larger and more comfortable editing canvas in both the main editor and the page editing modal, directly improving the user experience.