### PR TITLE
Fix: Complete correction of the Page Editor

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -31,7 +31,6 @@ import {
   Image as ImageIcon,
   BrandingWatermark,
 } from '@mui/icons-material';
-import { useCampaign } from '../context/CampaignContext';
 import BrandElementManager from './BrandElementManager';
 import ImageManager from './ImageManager';
 import TextFormatting from './formatting/TextFormatting';
@@ -50,18 +49,15 @@ const FormattingPanel = ({
   onChangeBackgroundImage,
   selectedField,
   setSelectedField,
+  fieldStyles,
+  setFieldStyles,
+  fieldPositions,
+  setFieldPositions,
+  brandElements,
+  setBrandElements,
+  pageTemplate,
+  setPageTemplate,
 }) => {
-  const {
-    fieldStyles,
-    setFieldStyles,
-    fieldPositions,
-    setFieldPositions,
-    brandElements,
-    setBrandElements,
-    pageTemplate,
-    setPageTemplate,
-  } = useCampaign();
-
   const [expandedPanel, setExpandedPanel] = React.useState(false);
 
   const handleAccordionChange = (panel) => (event, isExpanded) => {

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -177,7 +177,7 @@ const PageGeneratorFrontendOnly = ({
         brandElements,
         fieldPositions,
         fieldStyles,
-        fontScale: 1,
+        fontScale,
         pageTemplate: pageTemplate,
         aspectRatio,
       })
@@ -552,9 +552,9 @@ const PageGeneratorFrontendOnly = ({
                             src={pageData.url}
                             alt={`Preview ${index + 1}`}
                             style={{
-                              maxWidth: '100%',
-                              maxHeight: '150px',
-                              objectFit: 'contain',
+                              width: '100%',
+                              height: '100%',
+                              objectFit: 'cover',
                               transition: 'transform 0.3s',
                               opacity: regeneratingIndex === index ? 0.5 : 1,
                             }}

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -30,8 +30,9 @@ import {
   FormatItalic,
   FormatUnderlined,
   Edit,
+  BlurOn,
 } from '@mui/icons-material';
-import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { ToggleButton, ToggleButtonGroup, Switch, FormControlLabel } from '@mui/material';
 
 const rgbStringToHex = (colorString) => {
   if (!colorString || !colorString.startsWith('rgb')) return colorString;
@@ -73,6 +74,22 @@ const TextFormatting = ({
       <Accordion expanded={expandedPanel === 'boxStyle'} onChange={handleAccordionChange('boxStyle')}>
         <AccordionSummary expandIcon={<ExpandMore />}><Typography><CheckBoxOutlineBlank sx={{ mr: 1, verticalAlign: 'middle' }} />Caixa de Texto</Typography></AccordionSummary>
         <AccordionDetails><Grid container spacing={2}><Grid item xs={6}><TextField label="Cor Fundo" type="color" value={rgbStringToHex(currentElement.style.backgroundColor || '#000000')} onChange={(e) => updateFieldStyle('backgroundColor', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={6}><Typography gutterBottom>Opacidade Fundo: {Math.round((currentElement.style.backgroundOpacity ?? 1) * 100)}%</Typography><Slider value={currentElement.style.backgroundOpacity ?? 1} onChange={(e, v) => updateFieldStyle('backgroundOpacity', v)} min={0} max={1} step={0.01} /></Grid><Grid item xs={6}><TextField label="Cor Borda" type="color" value={rgbStringToHex(currentElement.style.borderColor || '#000000')} onChange={(e) => updateFieldStyle('borderColor', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={6}><Typography gutterBottom>Largura Borda: {currentElement.style.borderWidth || 0}px</Typography><Slider value={currentElement.style.borderWidth || 0} onChange={(e, v) => updateFieldStyle('borderWidth', v)} min={0} max={20} /></Grid><Grid item xs={6}><Typography gutterBottom>Curva: {currentElement.style.borderRadius || 0}px</Typography><Slider value={currentElement.style.borderRadius || 0} onChange={(e, v) => updateFieldStyle('borderRadius', v)} min={0} max={50} /></Grid><Grid item xs={6}><Typography gutterBottom>Padding: {currentElement.style.padding || 0}px</Typography><Slider value={currentElement.style.padding || 0} onChange={(e, v) => updateFieldStyle('padding', v)} min={0} max={50} /></Grid></Grid></AccordionDetails>
+      </Accordion>
+      <Accordion expanded={expandedPanel === 'effects'} onChange={handleAccordionChange('effects')}>
+        <AccordionSummary expandIcon={<ExpandMore />}><Typography><BlurOn sx={{ mr: 1, verticalAlign: 'middle' }} />Efeitos</Typography></AccordionSummary>
+        <AccordionDetails>
+          <Grid container spacing={2}>
+            <Grid item xs={12}><FormControlLabel control={<Switch checked={currentElement.style.textShadow || false} onChange={(e) => updateFieldStyle('textShadow', e.target.checked)} />} label="Sombra de Texto" /></Grid>
+            {currentElement.style.textShadow && (
+              <>
+                <Grid item xs={6}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.style.shadowColor || '#000000')} onChange={(e) => updateFieldStyle('shadowColor', e.target.value)} fullWidth size="small" /></Grid>
+                <Grid item xs={6}><Typography gutterBottom>Blur: {currentElement.style.shadowBlur || 4}px</Typography><Slider value={currentElement.style.shadowBlur || 4} onChange={(e, v) => updateFieldStyle('shadowBlur', v)} min={0} max={50} /></Grid>
+                <Grid item xs={6}><Typography gutterBottom>Offset X: {currentElement.style.shadowOffsetX || 2}px</Typography><Slider value={currentElement.style.shadowOffsetX || 2} onChange={(e, v) => updateFieldStyle('shadowOffsetX', v)} min={-50} max={50} /></Grid>
+                <Grid item xs={6}><Typography gutterBottom>Offset Y: {currentElement.style.shadowOffsetY || 2}px</Typography><Slider value={currentElement.style.shadowOffsetY || 2} onChange={(e, v) => updateFieldStyle('shadowOffsetY', v)} min={-50} max={50} /></Grid>
+              </>
+            )}
+          </Grid>
+        </AccordionDetails>
       </Accordion>
       <Divider sx={{ my: 2 }} /><Button variant="outlined" size="small" onClick={resetFieldStyle} color="secondary" fullWidth>Resetar Estilo</Button>
     </>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -543,6 +543,15 @@ function HomePage() {
   }, [aspectRatio]);
 
   useEffect(() => {
+    if (originalImageSize.width > 0 && displayedImageSize.width > 0) {
+      const scale = originalImageSize.width / displayedImageSize.width;
+      setFontScale(scale);
+    } else {
+      setFontScale(1);
+    }
+  }, [originalImageSize, displayedImageSize]);
+
+  useEffect(() => {
     if (activeStep === 1 && campaignContent) {
       const { titulo, conteudo, cta } = campaignContent;
       setPromptText(`${titulo || ''}\n\n${conteudo || ''}\n\n${cta || ''}`);


### PR DESCRIPTION
This commit resolves a set of critical bugs in the Page Editor, improving functionality and visual consistency.

The following issues have been addressed:

1.  **Broken Property Panel:** The communication between the `PageEditor` and the `FormattingPanel` has been fixed. The panel now correctly updates the editor's state by receiving its state and setters via props, rather than using a disconnected global context.

2.  **Restored 'Effects' Panel:** The 'Efeitos' (Effects) section for text formatting has been re-implemented in the `TextFormatting` component, allowing users to apply and control text shadows.

3.  **Corrected Thumbnail Rendering:** The thumbnail images in the `PageGeneratorFrontendOnly` component now use `object-fit: cover`. This eliminates image distortion and letterboxing, ensuring the thumbnails are visually consistent with the editor preview.

4.  **Corrected Font Scaling:** An automatic font scaling mechanism has been implemented. The application now calculates a scale factor based on the ratio between the final output resolution and the preview component size, ensuring fonts in thumbnails are scaled correctly and match the editor's appearance.