### PR TITLE
fix(editor): Synchronize page template in editor

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -92,7 +92,13 @@ const PageEditor = ({
         effectiveFieldStyles,
         effectiveBrandElements,
         record,
+        effectivePageTemplate,
       } = pageDataFromHook;
+
+      // Sincronizar o template do editor com o template efetivo do hook
+      if (setEditedPageTemplate) {
+        setEditedPageTemplate(effectivePageTemplate);
+      }
 
       setEditedPositions(JSON.parse(JSON.stringify(effectiveFieldPositions)));
       setEditedBrandElements(JSON.parse(JSON.stringify(effectiveBrandElements)));
@@ -111,7 +117,7 @@ const PageEditor = ({
       setEditedRecord(null);
       setSelectedFieldInternal(null);
     }
-  }, [open, pageData, pageDataFromHook, csvHeaders]);
+  }, [open, pageData, pageDataFromHook, csvHeaders, setEditedPageTemplate]);
 
   if (!open || !pageData || !editedPageTemplate) {
     // Render nothing or a loader until the state is initialized by the effect


### PR DESCRIPTION
When loading a campaign and editing a generated page, the editor preview was not displaying the page's image. This was due to the PageEditor component not correctly synchronizing its template state with the effective template of the selected page.

This commit fixes the issue by updating the useEffect hook in PageEditor.jsx to explicitly set the editor's template state using the effectivePageTemplate from the usePageData hook. This ensures the editor always has the correct template, including images, when it opens.