### PR TITLE
Debug: Add console log to DraggableElement

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -36,6 +36,7 @@ const DraggableElementInternal = ({
   darkMode,
   onDoubleClick,
 }) => {
+  console.log('[DraggableElement] PROPS RECEIVED:', { element, content });
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isRotating, setIsRotating] = useState(false);


### PR DESCRIPTION
Adds a console.log statement to the DraggableElement component to inspect the props it receives during render. This is for debugging a persistent issue where images are not displayed in the page editor.