### PR TITLE
feat(debug): Add temporary logs for background rendering

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -36,7 +36,9 @@ const DraggableElementInternal = ({
   darkMode,
   onDoubleClick,
 }) => {
-  console.log('[DraggableElement] PROPS RECEIVED:', { element, content });
+  if (element.type === 'image') {
+    console.log(`[DraggableElement] Image element received. Type: ${element.type}, Content starts with: ${String(content).substring(0, 100)}`);
+  }
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isRotating, setIsRotating] = useState(false);

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -287,6 +287,9 @@ const FieldPositioner = ({
   const renderableElements = React.useMemo(() => {
     const elements = [];
 
+    // DEBUG: Log the images array from pageTemplate
+    console.log('[FieldPositioner] Creating renderableElements. pageTemplate.images:', JSON.stringify(pageTemplate.images, null, 2));
+
     // Add page images
     (pageTemplate.images || []).forEach(image => {
         if (!image.visible) return;


### PR DESCRIPTION
This commit adds temporary console.log statements to the FieldPositioner and DraggableElement components.

These logs are intended to help diagnose a persistent visual bug where the background image in the PageEditor does not update correctly. This build is not a fix, but a tool to gather more information from a live test environment.