### PR TITLE
feat: Final Comprehensive Fix for Page Editor

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -48,13 +48,6 @@ const FormattingPanel = ({
   showImageLoaders = false,
   handleImageUpload,
   onChangeBackgroundImage,
-  selectedField,
-  setSelectedField,
-  fieldStyles,
-  setFieldStyles,
-  fieldPositions,
-  setFieldPositions,
-  brandElements,
   // Props for controlled state (from PageEditor)
   fieldStyles: fieldStylesProp,
   setFieldStyles: setFieldStylesProp,

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -31,6 +31,7 @@ import {
   Image as ImageIcon,
   BrandingWatermark,
 } from '@mui/icons-material';
+import { useCampaign } from '../context/CampaignContext';
 import BrandElementManager from './BrandElementManager';
 import ImageManager from './ImageManager';
 import TextFormatting from './formatting/TextFormatting';
@@ -54,10 +55,32 @@ const FormattingPanel = ({
   fieldPositions,
   setFieldPositions,
   brandElements,
-  setBrandElements,
-  pageTemplate,
-  setPageTemplate,
+  // Props for controlled state (from PageEditor)
+  fieldStyles: fieldStylesProp,
+  setFieldStyles: setFieldStylesProp,
+  fieldPositions: fieldPositionsProp,
+  setFieldPositions: setFieldPositionsProp,
+  brandElements: brandElementsProp,
+  setBrandElements: setBrandElementsProp,
+  pageTemplate: pageTemplateProp,
+  setPageTemplate: setPageTemplateProp,
+  selectedField: selectedFieldProp,
+  setSelectedField: setSelectedFieldProp,
 }) => {
+  const context = useCampaign();
+
+  // Use props if provided (controlled mode), otherwise use context (standalone mode)
+  const fieldStyles = fieldStylesProp ?? context.fieldStyles;
+  const setFieldStyles = setFieldStylesProp ?? context.setFieldStyles;
+  const fieldPositions = fieldPositionsProp ?? context.fieldPositions;
+  const setFieldPositions = setFieldPositionsProp ?? context.setFieldPositions;
+  const brandElements = brandElementsProp ?? context.brandElements;
+  const setBrandElements = setBrandElementsProp ?? context.setBrandElements;
+  const pageTemplate = pageTemplateProp ?? context.pageTemplate;
+  const setPageTemplate = setPageTemplateProp ?? context.setPageTemplate;
+  const selectedField = selectedFieldProp ?? context.selectedField;
+  const setSelectedField = setSelectedFieldProp ?? context.setSelectedField;
+
   const [expandedPanel, setExpandedPanel] = React.useState(false);
 
   const handleAccordionChange = (panel) => (event, isExpanded) => {

--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -50,21 +50,16 @@ const ImageStepUI = ({
   isCropping,
   setIsCropping,
   onFontScaleChange,
-  // Props that were previously from context
-  pageTemplate,
-  setPageTemplate,
-  fieldStyles,
-  setFieldStyles,
-  // fieldPositions, <-- Now from context
-  setFieldPositions,
-  brandElements,
-  setBrandElements,
-  selectedField,
-  setSelectedField,
-  // csvData,      <-- Now from context
-  // csvHeaders,   <-- Now from context
 }) => {
-  const { csvData, csvHeaders, fieldPositions } = useCampaign();
+  const {
+    csvData,
+    csvHeaders,
+    fieldPositions, setFieldPositions,
+    fieldStyles, setFieldStyles,
+    brandElements, setBrandElements,
+    pageTemplate, setPageTemplate,
+    selectedField, setSelectedField,
+  } = useCampaign();
 
   const handleNextPreview = () => {
     setCurrentPreviewIndex(prevIndex => Math.min(prevIndex + 1, csvData.length - 1));

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1261,21 +1261,6 @@ function HomePage() {
                     onFontScaleChange={setFontScale}
                     templateFieldStyles={templateFieldStyles}
                     activeStep={activeStep}
-                    // Pass all state and setters for FormattingPanel
-                    pageTemplate={pageTemplate}
-                    setPageTemplate={setPageTemplate}
-                    fieldStyles={fieldStyles}
-                    setFieldStyles={setFieldStyles}
-                    fieldPositions={fieldPositions}
-                    setFieldPositions={setFieldPositions}
-                    brandElements={brandElements}
-                    setBrandElements={setBrandElements}
-                    selectedField={selectedField}
-                    setSelectedField={setSelectedField}
-                    // No longer need to pass these, ImageStepUI gets them from context now
-                    // csvData={csvData}
-                    // csvHeaders={csvHeaders}
-                    // fieldPositions={fieldPositions}
                   />
                 )}
                 {activeStep === 4 && (


### PR DESCRIPTION
This commit resolves a wide range of bugs throughout the Page Editor, addressing state management, UI controls, visual rendering, and data serialization issues to create a stable and functional user experience.

Key fixes include:

1.  **State Management:** Refactored `FormattingPanel` to be a flexible component that uses props when provided (for controlled "draft" states in the `PageEditor` modal) and falls back to the global `useCampaign` context otherwise. This fixes numerous state synchronization bugs. The prop-drilling to `ImageStep` was removed, simplifying the component hierarchy.

2.  **Image Handling and Rendering:**
    - Fixed a critical bug in `DraggableElement.jsx` that prevented images from rendering in the preview. It now correctly renders an `<img>` tag.
    - Updated `DraggableElement.module.css` to properly style and contain these images.
    - Removed the concept of a special "background image". All images are now treated as selectable, draggable elements with a default `zIndex` of 1, per the user's final clarification.

3.  **UI Controls and Visuals:**
    - Restored and completed the 'Efeitos' (Effects) panel in the text formatter to include controls for both Text Shadow and Text Outline (Stroke).
    - Fixed thumbnail distortion by setting `object-fit: cover`.
    - Corrected font scaling issues by ensuring a 1:1 scale between the editor and the final render.

4.  **Data Serialization:**
    - Corrected the campaign saving logic in `campaignState.js` to properly handle `generatedPagesData`. The app now correctly extracts generated images, uploads them to blob storage, and replaces the temporary data with a permanent URL, resolving the "413 Content Too Large" error on save.