### PR TITLE
Fix: Corrige múltiplas regressões e bugs críticos de edição

### DIFF
--- a/src/hooks/usePageData.js
+++ b/src/hooks/usePageData.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useCampaign } from '../context/CampaignContext';
 
 /**
@@ -15,20 +16,22 @@ export const usePageData = (pageIndex) => {
     brandElements,
   } = useCampaign();
 
-  // Lógica para determinar os dados corretos (será implementada a seguir)
-  const pageData = generatedPagesData.find(p => p.index === pageIndex);
+  const pageData = useMemo(() => {
+    return generatedPagesData.find(p => p.index === pageIndex);
+  }, [generatedPagesData, pageIndex]);
 
-  const isCustom = Boolean(pageData?.customPageTemplate || pageData?.customFieldPositions || pageData?.customFieldStyles);
+  const data = useMemo(() => {
+    const isCustom = Boolean(pageData?.customPageTemplate || pageData?.customFieldPositions || pageData?.customFieldStyles);
 
-  // Por enquanto, retorna um placeholder. A lógica completa será adicionada.
-  const data = {
-    isCustom,
-    effectivePageTemplate: pageData?.customPageTemplate || pageTemplate,
-    effectiveFieldPositions: pageData?.customFieldPositions || fieldPositions,
-    effectiveFieldStyles: pageData?.customFieldStyles || fieldStyles,
-    effectiveBrandElements: pageData?.customBrandElements || brandElements,
-    record: pageData?.record,
-  };
+    return {
+      isCustom,
+      effectivePageTemplate: pageData?.customPageTemplate || pageTemplate,
+      effectiveFieldPositions: pageData?.customFieldPositions || fieldPositions,
+      effectiveFieldStyles: pageData?.customFieldStyles || fieldStyles,
+      effectiveBrandElements: pageData?.customBrandElements || brandElements,
+      record: pageData?.record,
+    };
+  }, [pageData, pageTemplate, fieldPositions, fieldStyles, brandElements]);
 
   return data;
 };


### PR DESCRIPTION
Este commit aborda uma série de problemas identificados no fluxo de geração e edição de páginas, culminando na correção de um bug de re-renderização infinita.

- **Validação de Fundo:** A lógica de validação agora considera gradientes como um fundo válido para a página.
- **Escala da Fonte:** A geração em massa de páginas agora utiliza uma escala de fonte fixa para evitar textos desproporcionais.
- **Thumbnails em Modo Escuro:** O fundo das miniaturas agora se adapta ao tema e possui um padding para criar um efeito de borda.
- **Botões Duplicados:** Remove a duplicação dos botões "Carregar" e "Galeria" na interface de edição de modelo de página.
- **Tratamento de Erro da API:** Melhora a mensagem de erro exibida ao usuário quando a API de geração de imagem (Gemini) retorna um erro 503.
- **Bug de Loop Infinito e Edição:** Corrige um bug crítico no editor de páginas geradas que causava um loop de re-renderização, impedindo a seleção, redimensionamento e posicionamento de campos. A causa raiz foi resolvida memorizando o retorno do hook `usePageData` com `useMemo`, estabilizando o estado do componente.