### PR TITLE
fix: Resolve multiple editor crashes

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -108,7 +108,6 @@ const FormattingPanel = ({
     setExpandedPanel(isExpanded ? panel : false);
   };
 
-  // This effect updates the state based on the selected field and available data
   React.useEffect(() => {
     let foundElement = null;
     let elIsTextField = false;
@@ -146,24 +145,18 @@ const FormattingPanel = ({
     setIsPageImage(elIsPageImage);
     setIsBrandElement(elIsBrandElement);
     setIsPageBackground(elIsPageBackground);
-  }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
 
-  // This separate effect handles which accordion is open, ONLY when the selection changes.
-  React.useEffect(() => {
+    // Set accordion state based on the types determined above
     if (!selectedField) {
       setExpandedPanel(false);
-      return;
-    }
-    // This logic relies on the state flags set by the other useEffect.
-    // It runs after the other effect has determined the type of the selected element.
-    if (isPageBackground) {
+    } else if (elIsPageBackground) {
       setExpandedPanel('backgroundColor');
-    } else if (isTextField) {
+    } else if (elIsTextField) {
       setExpandedPanel('fontStyle');
-    } else if (isImageElement) {
+    } else if (elIsPageImage || elIsBrandElement) {
       setExpandedPanel('imageStyle');
     }
-  }, [selectedField, isPageBackground, isTextField, isImageElement]);
+  }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
 
   const updateFieldStyle = (property, value) => {
     if (!isTextField) return;

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -20,7 +20,8 @@ import {
   FormControlLabel,
   Switch,
   Divider,
-  Tooltip
+  Tooltip,
+  CircularProgress,
 } from '@mui/material';
 import {
   Download,


### PR DESCRIPTION
This commit fixes two distinct crashes reported by the user:

1.  **Crash on AI Image Regeneration**: A `ReferenceError: CircularProgress is not defined` would occur when clicking the "Regenerate with AI" button on a page thumbnail. This was caused by a missing import from `@mui/material` in the `PageGeneratorFrontendOnly.jsx` component. The import has been added.

2.  **Crash on Step Transition**: A `ReferenceError: Cannot access 'q' before initialization` would occur when transitioning from the CSV loading step to the page template editor. This was caused by a race condition between two `useEffect` hooks in `FormattingPanel.jsx`. The hooks have been consolidated into a single, robust `useEffect` to ensure state is updated in the correct order, resolving the crash.

These fixes address critical stability issues in the editor workflow.