### PR TITLE
This commit includes two separate fixes.

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -370,7 +370,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => (a.zIndex || 0) - (b.zIndex || 0));
     return elements;
-  }, [pageTemplate, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
+  }, [pageTemplate, isCropping, csvHeaders, fieldPositions, completeFieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
   const getGradientCss = (gradient) => {
     if (!gradient) return 'none';


### PR DESCRIPTION
1. Fixes a bug where the text stroke effect would not disable in the preview. This was caused by a stale `useMemo` dependency in the `FieldPositioner` component.

2. Fixes a bug where the validation to proceed to the next step was checking for the wrong property (`.blob` instead of `.url`) on generated pages. This also refactors the validation logic to prevent toast messages from appearing on every component render.