### PR TITLE
Feat: Add generated pages to memorial and fix data rendering

### DIFF
--- a/src/components/MemorialDescritivo/GeneratedPagesSection.jsx
+++ b/src/components/MemorialDescritivo/GeneratedPagesSection.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Typography, Box, Grid, Paper, List, ListItem, ListItemText, Divider } from '@mui/material';
+
+const GeneratedPagesSection = ({ pages }) => {
+  if (!pages || pages.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Typography variant="h4" component="h2" sx={{ mb: 2 }}>
+        Páginas Geradas e Conteúdo
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 4, color: 'text.secondary' }}>
+        A seguir estão as páginas finais geradas para a campanha, cada uma acompanhada do texto extraído do arquivo CSV correspondente.
+      </Typography>
+      <Grid container spacing={4}>
+        {pages.map((page, index) => (
+          <Grid item xs={12} key={index}>
+            <Paper elevation={3} sx={{ p: 2 }}>
+              <Typography variant="h6" component="h3" sx={{ mb: 2 }}>
+                Página {index + 1}
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} md={6}>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Imagem Gerada
+                  </Typography>
+                  {page.url ? (
+                    <Box
+                      component="img"
+                      src={page.url}
+                      alt={`Página gerada ${index + 1}`}
+                      sx={{
+                        width: '100%',
+                        borderRadius: 1,
+                        border: '1px solid',
+                        borderColor: 'divider',
+                      }}
+                    />
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      (Nenhuma imagem gerada para esta página)
+                    </Typography>
+                  )}
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Dados do CSV
+                  </Typography>
+                  {page.record ? (
+                    <List dense>
+                      {Object.entries(page.record).map(([key, value]) => (
+                        <React.Fragment key={key}>
+                          <ListItem sx={{ py: 0.5 }}>
+                            <ListItemText
+                              primary={key}
+                              secondary={String(value)}
+                              primaryTypographyProps={{ fontWeight: 'bold' }}
+                            />
+                          </ListItem>
+                          <Divider component="li" />
+                        </React.Fragment>
+                      ))}
+                    </List>
+                  ) : (
+                     <Typography variant="body2" color="text.secondary">
+                      (Nenhum registro de CSV para esta página)
+                    </Typography>
+                  )}
+                </Grid>
+              </Grid>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default GeneratedPagesSection;

--- a/src/components/MemorialDescritivo/index.jsx
+++ b/src/components/MemorialDescritivo/index.jsx
@@ -6,6 +6,7 @@ import AuthorSection from './AuthorSection';
 import ContentSection from './ContentSection';
 import InstructionsSection from './InstructionsSection';
 import ColorPalette from './ColorPalette';
+import GeneratedPagesSection from './GeneratedPagesSection';
 
 const MemorialDescritivo = ({ campaignData }) => {
   if (!campaignData) {
@@ -23,6 +24,7 @@ const MemorialDescritivo = ({ campaignData }) => {
     aspectRatio,
     followupPosts,
     colors,
+    generatedPagesData,
   } = campaignData;
 
   // In the new structure, `colors` is the primary array of color objects.
@@ -74,6 +76,12 @@ const MemorialDescritivo = ({ campaignData }) => {
 
       <Box sx={{ my: 4 }}>
         <ColorPalette colors={uniqueColors} />
+      </Box>
+
+      <Divider sx={{ my: 6 }} />
+
+      <Box sx={{ my: 4 }}>
+        <GeneratedPagesSection pages={generatedPagesData} />
       </Box>
 
       <Divider sx={{ my: 6 }} />


### PR DESCRIPTION
This commit introduces a new section to the campaign memorial to display the generated pages and their corresponding CSV data. It also includes a critical bug fix to prevent the application from crashing when rendering complex author or persona data.

New Feature:
- A new `GeneratedPagesSection` component has been created and integrated into the main `MemorialDescritivo` component.
- This section displays each generated page's image alongside a list of the key-value pairs from the original CSV record, providing a complete overview of the campaign's output.

Bug Fix:
- The `DetailItem` components within `PersonaSection` and `AuthorSection` have been made more robust. They now detect if a data value is a nested object and, if so, render it as a formatted JSON string. This resolves the "Objects are not valid as a React child" error.
- The data flow in `MyCampaignsStep` has been corrected to ensure the nested `autor_data` and `persona_data` objects are extracted and passed to the memorial, rather than the entire database record.