### PR TITLE
fix(editor): Prevent accordion from collapsing on style change

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -108,6 +108,8 @@ const FormattingPanel = ({
     setExpandedPanel(isExpanded ? panel : false);
   };
 
+  // Effect 1: This effect determines the element type and its data.
+  // It runs whenever the selection or the data of any element changes.
   React.useEffect(() => {
     let foundElement = null;
     let elIsTextField = false;
@@ -145,18 +147,24 @@ const FormattingPanel = ({
     setIsPageImage(elIsPageImage);
     setIsBrandElement(elIsBrandElement);
     setIsPageBackground(elIsPageBackground);
+  }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
 
-    // Set accordion state based on the types determined above
+  // Effect 2: This effect ONLY handles which accordion is open, and it ONLY runs when the selection changes.
+  React.useEffect(() => {
     if (!selectedField) {
       setExpandedPanel(false);
-    } else if (elIsPageBackground) {
+      return;
+    }
+
+    // Re-check the type here based only on the ID to be safe.
+    if (selectedField === '__page_background__') {
       setExpandedPanel('backgroundColor');
-    } else if (elIsTextField) {
+    } else if (fieldPositions[selectedField]) {
       setExpandedPanel('fontStyle');
-    } else if (elIsPageImage || elIsBrandElement) {
+    } else if (pageTemplate?.images?.some(img => img.id === selectedField) || brandElements?.some(el => el.id === selectedField)) {
       setExpandedPanel('imageStyle');
     }
-  }, [selectedField, fieldPositions, fieldStyles, brandElements, pageTemplate]);
+  }, [selectedField]);
 
   const updateFieldStyle = (property, value) => {
     if (!isTextField) return;


### PR DESCRIPTION
This commit fixes a persistent UI bug in the `FormattingPanel` where editing a property in one accordion (e.g., the 'Textbox' section) would cause it to collapse and another accordion ('Font and Style') to expand.

The root cause was a `useEffect` hook that was responsible for both updating the currently selected element's data and setting the default expanded accordion. This effect was running on every style change, incorrectly resetting the accordion's state.

The fix refactors this into two separate `useEffect` hooks:
1.  One effect to keep the element's data in sync, which runs on style/position changes.
2.  A second, more specific effect that *only* runs when the `selectedField` ID changes. This effect is now solely responsible for setting the default expanded accordion for the newly selected element.

This separation of concerns ensures that editing a property no longer affects which accordion is open, providing a much smoother and more predictable user experience.