### PR TITLE
fix(editing): Corrige o z-index e a lógica de inserção da galeria de …

### DIFF
--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -27,7 +27,7 @@ const FormattingDrawer = ({
   setIsCropping,
   showImageLoaders,
   handleImageUpload,
-  onChangeBackgroundImage,
+  onOpenImageGallery,
 }) => {
   return (
     <Drawer anchor="right" open={open} onClose={onClose} sx={{ zIndex: 1400 }}>
@@ -60,7 +60,7 @@ const FormattingDrawer = ({
           setIsCropping={setIsCropping}
           showImageLoaders={showImageLoaders}
           handleImageUpload={handleImageUpload}
-          onChangeBackgroundImage={onChangeBackgroundImage}
+          onOpenImageGallery={onOpenImageGallery}
         />
       </Box>
     </Drawer>

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -47,7 +47,7 @@ const FormattingPanel = ({
   setIsCropping,
   showImageLoaders = false,
   handleImageUpload,
-  onChangeBackgroundImage,
+  onOpenImageGallery,
   // Props for controlled state (from PageEditor)
   fieldStyles: fieldStylesProp,
   setFieldStyles: setFieldStylesProp,
@@ -217,7 +217,7 @@ const FormattingPanel = ({
             <Button variant="contained" component="label" startIcon={<ImageIcon />} fullWidth>
               Carregar <input type="file" accept=".png,.jpg,.jpeg" hidden onChange={handleImageUpload} />
             </Button>
-            <Button variant="outlined" onClick={onChangeBackgroundImage} fullWidth> Galeria </Button>
+            <Button variant="outlined" onClick={onOpenImageGallery} fullWidth> Galeria </Button>
           </Box>
         )}
         {!currentElement ? (

--- a/src/components/ImageGallerySelector.jsx
+++ b/src/components/ImageGallerySelector.jsx
@@ -118,8 +118,8 @@ const BackgroundImageSelector = ({ open, onClose, onSelect, onLocalUpload }) => 
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
-      <DialogTitle>Selecionar Imagem de Fundo</DialogTitle>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" sx={{ zIndex: 1400 }}>
+      <DialogTitle>Selecionar Imagem</DialogTitle>
       <DialogContent sx={{ p: 0 }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={tab} onChange={(e, newValue) => setTab(newValue)} centered>

--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -30,7 +30,7 @@ const ImageStepUI = ({
   handleImageDragLeave,
   imageInputRef,
   handleImageUpload,
-  onChangeBackgroundImage,
+  onOpenImageGallery,
   initialFieldStyles,
   onImageDisplayedSizeChange,
   colorPalette,
@@ -151,7 +151,7 @@ const ImageStepUI = ({
             <FormattingPanel
               showImageLoaders={true}
               handleImageUpload={handleImageUpload}
-              onChangeBackgroundImage={onChangeBackgroundImage}
+              onOpenImageGallery={onOpenImageGallery}
               selectedField={selectedField}
               setSelectedField={setSelectedField}
               fieldStyles={fieldStyles}
@@ -211,7 +211,7 @@ const ImageStepUI = ({
             setIsCropping={setIsCropping}
             showImageLoaders={true}
             handleImageUpload={handleImageUpload}
-            onChangeBackgroundImage={onChangeBackgroundImage}
+            onOpenImageGallery={onOpenImageGallery}
           />
         </>
       )}

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -38,7 +38,7 @@ const PageEditor = ({
   originalImageSize,
   standardsColors,
   aspectRatio,
-  onChangeBackgroundImage,
+  onOpenImageGallery,
   editedPageTemplate,
   setEditedPageTemplate,
 }) => {
@@ -183,7 +183,7 @@ const PageEditor = ({
                 standardsColors={standardsColors || colorPalette}
                 showImageLoaders={true}
                 handleImageUpload={handleLocalImageUpload}
-                onChangeBackgroundImage={onChangeBackgroundImage}
+                onOpenImageGallery={onOpenImageGallery}
               />
             </Grid>
           )}
@@ -214,7 +214,7 @@ const PageEditor = ({
             standardsColors={standardsColors || colorPalette}
             showImageLoaders={true}
             handleImageUpload={handleLocalImageUpload}
-            onChangeBackgroundImage={onChangeBackgroundImage}
+            onOpenImageGallery={onOpenImageGallery}
           />
         </>
       )}

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -56,7 +56,7 @@ const PageGeneratorFrontendOnly = ({
   handleGenerateSinglePage,
   aspectRatio,
   handleImageUpload, // New prop
-  onChangeBackgroundImage, // New prop
+  onOpenImageGallery,
 }) => {
   const {
     csvData,
@@ -625,7 +625,7 @@ const PageGeneratorFrontendOnly = ({
           standardsColors={standardsColors}
           aspectRatio={aspectRatio}
           originalImageSize={originalImageSize}
-          onChangeBackgroundImage={onChangeBackgroundImage}
+          onOpenImageGallery={() => onOpenImageGallery(editingGeneratedPageIndex)}
           editedPageTemplate={pageTemplateForEditor}
           setEditedPageTemplate={setPageTemplateForEditor}
         />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -42,7 +42,7 @@ import SetupModal from '../components/SetupModal';
 import CampaignStandardsModal from '../components/CampaignStandardsModal';
 import SaveCampaignModal from '../components/SaveCampaignModal';
 import LoadCampaignModal from '../components/LoadCampaignModal';
-import BackgroundImageSelector from '../components/BackgroundImageSelector';
+import ImageGallerySelector from '../components/ImageGallerySelector';
 import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
 
 
@@ -176,7 +176,8 @@ function HomePage() {
   const [showMemorialDescritivoModal, setShowMemorialDescritivoModal] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showLoadModal, setShowLoadModal] = useState(false);
-  const [showBgSelector, setShowBgSelector] = useState(false);
+  const [showImageGallery, setShowImageGallery] = useState(false);
+  const [imageGalleryTargetIndex, setImageGalleryTargetIndex] = useState(null);
   const [currentPreviewIndex, setCurrentPreviewIndex] = useState(0);
   const [uploadProgress, setUploadProgress] = useState({ current: 0, total: 0 });
   const [fontScale, setFontScale] = useState(1);
@@ -657,26 +658,36 @@ function HomePage() {
   const handleDrop = (event) => { event.preventDefault(); event.stopPropagation(); const file = event.dataTransfer.files[0]; parseCsvFile(file); };
   const handleDragOver = (event) => { event.preventDefault(); event.stopPropagation(); };
 
+  const handleOpenImageGallery = (index = null) => {
+    console.log(`[HomePage] Opening image gallery for index: ${index}`);
+    setImageGalleryTargetIndex(index);
+    setShowImageGallery(true);
+  };
+
+  const handleCloseImageGallery = () => {
+    setShowImageGallery(false);
+    setImageGalleryTargetIndex(null);
+  };
+
   const addNewImageToCanvas = useCallback((imageUrl) => {
-    console.log('[HomePage] addNewImageToCanvas called for step:', activeStep);
+    console.log(`[HomePage] addNewImageToCanvas called. Target index: ${imageGalleryTargetIndex}`);
     const newImage = createNewImageElement(imageUrl);
 
-    // This is the core fix: check which step we are on.
-    if (activeStep === 4) {
-      // We are on the "Page Editing" step, so apply to a single page.
+    // If target index is a number, we are on the "Page Editing" step for a specific page.
+    if (typeof imageGalleryTargetIndex === 'number') {
       setGeneratedPagesData(prevPages => {
         const newPages = [...prevPages];
-        const pageIndex = currentPreviewIndex;
+        const pageIndex = imageGalleryTargetIndex;
 
         if (pageIndex < 0 || pageIndex >= newPages.length) {
           console.error("Invalid page index for custom template update:", pageIndex);
+          toast.error(`Falha ao adicionar imagem: índice de página inválido (${pageIndex}).`);
           return prevPages;
         }
 
         const pageToUpdate = { ...newPages[pageIndex] };
         const baseTemplate = pageToUpdate.customPageTemplate || pageTemplate;
 
-        // Append the new image instead of replacing it.
         const newCustomTemplate = {
           ...baseTemplate,
           images: [...(baseTemplate.images || []), newImage],
@@ -685,16 +696,17 @@ function HomePage() {
         pageToUpdate.customPageTemplate = newCustomTemplate;
         newPages[pageIndex] = pageToUpdate;
 
+        console.log(`[HomePage] Image added to specific page index: ${pageIndex}`);
         toast.success(`Imagem adicionada à página ${pageIndex + 1}.`);
         return newPages;
       });
-
     } else {
-      // We are on another step (likely Step 3), so update the global template.
+      // Otherwise, update the global template (likely on Step 3).
       setPageTemplate(prevTemplate => ({
         ...prevTemplate,
         images: [...(prevTemplate.images || []), newImage],
       }));
+      console.log('[HomePage] Image added to global page template.');
       toast.success('Imagem adicionada ao modelo.');
     }
 
@@ -716,7 +728,7 @@ function HomePage() {
       setColorPalette([]);
     };
     img.src = imageUrl;
-  }, [activeStep, currentPreviewIndex, pageTemplate, setPageTemplate, setGeneratedPagesData, setColorPalette]);
+  }, [imageGalleryTargetIndex, pageTemplate, setPageTemplate, setGeneratedPagesData, setColorPalette]);
 
   const parseImageFile = (file) => {
     if (!file) return;
@@ -1280,7 +1292,7 @@ function HomePage() {
                     handleImageDragLeave={handleImageDragLeave}
                     imageInputRef={imageInputRef}
                     handleImageUpload={handleForegroundImageUpload} // Use new handler for foreground
-                    onChangeBackgroundImage={() => setShowBgSelector(true)} // This is for background
+                    onOpenImageGallery={handleOpenImageGallery}
                     initialFieldStyles={initialFieldStyles}
                     onImageDisplayedSizeChange={setDisplayedImageSize}
                     colorPalette={colorPalette}
@@ -1314,7 +1326,7 @@ function HomePage() {
                     aspectRatio={aspectRatio}
                     generatedPagesData={generatedPagesData}
                     handleImageUpload={handleImageUpload}
-                    onChangeBackgroundImage={() => setShowBgSelector(true)}
+                    onOpenImageGallery={handleOpenImageGallery}
                   />
                 )}
                 {activeStep === 5 && (
@@ -1374,9 +1386,9 @@ function HomePage() {
       <LoadCampaignModal open={showLoadModal} onClose={() => setShowLoadModal(false)} onLoad={handleLoadCampaign} onEdit={(campaign) => { setCurrentCampaign(campaign); setShowSaveModal(true); }} />
       <MemorialDescritivoModal open={showMemorialDescritivoModal} onClose={() => setShowMemorialDescritivoModal(false)} campaignData={campaignData} />
       <CampaignStandardsModal open={showCampaignStandardsModal} onClose={() => { setShowCampaignStandardsModal(false); loadCampaignStandards(); }} onGeneratePalette={async (briefing) => { try { const palette = await generateColorPalette(briefing); return palette; } catch (error) { toast.error(error.message || "Ocorreu um erro ao gerar a paleta de cores."); throw error; } }} />
-      <BackgroundImageSelector
-        open={showBgSelector}
-        onClose={() => setShowBgSelector(false)}
+      <ImageGallerySelector
+        open={showImageGallery}
+        onClose={handleCloseImageGallery}
         onSelect={handleImageSelected}
         onLocalUpload={parseImageFile}
       />


### PR DESCRIPTION
…imagens

Esta alteração aborda três problemas relacionados à edição de páginas e à galeria de imagens:

1.  **Z-index do Diálogo da Galeria:** O diálogo da galeria de imagens agora aparece sobreposto ao painel de edição de página, definindo um z-index explícito de 1400.

2.  **Inserção de Imagem em Página Gerada:** A lógica de inserção de imagens foi corrigida para garantir que, ao editar uma página gerada específica, a nova imagem seja adicionada apenas a essa página. Um novo estado (`imageGalleryTargetIndex`) foi introduzido para rastrear a página que está sendo editada, tornando a atualização consistente e previsível.

3.  **Clareza do Código:** Foram renomeadas todas as referências a "background image" (imagem de fundo) para "image gallery" (galeria de imagens) para refletir com mais precisão a funcionalidade, que é adicionar imagens de primeiro plano à tela, não como um fundo de página. Isso inclui o nome do componente `BackgroundImageSelector` -> `ImageGallerySelector`, a prop `onChangeBackgroundImage` -> `onOpenImageGallery` e variáveis de estado relacionadas.