### PR TITLE
Fix: Prevent editor crash on null record and sanitize data

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -335,8 +335,8 @@ const FieldPositioner = ({
         const style = completeFieldStyles[header];
         if (!position || !position.visible) return null;
 
-        const record = csvData[currentPreviewIndex] || {};
-        const sampleData = record[header] !== undefined ? record[header] : `[${header}]`;
+        const record = csvData?.[currentPreviewIndex] ?? {};
+        const sampleData = record?.[header] !== undefined ? record[header] : `[${header}]`;
 
         return {
           id: header,

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -133,7 +133,7 @@ const PageEditor = ({
     onClose();
   };
 
-  const editorCsvData = editedRecord ? [editedRecord] : (pageData ? [pageData.record] : []);
+  const editorCsvData = editedRecord ? [editedRecord] : (pageData && pageData.record ? [pageData.record] : []);
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth scroll="paper" fullScreen={isMobile}>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -243,7 +243,15 @@ function HomePage() {
     setColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
     setStandardsColors(Array.isArray(state.standardsColors) ? state.standardsColors : []);
     setFollowupPosts(Array.isArray(state.followupPosts) ? state.followupPosts : []);
-    setGeneratedPagesData(Array.isArray(state.generatedPagesData) ? state.generatedPagesData : []);
+    const sanitizedPagesData = (Array.isArray(state.generatedPagesData) ? state.generatedPagesData : [])
+      .filter(page => {
+        if (!page || page.record === null || page.record === undefined) {
+          console.warn('Filtering out invalid page data on load:', page);
+          return false;
+        }
+        return true;
+      });
+    setGeneratedPagesData(sanitizedPagesData);
 
     // FIX: Filter out invalid audio data on load to prevent crashes
     setGeneratedAudioData(


### PR DESCRIPTION
This commit introduces a multi-layered fix to prevent a `TypeError` that occurred in the page editor when encountering a `null` record in the campaign data.

The fix includes:
1.  **Data Sanitization on Load**: In `HomePage.jsx`, the `applyAppState` function now filters `generatedPagesData` when a campaign is loaded, removing any pages that are `null` or contain a `null` record. This addresses the root cause by preventing corrupted data from entering the application state.
2.  **Defensive Safeguard in PageEditor**: In `PageEditor.jsx`, a check was added to ensure that if a page with a `null` record is somehow passed to the editor, it will not create a `[null]` array to pass down as props, instead passing an empty `[]`.
3.  **Robust Access in FieldPositioner**: In `FieldPositioner.jsx`, data access was made more robust using optional chaining (`?.`) and the nullish coalescing operator (`??`) to gracefully handle any unexpected `null` or `undefined` values without crashing.