### PR TITLE
fix(linkedin): Fix scheduled posts, media selection, and token refresh

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -345,10 +345,10 @@ async function handleRefreshTokenInternal(fetch, userId) {
     const data = await linkedinResponse.json();
 
     if (linkedinResponse.ok) {
-        const { access_token, expires_in } = data;
+        const { access_token, expires_in, refresh_token } = data;
         await query(
-            'UPDATE users SET linkedin_access_token = $1, linkedin_access_token_expiry = $2 WHERE id = $3',
-            [access_token, new Date(Date.now() + expires_in * 1000), userId]
+            'UPDATE users SET linkedin_access_token = $1, linkedin_access_token_expiry = $2, linkedin_refresh_token = $3 WHERE id = $4',
+            [access_token, new Date(Date.now() + expires_in * 1000), refresh_token || rows[0].linkedin_refresh_token, userId]
         );
         return { success: true, accessToken: access_token };
     } else {


### PR DESCRIPTION
This commit fixes three issues related to LinkedIn publishing:

1.  **Scheduled posts not being published:** The scheduler was failing because of a missing `node-fetch` dependency in the `api` service. This dependency has been added to the `api/package.json` file. Additionally, the logic for handling images in scheduled posts was corrected. The selected images are now correctly passed to the backend and included in the scheduled post.

2.  **Media selection:** The UI has been updated to allow the selection of multiple images and one video at the same time. The UI has also been updated to make the LinkedIn API limitations more clear to the user.

3.  **Token refresh:** The token refresh logic has been fixed to correctly save the new `refresh_token` to the database. This will prevent the `401 Unauthorized` error when the access token expires.