### PR TITLE
feat(editing): Adiciona controle de ajuste de imagem e melhora UX da …

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -85,7 +85,7 @@ const DraggableElementInternal = ({
       return null;
     }
     if (element.type === 'image') {
-      return <img src={content} alt="Elemento de imagem" />;
+      return <img src={content} alt="Elemento de imagem" style={{ objectFit: style.objectFit || 'fill' }} />;
     }
 
     if (element.type === 'cropbox') {

--- a/src/components/DraggableElement.module.css
+++ b/src/components/DraggableElement.module.css
@@ -51,9 +51,9 @@
 }
 
 .imageElement img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .textContent {

--- a/src/components/formatting/ImageFormatting.jsx
+++ b/src/components/formatting/ImageFormatting.jsx
@@ -12,6 +12,8 @@ import {
   AccordionDetails,
   TextField,
   Typography,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import {
   ExpandMore,
@@ -45,7 +47,30 @@ const ImageFormatting = ({
     <>
       <Accordion expanded={expandedPanel === 'imageStyle'} onChange={handleAccordionChange('imageStyle')}>
         <AccordionSummary expandIcon={<ExpandMore />}><Typography><Palette sx={{ mr: 1, verticalAlign: 'middle' }} />Estilo da Imagem</Typography></AccordionSummary>
-        <AccordionDetails><Grid container spacing={2}><Grid item xs={12}><FormControlLabel control={<Switch checked={currentElement.shadow || false} onChange={(e) => updateElementProperty('shadow', e.target.checked)} />} label="Sombra" />{currentElement.shadow && (<Grid container spacing={2} sx={{ mt: 1 }}><Grid item xs={6}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.shadowColor || '#000000')} onChange={(e) => updateElementProperty('shadowColor', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={6}><Typography gutterBottom>Desfoque</Typography><Slider value={currentElement.shadowBlur || 10} onChange={(e, v) => updateElementProperty('shadowBlur', v)} min={0} max={50} /></Grid><Grid item xs={6}><Typography gutterBottom>Offset X</Typography><Slider value={currentElement.shadowOffsetX || 5} onChange={(e, v) => updateElementProperty('shadowOffsetX', v)} min={-50} max={50} /></Grid><Grid item xs={6}><Typography gutterBottom>Offset Y</Typography><Slider value={currentElement.shadowOffsetY || 5} onChange={(e, v) => updateElementProperty('shadowOffsetY', v)} min={-50} max={50} /></Grid></Grid>)}</Grid><Grid item xs={12}><Divider sx={{ my: 1 }} /></Grid><Grid item xs={6}><TextField label="Cor da Borda" type="color" value={rgbStringToHex(currentElement.borderColor || '#000000')} onChange={(e) => updateElementProperty('borderColor', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={6}><Typography gutterBottom>Largura da Borda (px)</Typography><Slider value={currentElement.borderWidth || 0} onChange={(e, v) => updateElementProperty('borderWidth', v)} min={0} max={50} /></Grid><Grid item xs={12}><Typography gutterBottom>Cantos Arredondados (px)</Typography><Slider value={currentElement.borderRadius || 0} onChange={(e, v) => updateElementProperty('borderRadius', v)} min={0} max={100} /></Grid></Grid></AccordionDetails>
+        <AccordionDetails>
+            <Grid container spacing={2}>
+                <Grid item xs={12}>
+                    <Typography gutterBottom>Ajuste da Imagem</Typography>
+                    <ToggleButtonGroup
+                        value={currentElement.objectFit || 'fill'}
+                        exclusive
+                        fullWidth
+                        size="small"
+                        onChange={(e, newFit) => { if (newFit) updateElementProperty('objectFit', newFit); }}
+                    >
+                        <ToggleButton value="fill">Preencher</ToggleButton>
+                        <ToggleButton value="contain">Conter</ToggleButton>
+                        <ToggleButton value="cover">Cobrir</ToggleButton>
+                    </ToggleButtonGroup>
+                </Grid>
+                <Grid item xs={12}><FormControlLabel control={<Switch checked={currentElement.shadow || false} onChange={(e) => updateElementProperty('shadow', e.target.checked)} />} label="Sombra" /></Grid>
+                {currentElement.shadow && (<Grid item xs={12}><Grid container spacing={2}><Grid item xs={6}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.shadowColor || '#000000')} onChange={(e) => updateElementProperty('shadowColor', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={6}><Typography gutterBottom>Desfoque</Typography><Slider value={currentElement.shadowBlur || 10} onChange={(e, v) => updateElementProperty('shadowBlur', v)} min={0} max={50} /></Grid><Grid item xs={6}><Typography gutterBottom>Offset X</Typography><Slider value={currentElement.shadowOffsetX || 5} onChange={(e, v) => updateElementProperty('shadowOffsetX', v)} min={-50} max={50} /></Grid><Grid item xs={6}><Typography gutterBottom>Offset Y</Typography><Slider value={currentElement.shadowOffsetY || 5} onChange={(e, v) => updateElementProperty('shadowOffsetY', v)} min={-50} max={50} /></Grid></Grid></Grid>)}
+                <Grid item xs={12}><Divider sx={{ my: 1 }} /></Grid>
+                <Grid item xs={6}><TextField label="Cor da Borda" type="color" value={rgbStringToHex(currentElement.borderColor || '#000000')} onChange={(e) => updateElementProperty('borderColor', e.target.value)} fullWidth size="small" /></Grid>
+                <Grid item xs={6}><Typography gutterBottom>Largura da Borda (px)</Typography><Slider value={currentElement.borderWidth || 0} onChange={(e, v) => updateElementProperty('borderWidth', v)} min={0} max={50} /></Grid>
+                <Grid item xs={12}><Typography gutterBottom>Cantos Arredondados (px)</Typography><Slider value={currentElement.borderRadius || 0} onChange={(e, v) => updateElementProperty('borderRadius', v)} min={0} max={100} /></Grid>
+            </Grid>
+        </AccordionDetails>
       </Accordion>
       <Accordion expanded={expandedPanel === 'imageFilters'} onChange={handleAccordionChange('imageFilters')}>
         <AccordionSummary expandIcon={<ExpandMore />}><Typography><Tune sx={{ mr: 1, verticalAlign: 'middle' }} />Filtros</Typography></AccordionSummary>

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -156,6 +156,7 @@ const drawImageWithEffects = async (ctx, element, canvasWidth, canvasHeight) => 
           crop,
           shadow, shadowColor, shadowBlur, shadowOffsetX, shadowOffsetY,
           borderRadius = 0,
+          objectFit = 'fill',
         } = element;
 
         const dx = (x / 100) * canvasWidth;
@@ -194,7 +195,41 @@ const drawImageWithEffects = async (ctx, element, canvasWidth, canvasHeight) => 
           const sHeight = (crop.height / 100) * img.height;
           ctx.drawImage(img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
         } else {
-          ctx.drawImage(img, dx, dy, dWidth, dHeight);
+            let finalDestX = dx;
+            let finalDestY = dy;
+            let finalDestWidth = dWidth;
+            let finalDestHeight = dHeight;
+            let finalSrcX = 0;
+            let finalSrcY = 0;
+            let finalSrcWidth = img.width;
+            let finalSrcHeight = img.height;
+
+            const imgRatio = img.width / img.height;
+            const containerRatio = dWidth / dHeight;
+
+            if (objectFit === 'contain') {
+                if (imgRatio > containerRatio) { // Image is wider than container
+                    finalDestWidth = dWidth;
+                    finalDestHeight = dWidth / imgRatio;
+                    finalDestY = dy + (dHeight - finalDestHeight) / 2;
+                } else { // Image is taller or same aspect ratio
+                    finalDestHeight = dHeight;
+                    finalDestWidth = dHeight * imgRatio;
+                    finalDestX = dx + (dWidth - finalDestWidth) / 2;
+                }
+            } else if (objectFit === 'cover') {
+                if (imgRatio > containerRatio) { // Image is wider, so height is the limiting dimension for covering
+                    finalSrcHeight = img.height;
+                    finalSrcWidth = img.height * containerRatio;
+                    finalSrcX = (img.width - finalSrcWidth) / 2;
+                } else { // Image is taller, so width is the limiting dimension
+                    finalSrcWidth = img.width;
+                    finalSrcHeight = img.width / containerRatio;
+                    finalSrcY = (img.height - finalSrcHeight) / 2;
+                }
+            }
+            // For 'fill', we use the default values which stretch the image.
+            ctx.drawImage(img, finalSrcX, finalSrcY, finalSrcWidth, finalSrcHeight, finalDestX, finalDestY, finalDestWidth, finalDestHeight);
         }
 
         ctx.filter = 'none';


### PR DESCRIPTION
…galeria

Este commit introduz uma nova funcionalidade para controlar o ajuste de imagens (`object-fit`) e implementa várias melhorias de usabilidade e correções de bugs relacionadas à edição de imagens.

1.  **Novo Recurso: Controle de Ajuste de Imagem (`object-fit`):**
    - Adicionado um controle na interface de formatação de imagem que permite ao usuário escolher como a imagem se ajusta ao seu contêiner: 'Preencher' (`fill`), 'Conter' (`contain`), ou 'Cobrir' (`cover`).
    - O preview do editor (`DraggableElement`) agora reflete dinamicamente a configuração de `object-fit` selecionada.
    - A lógica de renderização de imagem no canvas (`imageComposer.js`) foi atualizada para replicar o comportamento de `object-fit`, garantindo que a miniatura final seja idêntica ao preview.

2.  **Correção de Z-index da Galeria:** O diálogo da galeria de imagens agora tem um `zIndex` explícito de 1400, garantindo que ele sempre apareça sobreposto ao painel de edição da página.

3.  **Correção na Inserção de Imagem em Página Gerada:** A lógica de inserção de imagens foi aprimorada para rastrear qual página específica está sendo editada, corrigindo um bug que causava falhas intermitentes ao adicionar uma imagem a uma página gerada.

4.  **Renderização de Cantos Arredondados:** A função de renderização no canvas agora aplica um caminho de recorte para `borderRadius`, garantindo que as imagens com cantos arredondados sejam exibidas corretamente nas miniaturas.

5.  **Clareza do Código:** Todas as referências a "background image" foram renomeadas para "image gallery" para refletir com mais precisão a funcionalidade da galeria.