### PR TITLE
Fix: Prevent rendering of image elements without a valid source URL

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -289,7 +289,7 @@ const FieldPositioner = ({
 
     // Add page images
     (pageTemplate.images || []).forEach(image => {
-        if (image.visible === false) return;
+        if (image.visible === false || !image.src) return;
         elements.push({
             id: image.id,
             type: 'image',
@@ -344,7 +344,7 @@ const FieldPositioner = ({
 
     const brandEls = (brandElements || [])
       .map(element => {
-        if (element.visible === false) return null;
+        if (element.visible === false || !element.url) return null;
         return {
           id: element.id,
           type: 'image',


### PR DESCRIPTION
This commit addresses an issue where images could be added to the preview canvas without a valid `src` or `url`, causing them to be invisible and unselectable. This also led to inconsistencies between the template preview and the final generated page.

The change modifies `FieldPositioner.jsx` to add checks that ensure an image element has a valid source URL before it is added to the list of renderable elements. This makes the preview more robust and consistent with the behavior of the final page generation.