### PR TITLE
Fix: Corrige regressões e UI na geração de páginas

### DIFF
--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -148,24 +148,6 @@ const ImageStepUI = ({
           overflowY: 'auto'
         }}>
           <Stack spacing={2}>
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Button
-                variant="contained"
-                component="label"
-                startIcon={<ImageIcon />}
-                fullWidth
-              >
-                Carregar
-                <input type="file" accept=".png,.jpg,.jpeg" hidden ref={imageInputRef} onChange={handleImageUpload} />
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={onChangeBackgroundImage}
-                fullWidth
-              >
-                Galeria
-              </Button>
-            </Box>
             <FormattingPanel
               showImageLoaders={true}
               handleImageUpload={handleImageUpload}


### PR DESCRIPTION
Este commit aborda uma série de problemas no fluxo de geração de páginas:

- **Validação de Fundo:** A lógica de validação agora considera gradientes como um fundo válido para a página, corrigindo um bug que impedia a geração de páginas com esse tipo de fundo.
- **Escala da Fonte:** A geração em massa de páginas agora utiliza uma escala de fonte fixa de 100% (fontScale: 1), resolvendo o problema de fontes desproporcionalmente grandes na geração inicial.
- **Thumbnails em Modo Escuro:** O fundo das miniaturas das páginas geradas agora se adapta ao tema (usando `background.paper`) e possui um padding para criar um efeito de borda, melhorando a aparência em temas escuros.
- **Botões Duplicados:** Remove a duplicação dos botões "Carregar" e "Galeria" na interface de edição de modelo de página, mantendo a funcionalidade em todos os contextos necessários (desktop e móvel).