### PR TITLE
Fix: Correct data structure for campaign memorial

### DIFF
--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -66,12 +66,12 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorLis
   const handleShowMemorial = async (campaignId) => {
     try {
       const campaignData = await loadCampaign(campaignId);
-      const autor = autorList.find(a => a.id === campaignData.autor_id);
-      const persona = personaList.find(p => p.id === campaignData.persona_id);
+      const autorFromDb = autorList.find(a => a.id === campaignData.autor_id);
+      const personaFromDb = personaList.find(p => p.id === campaignData.persona_id);
       const fullCampaignData = {
         ...campaignData.campaign_data,
-        autor: autor,
-        persona: persona,
+        autor: autorFromDb ? autorFromDb.autor_data : null,
+        persona: personaFromDb ? personaFromDb.persona_data : null,
       };
       setSelectedCampaignData(fullCampaignData);
       setShowMemorialModal(true);


### PR DESCRIPTION
This commit fixes a runtime error in the campaign memorial component. The error "Objects are not valid as a React child" was caused by passing the full author and persona database objects to the memorial, when the components expected only the nested data objects.

The `handleShowMemorial` function in `MyCampaignsStep.jsx` has been modified to correctly extract the `autor_data` and `persona_data` properties from the full author and persona objects before passing them to the memorial modal.

This ensures the components receive the data in the expected format, resolving the rendering error.