### PR TITLE
Fix: Prevent crash in campaign memorial and display full data

### DIFF
--- a/src/components/MemorialDescritivo/AuthorSection.jsx
+++ b/src/components/MemorialDescritivo/AuthorSection.jsx
@@ -4,6 +4,21 @@ import parse from 'html-react-parser';
 
 const DetailItem = ({ title, value, isHtml = false }) => {
   if (!value) return null;
+
+  const renderContent = () => {
+    if (isHtml && typeof value === 'string') {
+      return <Typography component="div" variant="body1">{parse(value)}</Typography>;
+    }
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      return (
+        <pre style={{ fontFamily: 'inherit', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      );
+    }
+    return <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{value}</Typography>;
+  };
+
   return (
     <Box sx={{ mb: 3 }}>
       <Typography variant="h6" component="h4" color="primary.main" sx={{ mb: 1 }}>
@@ -16,7 +31,7 @@ const DetailItem = ({ title, value, isHtml = false }) => {
         '& p, & li': { mb: 1.5 },
         '& ul, & ol': { pl: 2.5 },
       }}>
-        {isHtml && typeof value === 'string' ? <Typography component="div" variant="body1">{parse(value)}</Typography> : <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{value}</Typography>}
+        {renderContent()}
       </Box>
     </Box>
   );

--- a/src/components/MemorialDescritivo/PersonaSection.jsx
+++ b/src/components/MemorialDescritivo/PersonaSection.jsx
@@ -35,6 +35,13 @@ const DetailItem = ({ title, value, isHtml = false }) => {
         </List>
       );
     }
+    if (typeof value === 'object' && value !== null) {
+      return (
+        <pre style={{ fontFamily: 'inherit', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      );
+    }
     return <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{value}</Typography>;
   };
 


### PR DESCRIPTION
This commit resolves a multi-part issue that caused the campaign memorial to crash.

First, it refactors the data flow to correctly pass author and persona data to the memorial. `MyCampaignsStep.jsx` now correctly uses the `autor_id` and `persona_id` from a campaign to find the full author and persona objects and passes their nested `autor_data` and `persona_data` to the memorial component.

Second, it addresses the "Objects are not valid as a React child" error that occurred because the `persona_data` and `autor_data` objects can contain nested objects. The `DetailItem` components within `PersonaSection.jsx` and `AuthorSection.jsx` have been updated to be more robust. They now check if a value is an object and, if so, render it as a formatted JSON string instead of trying to render it directly.

This ensures the memorial can display all campaign data without crashing.