### PR TITLE
Fix: Ensure editor images are visible by correcting z-index passing

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -295,18 +295,16 @@ const FieldPositioner = ({
 
     // Add page images
     (pageTemplate.images || []).forEach(image => {
-        const imageUrl = image.src || image.imageUrl; // Prioriza 'src', fallback para 'imageUrl'
-        if (image.visible === false || !imageUrl) return; // Verifica se há alguma URL válida
-        // Normalize legacy 'background' type to 'image'
+        const imageUrl = image.src || image.imageUrl;
+        if (image.visible === false || !imageUrl) return;
         const elementType = image.type === 'background' ? 'image' : image.type;
 
         elements.push({
             id: image.id,
             type: elementType,
-            position: image,
+            position: { ...image, zIndex: Math.max(image.zIndex || 0, 0) },
             style: { ...image.filters, ...image },
-            content: imageUrl, // Usa a URL encontrada
-            zIndex: Math.max(image.zIndex || 0, 0), // Garante que o zIndex não seja negativo
+            content: imageUrl,
             rotation: image.rotation || 0,
             fontScale: 1,
             enableHtmlRendering: false,
@@ -358,10 +356,9 @@ const FieldPositioner = ({
         return {
           id: element.id,
           type: 'image',
-          position: element,
+          position: { ...element, zIndex: Math.max(element.zIndex || 0, 0) },
           style: { ...element.filters, ...element },
           content: element.url,
-          zIndex: Math.max(element.zIndex || 0, 0), // Garante que o zIndex não seja negativo
           rotation: element.rotation,
           fontScale: 1,
           enableHtmlRendering: false,


### PR DESCRIPTION
This commit fixes a critical bug where images were not visible in the page editor. The root cause was a Javascript object reference error combined with a special `z-index` value for background images.

Elements intended as backgrounds are stored with `zIndex: -1`. When the editor rendered these as interactive elements, a previous attempt to fix the `zIndex` failed because it modified a temporary object, while the rendering component received a reference to the original object which still contained `zIndex: -1`. This caused the image to be hidden behind its parent container.

This commit resolves the issue by:
- Modifying `FieldPositioner.jsx` to create a new `position` object for the `DraggableElement` component. This new object is created using the spread syntax (`{ ...image, zIndex: Math.max(image.zIndex || 0, 0) }`) to correctly override the `zIndex` with a non-negative value.
- This ensures the `DraggableElement` always receives the corrected `zIndex` in its `position` prop, making the image visible.
- This commit also includes previously added data integrity checks to prevent crashes from null records.