### PR TITLE
feat: Relocate Memorial button and fix image rendering issues

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -325,7 +325,12 @@ const PageGeneratorFrontendOnly = ({
 
   const handleOpenGeneratedPageEditor = (pageFromClosure, index) => {
     const template = pageFromClosure.customPageTemplate || pageTemplate;
-    setPageTemplateForEditor(JSON.parse(JSON.stringify(template)));
+    // Use a shallow copy to prevent deep copy from breaking blob URLs
+    const templateCopy = {
+      ...template,
+      images: template.images ? [...template.images] : []
+    };
+    setPageTemplateForEditor(templateCopy);
     setEditingGeneratedPageIndex(index);
     setShowGeneratedPageEditor(true);
   };


### PR DESCRIPTION
This commit addresses several related issues concerning UI updates and data flow for loaded campaigns.

1.  **Relocated Memorial Button:**
    -   The "Memorial Descritivo" button has been moved from its location within each campaign card in the `MyCampaignsStep` component to the main `MainAppBar`.
    -   The button is now only enabled when a campaign is loaded and active, controlled by an `isCampaignOpen` prop passed from `HomePage`.

2.  **Fixed Missing Images in Memorial:**
    -   A bug was fixed where the Memorial modal would not display the generated page images. This was resolved by ensuring the `generatedPagesData` (containing the correct `blob:` URLs) is included in the `campaignData` prop passed to the `MemorialDescritivoModal`.

3.  **Fixed Missing Images in Page Editor:**
    -   A bug was fixed where opening a generated page for editing would not render its image in the preview canvas, even though the image was listed.
    -   The root cause was a `JSON.parse(JSON.stringify())` deep copy of the page template, which stripped the `Blob` object from the `blob:` URL.
    -   The fix replaces the deep copy with a shallow copy in `PageGeneratorFrontendOnly.jsx`, preserving the blob URL and allowing the `PageEditor` to render the image correctly.

These changes ensure a more consistent and correct user experience when working with saved and loaded campaigns.