### PR TITLE
fix: Resolve multiple editor bugs and UX issues

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -108,44 +108,62 @@ const FormattingPanel = ({
     setExpandedPanel(isExpanded ? panel : false);
   };
 
+  // This effect updates the state based on the selected field and available data
   React.useEffect(() => {
-    setIsTextField(false);
-    setIsPageImage(false);
-    setIsBrandElement(false);
-    setIsPageBackground(false);
-    setCurrentElement(null);
+    let foundElement = null;
+    let elIsTextField = false;
+    let elIsPageImage = false;
+    let elIsBrandElement = false;
+    let elIsPageBackground = false;
 
     if (selectedField) {
       if (selectedField === '__page_background__') {
-        setIsPageBackground(true);
-        setCurrentElement(pageTemplate);
-        setExpandedPanel('backgroundColor');
+        elIsPageBackground = true;
+        foundElement = pageTemplate;
       } else if (fieldPositions[selectedField]) {
-        setIsTextField(true);
-        setCurrentElement({
+        elIsTextField = true;
+        foundElement = {
           ...fieldPositions[selectedField],
           style: fieldStyles[selectedField] || {},
-        });
-        setExpandedPanel('fontStyle');
+        };
       } else {
         const pageImg = pageTemplate?.images?.find(img => img.id === selectedField);
         if (pageImg) {
-          setIsPageImage(true);
-          setCurrentElement(pageImg);
-          setExpandedPanel('imageStyle');
+          elIsPageImage = true;
+          foundElement = pageImg;
         } else {
           const brandEl = brandElements?.find(el => el.id === selectedField);
           if (brandEl) {
-            setIsBrandElement(true);
-            setCurrentElement(brandEl);
-            setExpandedPanel('imageStyle');
+            elIsBrandElement = true;
+            foundElement = brandEl;
           }
         }
       }
-    } else {
-      setExpandedPanel(false);
     }
+
+    setCurrentElement(foundElement);
+    setIsTextField(elIsTextField);
+    setIsPageImage(elIsPageImage);
+    setIsBrandElement(elIsBrandElement);
+    setIsPageBackground(elIsPageBackground);
   }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
+
+  // This separate effect handles which accordion is open, ONLY when the selection changes.
+  React.useEffect(() => {
+    if (!selectedField) {
+      setExpandedPanel(false);
+      return;
+    }
+    // This logic relies on the state flags set by the other useEffect.
+    // It runs after the other effect has determined the type of the selected element.
+    if (isPageBackground) {
+      setExpandedPanel('backgroundColor');
+    } else if (isTextField) {
+      setExpandedPanel('fontStyle');
+    } else if (isImageElement) {
+      setExpandedPanel('imageStyle');
+    }
+  }, [selectedField, isPageBackground, isTextField, isImageElement]);
 
   const updateFieldStyle = (property, value) => {
     if (!isTextField) return;


### PR DESCRIPTION
This commit provides a comprehensive set of fixes to address multiple bugs and UX complaints reported by the user, aiming to create a stable and intuitive editing experience.

The following issues have been resolved:
1.  **Critical Save Error**: Fixed the "Pré-requisitos não atendidos" error that occurred when saving edits from the `PageEditor`. This was caused by a data mismatch between the editor and its parent component, which has now been corrected.
2.  **Image Style Preview**: Fixed a bug where border and border-radius styles were not visible on images in the real-time editor preview by updating the `DraggableElement` component.
3.  **Accordion Behavior**: Reverted the formatting panel's accordions to only allow one section to be open at a time, per user request. The logic for auto-expanding the correct accordion on selection has also been made more robust by separating it into its own `useEffect` hook.
4.  **AI Regeneration Feedback**: Added a loading spinner overlay to individual page thumbnails in the `PageGenerator` view while the AI is regenerating an image, providing clear visual feedback.
5.  **Missing Buttons in PageEditor**: Added the "Load Image" and "Gallery" buttons to the `PageEditor` modal by passing the necessary handlers down through the component tree, allowing users to change the image of an individually generated page.