### PR TITLE
fix(editor): Ensure PageEditor inherits template styles correctly

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -46,6 +46,8 @@ const PageEditor = ({
   aspectRatio,
   handleImageUpload,
   onChangeBackgroundImage,
+  globalFieldPositions,
+  globalFieldStyles,
 }) => {
   const [editedPositions, setEditedPositions] = useState({});
   const [editedStyles, setEditedStyles] = useState({});
@@ -73,8 +75,8 @@ const PageEditor = ({
 
   useEffect(() => {
     if (open && pageData) {
-      const initialPositions = pageData.customFieldPositions || pageData.fieldPositions || {};
-      const initialStyles = pageData.customFieldStyles || pageData.fieldStyles || {};
+      const initialPositions = pageData.customFieldPositions || globalFieldPositions || {};
+      const initialStyles = pageData.customFieldStyles || globalFieldStyles || {};
       const initialBrandElements = pageData.customBrandElements || brandElements || [];
       const initialTemplate = pageData.customPageTemplate || globalPageTemplate || defaultPageTemplate;
 
@@ -90,7 +92,7 @@ const PageEditor = ({
       setEditedStyles(newEditedStyles);
 
     }
-  }, [open, pageData, globalCsvHeaders, brandElements, globalPageTemplate]);
+  }, [open, pageData, globalCsvHeaders, brandElements, globalPageTemplate, globalFieldPositions, globalFieldStyles]);
 
   if (!pageData) return null;
 

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -624,6 +624,8 @@ const PageGeneratorFrontendOnly = ({
           originalImageSize={originalImageSize}
           handleImageUpload={handleImageUpload}
           onChangeBackgroundImage={onChangeBackgroundImage}
+          globalFieldPositions={fieldPositions}
+          globalFieldStyles={fieldStyles}
         />
       )}
 


### PR DESCRIPTION
This commit fixes a critical bug where opening a newly generated page in the `PageEditor` modal would result in a blank canvas with no elements.

The root cause was that the `PageEditor` was not being passed the global `fieldPositions` and `fieldStyles` from the main page template. When a page had no custom overrides, the editor would initialize with empty position and style objects, causing no elements to be rendered.

The fix involves:
1.  Passing the global `fieldPositions` and `fieldStyles` from `PageGeneratorFrontendOnly` down to `PageEditor`.
2.  Updating the `useEffect` hook in `PageEditor` to use these global props as the fallback if `pageData.customFieldPositions` or `pageData.customFieldStyles` do not exist.

This ensures that newly generated pages correctly inherit from the main template when opened in the editor, resolving the blank canvas issue.