### PR TITLE
Refactor: Update campaign memorial data flow

### DIFF
--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -24,7 +24,7 @@ import { getCampaigns, deleteCampaign, loadCampaign } from '../utils/campaignSta
 import { toast } from 'sonner';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
 
-const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
+const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorList, personaList }) => {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -66,7 +66,14 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew }) => {
   const handleShowMemorial = async (campaignId) => {
     try {
       const campaignData = await loadCampaign(campaignId);
-      setSelectedCampaignData(campaignData.campaign_data);
+      const autor = autorList.find(a => a.id === campaignData.autor_id);
+      const persona = personaList.find(p => p.id === campaignData.persona_id);
+      const fullCampaignData = {
+        ...campaignData.campaign_data,
+        autor: autor,
+        persona: persona,
+      };
+      setSelectedCampaignData(fullCampaignData);
       setShowMemorialModal(true);
     } catch (err) {
       toast.error(`Failed to load campaign data: ${err.message}`);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1207,6 +1207,8 @@ function HomePage() {
                     onLoadCampaign={handleLoadCampaign}
                     onEditCampaign={handleEditCampaign}
                     onCreateNew={handleCreateNewCampaign}
+                    autorList={autorList}
+                    personaList={personaList}
                   />
                 )}
                 {activeStep === 1 && (


### PR DESCRIPTION
This commit refactors the data flow for the campaign memorial component.

Previously, the memorial component expected author and persona data to be embedded within the campaign data object. This is now updated to reflect a segregated data structure where campaigns store `autor_id` and `persona_id`.

The changes are as follows:
- `HomePage.jsx` now passes `autorList` and `personaList` down to `MyCampaignsStep.jsx`.
- `MyCampaignsStep.jsx` is updated to receive these lists.
- The `handleShowMemorial` function in `MyCampaignsStep.jsx` now uses the `autor_id` and `persona_id` from the loaded campaign to find the full author and persona objects from the lists and injects them into the data object passed to the memorial modal.

This ensures the campaign memorial correctly displays author and persona information based on the current data structure.