### PR TITLE
Refactor: Lift PageEditor state to fix image list updates

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -39,6 +39,8 @@ const PageEditor = ({
   standardsColors,
   aspectRatio,
   onChangeBackgroundImage,
+  editedPageTemplate,
+  setEditedPageTemplate,
 }) => {
   const { csvHeaders } = useCampaign();
   const pageDataFromHook = usePageData(pageData?.index);
@@ -47,7 +49,6 @@ const PageEditor = ({
   const [editedStyles, setEditedStyles] = useState(null);
   const [editedBrandElements, setEditedBrandElements] = useState(null);
   const [editedRecord, setEditedRecord] = useState(null);
-  const [editedPageTemplate, setEditedPageTemplate] = useState(null);
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [editingField, setEditingField] = useState(null);
@@ -89,14 +90,12 @@ const PageEditor = ({
         effectiveFieldPositions,
         effectiveFieldStyles,
         effectiveBrandElements,
-        effectivePageTemplate,
         record,
       } = pageDataFromHook;
 
       setEditedPositions(JSON.parse(JSON.stringify(effectiveFieldPositions)));
       setEditedBrandElements(JSON.parse(JSON.stringify(effectiveBrandElements)));
       setEditedRecord(JSON.parse(JSON.stringify(record)));
-      setEditedPageTemplate(JSON.parse(JSON.stringify(effectivePageTemplate)));
 
       const newEditedStyles = {};
       (csvHeaders || []).forEach(field => {
@@ -109,7 +108,6 @@ const PageEditor = ({
       setEditedStyles(null);
       setEditedBrandElements(null);
       setEditedRecord(null);
-      setEditedPageTemplate(null);
       setSelectedFieldInternal(null);
     }
   }, [open, pageData, pageDataFromHook, csvHeaders]);

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -75,6 +75,7 @@ const PageGeneratorFrontendOnly = ({
   const [selectedPreview, setSelectedPreview] = useState(null);
   const [editingGeneratedPageIndex, setEditingGeneratedPageIndex] = useState(null);
   const [showGeneratedPageEditor, setShowGeneratedPageEditor] = useState(false);
+  const [pageTemplateForEditor, setPageTemplateForEditor] = useState(null);
   const { googleAccessToken } = useUserAuth();
   const isGoogleDriveConnected = !!googleAccessToken;
   const [projectName, setProjectName] = useState('');
@@ -323,6 +324,8 @@ const PageGeneratorFrontendOnly = ({
   };
 
   const handleOpenGeneratedPageEditor = (pageFromClosure, index) => {
+    const template = pageFromClosure.customPageTemplate || pageTemplate;
+    setPageTemplateForEditor(JSON.parse(JSON.stringify(template)));
     setEditingGeneratedPageIndex(index);
     setShowGeneratedPageEditor(true);
   };
@@ -330,6 +333,7 @@ const PageGeneratorFrontendOnly = ({
   const handleCloseGeneratedPageEditor = () => {
     setShowGeneratedPageEditor(false);
     setEditingGeneratedPageIndex(null);
+    setPageTemplateForEditor(null);
   };
 
   const handleSaveIndividualModifications = async (modifiedPageData) => {
@@ -622,6 +626,8 @@ const PageGeneratorFrontendOnly = ({
           aspectRatio={aspectRatio}
           originalImageSize={originalImageSize}
           onChangeBackgroundImage={onChangeBackgroundImage}
+          editedPageTemplate={pageTemplateForEditor}
+          setEditedPageTemplate={setPageTemplateForEditor}
         />
       )}
 


### PR DESCRIPTION
This commit refactors the state management for the page editor to resolve an issue where the image list would not update after a new image was uploaded.

The `editedPageTemplate` state, which was previously managed locally within `PageEditor.jsx`, has been lifted to the parent component, `PageGeneratorFrontendOnly.jsx`.

This change prevents the component's state from being reset on re-renders, ensuring that newly added images are correctly reflected in the UI.