### PR TITLE
feat: Relocate Memorial button and fix missing images

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -45,6 +45,8 @@ const MainAppBar = ({
   onPersonaMenuClick,
   onAutorMenuClick,
   isDrawerOpen,
+  onShowMemorial,
+  isCampaignOpen,
 }) => {
   const { user, logout } = useUserAuth();
   const navigate = useNavigate();
@@ -118,6 +120,18 @@ const MainAppBar = ({
           <IconButton color="inherit" onClick={onLoadCampaign}>
             <FolderOpenIcon />
           </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Ver Memorial Descritivo">
+          <span>
+            <IconButton
+              color="inherit"
+              onClick={onShowMemorial}
+              disabled={!isCampaignOpen}
+            >
+              <ArticleIcon />
+            </IconButton>
+          </span>
         </Tooltip>
 
         <Tooltip title={darkMode ? 'Modo Claro' : 'Modo Escuro'}>

--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -18,18 +18,15 @@ import {
   CardActions,
   Fab,
 } from '@mui/material';
-import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon, Article as ArticleIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon } from '@mui/icons-material';
 import { useIsMobile } from '../hooks/use-mobile';
 import { getCampaigns, deleteCampaign, loadCampaign } from '../utils/campaignState';
 import { toast } from 'sonner';
-import MemorialDescritivoModal from './MemorialDescritivoModal';
 
 const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorList, personaList }) => {
   const [campaigns, setCampaigns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [showMemorialModal, setShowMemorialModal] = useState(false);
-  const [selectedCampaignData, setSelectedCampaignData] = useState(null);
   const isMobile = useIsMobile();
 
   const fetchCampaigns = () => {
@@ -60,23 +57,6 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorLis
       } catch (err) {
         toast.error(err.message);
       }
-    }
-  };
-
-  const handleShowMemorial = async (campaignId) => {
-    try {
-      const campaignData = await loadCampaign(campaignId);
-      const autorFromDb = autorList.find(a => a.id === campaignData.autor_id);
-      const personaFromDb = personaList.find(p => p.id === campaignData.persona_id);
-      const fullCampaignData = {
-        ...campaignData.campaign_data,
-        autor: autorFromDb ? autorFromDb.autor_data : null,
-        persona: personaFromDb ? personaFromDb.persona_data : null,
-      };
-      setSelectedCampaignData(fullCampaignData);
-      setShowMemorialModal(true);
-    } catch (err) {
-      toast.error(`Failed to load campaign data: ${err.message}`);
     }
   };
 
@@ -125,9 +105,6 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorLis
                     </CardContent>
                   </ListItemButton>
                   <CardActions sx={{ justifyContent: 'flex-end' }}>
-                    <IconButton aria-label="view memorial" onClick={() => handleShowMemorial(campaign.id)}>
-                      <ArticleIcon />
-                    </IconButton>
                     <IconButton aria-label="edit" onClick={() => onEditCampaign(campaign)}>
                       <EditIcon />
                     </IconButton>
@@ -155,13 +132,6 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorLis
           </Fab>
         )}
       </Paper>
-      {selectedCampaignData && (
-        <MemorialDescritivoModal
-          open={showMemorialModal}
-          onClose={() => setShowMemorialModal(false)}
-          campaignData={selectedCampaignData}
-        />
-      )}
     </Container>
   );
 };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1175,7 +1175,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, };
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, generatedPagesData, };
 
   return (
     <ThemeProvider theme={currentTheme}>
@@ -1197,6 +1197,8 @@ function HomePage() {
             onPersonaMenuClick={() => setPersonaDrawerOpen(!personaDrawerOpen)}
             onAutorMenuClick={() => setAutorDrawerOpen(!autorDrawerOpen)}
             isDrawerOpen={currentView === 'personas' ? personaDrawerOpen : currentView === 'autores' ? autorDrawerOpen : sidebarOpen}
+            onShowMemorial={() => setShowMemorialDescritivoModal(true)}
+            isCampaignOpen={currentCampaign !== null}
         />
         {currentView === 'campaigns' && (
           <>


### PR DESCRIPTION
This commit addresses two issues:
1.  The "Memorial Descritivo" button has been relocated from the campaign list to the main top app bar. It is now positioned next to the "Save" and "Load" buttons and is only enabled when a campaign is open.
2.  A bug has been fixed where images were not appearing in the Memorial Descritivo modal. This was because the `generatedPagesData` (which contains the image URLs) was not being passed to the modal.

Changes:
-   **`src/components/MyCampaignsStep.jsx`**: Removed the Memorial button and its associated state and logic.
-   **`src/components/MainAppBar.jsx`**: Added a new "Memorial" button with a `disabled` state controlled by the `isCampaignOpen` prop.
-   **`src/pages/HomePage.jsx`**:
    -   Passed the `onShowMemorial` handler and `isCampaignOpen` prop to `MainAppBar`.
    -   Included `generatedPagesData` in the `campaignData` object that is passed to the `MemorialDescritivoModal`, ensuring the images are displayed correctly.