### PR TITLE
Fixes a bug where disabling the text stroke effect in the page editor…

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -370,7 +370,7 @@ const FieldPositioner = ({
 
     elements.sort((a, b) => (a.zIndex || 0) - (b.zIndex || 0));
     return elements;
-  }, [pageTemplate, isCropping, csvHeaders, fieldPositions, fieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
+  }, [pageTemplate, isCropping, csvHeaders, fieldPositions, completeFieldStyles, brandElements, csvData, currentPreviewIndex, fontScale]);
 
   const getGradientCss = (gradient) => {
     if (!gradient) return 'none';


### PR DESCRIPTION
… would not update the preview correctly.

The issue was caused by a stale `useMemo` dependency in the `FieldPositioner` component. The `renderableElements` array was depending on `fieldStyles` instead of the derived `completeFieldStyles`, causing it to sometimes use stale style data from the previous render.

This commit corrects the dependency array to ensure that the preview always re-renders with the most up-to-date styles.