### PR TITLE
fix: Correct font and image scaling in page editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -247,10 +247,12 @@ const FieldPositioner = ({
 
   useEffect(() => {
     if (renderedImageMetrics.width > 0 && effectiveImageSize?.width > 0) {
-      const scale = renderedImageMetrics.width / effectiveImageSize.width;
-      setFontScale(scale);
+      const previewScale = renderedImageMetrics.width / effectiveImageSize.width;
+      setFontScale(previewScale); // Local scale for preview rendering
+
+      const finalRenderScale = effectiveImageSize.width / renderedImageMetrics.width;
       if (onFontScaleChange) {
-        onFontScaleChange(scale);
+        onFontScaleChange(finalRenderScale); // Pass up the correct scale for final rendering
       }
     } else {
       setFontScale(1);

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -51,6 +51,7 @@ const PageEditor = ({
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [editingField, setEditingField] = useState(null);
+  const [modalFontScale, setModalFontScale] = useState(1);
   const isMobile = useIsMobile();
 
   const handleOpenHtmlEditor = (fieldId) => {
@@ -127,6 +128,7 @@ const PageEditor = ({
       customFieldStyles: editedStyles,
       customBrandElements: editedBrandElements,
       customPageTemplate: editedPageTemplate,
+      fontScale: modalFontScale, // Pass the correct font scale on save
     };
     console.log('[PageEditor] handleSave called. Data being passed up:', savedData);
     onSave(savedData);
@@ -162,6 +164,7 @@ const PageEditor = ({
               pageTemplate={editedPageTemplate}
               setPageTemplate={setEditedPageTemplate}
               currentPreviewIndex={0}
+              onFontScaleChange={setModalFontScale} // Capture the scale from the preview
             />
           </Grid>
           {!isMobile && (


### PR DESCRIPTION
This commit resolves two distinct scaling-related bugs in the page editor:

1.  **Corrected Font Scaling Calculation:** The logic in `FieldPositioner.jsx` that calculates the font scale for the final render has been corrected. It now correctly computes the ratio of the final image width to the preview width (`final_width / preview_width`), ensuring that text in the generated thumbnails is scaled proportionally to match the visual appearance of the editor preview.

2.  **Preserved Font Scale from PageEditor Modal:** The `PageEditor` component now captures the font scale from its internal preview. This scale is attached to the saved data, ensuring that when a single page is re-generated after being edited, it uses the correct font scale that the user saw in the modal preview, preventing visual inconsistencies.