### PR TITLE
Fix: Change audio format to WAV to bypass upload error

### DIFF
--- a/api/upload.js
+++ b/api/upload.js
@@ -44,8 +44,8 @@ const handler = async (req, res) => {
 
         return {
           addRandomSuffix: true,
-          allowedContentTypes: ['image/jpeg', 'image/png', 'image/gif', 'video/mp4', 'video/webm', 'audio/*'],
-          maximumFileSize: 524288000, // 500MB
+          allowedContentTypes: ['image/jpeg', 'image/png', 'image/gif', 'video/mp4', 'audio/mpeg', 'video/webm', 'audio/webm', 'audio/wav', 'audio/mp3'],
+          maximumSizeInBytes: 524288000, // 500MB
           tokenPayload: JSON.stringify({ userId }),
           pathname: sanitizedPathname,
         };

--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -157,7 +157,7 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
     
     // A velocidade é passada para o método synthesize
     const audioContent = await googleCloudTTSAPI.synthesize(cleanText, voice, rate);
-    const blob = new Blob([Uint8Array.from(atob(audioContent), c => c.charCodeAt(0))], { type: 'audio/mpeg' });
+    const blob = new Blob([Uint8Array.from(atob(audioContent), c => c.charCodeAt(0))], { type: 'audio/wav' });
 
     // Convert blob to a data URL for serialization
     const dataURL = await blobToDataURL(blob);
@@ -194,11 +194,11 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
         if (audioMode.startsWith('google-tts')) {
           audio = await generateAudioGoogleTTS(textToSpeak, voice, speechRate);
           audio.index = i;
-          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.mp3`;
+          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.wav`;
         } else {
           audio = await generateAudioBrowser(textToSpeak, speechRate);
           audio.index = i;
-          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.mp3`;
+          audio.filename = `audio_${String(i + 1).padStart(3, '0')}.wav`;
         }
         generatedAudios.push(audio);
       } catch (error) {
@@ -304,7 +304,7 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
       const url = URL.createObjectURL(audio.blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `audio_${index + 1}.mp3`;
+      a.download = `audio_${index + 1}.wav`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -317,7 +317,7 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
         const url = URL.createObjectURL(audio.blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `audio_${index + 1}.mp3`;
+        a.download = `audio_${index + 1}.wav`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);

--- a/src/utils/googleCloudTTSAPI.js
+++ b/src/utils/googleCloudTTSAPI.js
@@ -106,8 +106,9 @@ class GoogleCloudTTSAPI {
         name: voice,
       },
       audioConfig: {
-        audioEncoding: 'MP3',
+        audioEncoding: 'LINEAR16',
         speakingRate: rate,
+        sampleRateHertz: 24000
       },
     };
 


### PR DESCRIPTION
This commit attempts to resolve a persistent `403 Forbidden` error when uploading audio files by changing the generated audio format from MP3 (`audio/mpeg`) to WAV (`audio/wav`).

This change is a diagnostic step to determine if the issue is specific to how Vercel's Blob storage handles the `audio/mpeg` content type.

Changes include:
-   Modifying `src/utils/googleCloudTTSAPI.js` to request `LINEAR16` encoding from the Google TTS API.
-   Updating `src/components/AudioGenerator.jsx` to create blobs with the `audio/wav` MIME type and to use the `.wav` file extension for generated filenames and downloads.