### PR TITLE
Fix: Corrige regressões, bugs de UI e de edição

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -48,10 +48,10 @@ const FormattingPanel = ({
   showImageLoaders = false,
   handleImageUpload,
   onChangeBackgroundImage,
+  selectedField,
+  setSelectedField,
 }) => {
   const {
-    selectedField,
-    setSelectedField,
     fieldStyles,
     setFieldStyles,
     fieldPositions,

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -917,7 +917,11 @@ function HomePage() {
       updateImageAndPalette(imageUrl);
       return true;
     } catch (imageError) {
-      toast.error(`Ocorreu um erro ao gerar a imagem da campanha: ${imageError.message}`);
+      if (imageError.message && imageError.message.includes('503')) {
+        toast.error('O serviço de geração de imagem está indisponível no momento. Tente novamente mais tarde.');
+      } else {
+        toast.error(`Ocorreu um erro ao gerar a imagem da campanha: ${imageError.message}`);
+      }
       console.log('[HomePage] DIAGNOSTIC: handleGenerateImage failed. Setting generatedPageUrl to null.');
       setGeneratedPageUrl(null);
       return false;
@@ -1062,7 +1066,11 @@ function HomePage() {
             effectivePageTemplate = tempPageTemplate; // Update for this generation pass
             pageUpdateData.customPageTemplate = tempPageTemplate; // Persist this change
         } catch (error) {
-            toast.error(`Falha ao gerar imagem para o post #${index + 1}: ${error.message}`);
+            if (error.message && error.message.includes('503')) {
+                toast.error(`O serviço de geração de imagem está indisponível no momento. Tente novamente mais tarde para o post #${index + 1}.`);
+            } else {
+                toast.error(`Falha ao gerar imagem para o post #${index + 1}: ${error.message}`);
+            }
         }
     }
 


### PR DESCRIPTION
Este commit aborda uma série de problemas no fluxo de geração e edição de páginas:

- **Validação de Fundo:** A lógica de validação agora considera gradientes como um fundo válido para a página.
- **Escala da Fonte:** A geração em massa de páginas agora utiliza uma escala de fonte fixa para evitar textos desproporcionais.
- **Thumbnails em Modo Escuro:** O fundo das miniaturas agora se adapta ao tema e possui um padding para criar um efeito de borda.
- **Botões Duplicados:** Remove a duplicação dos botões "Carregar" e "Galeria" na interface de edição de modelo de página.
- **Tratamento de Erro da API:** Melhora a mensagem de erro exibida ao usuário quando a API de geração de imagem (Gemini) retorna um erro 503 (serviço indisponível).
- **Bug de Edição de Campo:** Corrige um bug crítico no editor de páginas geradas onde a seleção de campo não funcionava, impedindo o redimensionamento/posicionamento e aplicando edições ao campo errado. A causa era um problema de gerenciamento de estado entre o `PageEditor` e o `FormattingPanel`.