### PR TITLE
fix: Comprehensive fix for image handling and editor UI

### DIFF
--- a/src/components/DraggableElement.module.css
+++ b/src/components/DraggableElement.module.css
@@ -137,7 +137,7 @@
   border-radius: 50%;
   cursor: grab;
   pointer-events: auto;
-  z-index: 11;
+  z-index: 9999;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -40,6 +40,7 @@ import {
 } from '@mui/icons-material';
 import PageEditor from './PageEditor';
 import { createFolder, uploadFile, createSpreadsheet } from '../utils/googleApi';
+import { upload } from '@vercel/blob/client';
 import { drawAndComposeImage, dataURLtoBlob, wrapTextInArea, applyTextEffects, drawTextWithEffects } from '../utils/imageComposer';
 import { createNewImageElement } from '../utils/elementFactory';
 import { useUserAuth } from '../context/UserAuthContext';
@@ -82,6 +83,7 @@ const PageGeneratorFrontendOnly = ({
   const [isUploadingToDrive, setIsUploadingToDrive] = useState(false);
   const [driveResult, setDriveResult] = useState(null);
   const [replacingImageIndex, setReplacingImageIndex] = useState(null);
+  const [isReplacingImage, setIsReplacingImage] = useState(false);
   const [regeneratingIndex, setRegeneratingIndex] = useState(null);
   const individualImageInputRef = useRef(null);
   const [fontsLoaded, setFontsLoaded] = useState(false);
@@ -380,50 +382,59 @@ const PageGeneratorFrontendOnly = ({
     }
   };
 
-  const handleIndividualImageUpload = (event) => {
+  const handleIndividualImageUpload = async (event) => {
     const file = event.target.files[0];
-    if (file && replacingImageIndex !== null) {
-      const reader = new FileReader();
-      reader.onload = async (e) => {
-        const newImageUrl = e.target.result;
-        const pageToUpdate = initialGeneratedPagesData.find(img => img.index === replacingImageIndex);
-        if (pageToUpdate) {
-          const templateToUpdate = pageToUpdate.customPageTemplate || pageTemplate;
-          const newImageElement = createNewImageElement(newImageUrl);
-          newImageElement.zIndex = -1; // Keep the background zIndex
-
-          const updatedTemplate = {
-            ...templateToUpdate,
-            images: [newImageElement, ...templateToUpdate.images.slice(1)],
-          };
-
-          try {
-            const newPageData = await regenerateSinglePage(
-              replacingImageIndex,
-              pageToUpdate.record,
-              updatedTemplate,
-              pageToUpdate.customFieldPositions || fieldPositions,
-              pageToUpdate.customFieldStyles || fieldStyles,
-              pageToUpdate.customBrandElements || brandElements,
-              pageToUpdate.fontScale || 1
-            );
-            setGeneratedPagesData(currentPages => currentPages.map(p => {
-              if (p.index === replacingImageIndex) {
-                return { ...p, ...newPageData, customPageTemplate: updatedTemplate };
-              }
-              return p;
-            }));
-          } catch (error) {
-            alert(`Falha ao substituir o fundo da página: ${error.message}`);
-          }
-        }
-      };
-      reader.readAsDataURL(file);
+    if (!file || replacingImageIndex === null) {
+      if (individualImageInputRef.current) individualImageInputRef.current.value = "";
+      setReplacingImageIndex(null);
+      return;
     }
-    if (individualImageInputRef.current) {
-      individualImageInputRef.current.value = "";
+
+    setIsReplacingImage(true);
+    const currentIndex = replacingImageIndex; // Capture index before resetting
+    setRegeneratingIndex(currentIndex); // Use existing state to show loading on the specific card
+
+    try {
+      const newBlob = await upload(file.name, file, {
+        access: 'public',
+        handleUploadUrl: '/api/upload',
+      });
+
+      const pageToUpdate = initialGeneratedPagesData.find(img => img.index === currentIndex);
+      if (pageToUpdate) {
+        const templateToUpdate = pageToUpdate.customPageTemplate || pageTemplate;
+        const newImageElement = createNewImageElement(newBlob.url);
+        newImageElement.zIndex = -1;
+
+        const updatedTemplate = {
+          ...templateToUpdate,
+          images: [newImageElement, ...templateToUpdate.images.slice(1)],
+        };
+
+        const newPageData = await regenerateSinglePage(
+          currentIndex,
+          pageToUpdate.record,
+          updatedTemplate,
+          pageToUpdate.customFieldPositions || fieldPositions,
+          pageToUpdate.customFieldStyles || fieldStyles,
+          pageToUpdate.customBrandElements || brandElements,
+          pageToUpdate.fontScale || 1
+        );
+
+        setGeneratedPagesData(currentPages => currentPages.map(p =>
+          p.index === currentIndex
+            ? { ...p, ...newPageData, customPageTemplate: updatedTemplate }
+            : p
+        ));
+      }
+    } catch (error) {
+      alert(`Falha ao substituir o fundo da página: ${error.message}`);
+    } finally {
+      if (individualImageInputRef.current) individualImageInputRef.current.value = "";
+      setReplacingImageIndex(null);
+      setIsReplacingImage(false);
+      setRegeneratingIndex(null); // Stop loading indicator
     }
-    setReplacingImageIndex(null);
   };
 
   const uploadToGoogleDrive = async () => {


### PR DESCRIPTION
This commit resolves several critical issues related to image handling and the page editor's UI:

1.  **Fix `Content Too Large` Error on Upload:**
    - Replaced all instances of `FileReader.readAsDataURL` with a robust server-side upload mechanism using `@vercel/blob/client`.
    - This affects both the main image uploader in `PageEditor` and the 'Replace Background' functionality in `PageGeneratorFrontendOnly`.
    - Images are now uploaded to Vercel Blob storage, and only the returned URL is stored in the campaign state, preventing payload size errors.
    - Added loading indicators to the UI for better user feedback during uploads.

2.  **Fix Z-Index Stacking:**
    - The `handleZIndexChange` function in `FormattingPanel.jsx` was refactored to be aware of all element types (page images, brand elements, and text fields).
    - This ensures that elements now stack correctly when using "Send to Back" or "Bring to Front", resolving the initial bug report.

3.  **Fix Invisible Rotation Handle:**
    - The rotation handle was being clipped by a parent container with `overflow: hidden`.
    - Fixed by changing the container's `overflow` to `visible` in `FieldPositioner.jsx`.
    - Also increased the handle's `z-index` in `DraggableElement.module.css` to `9999` to ensure it always appears on top.