### PR TITLE
Fix payload mismatch for scheduler createPost action

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -186,13 +186,23 @@ async function handleCreatePost(fetch, request, response) {
 
         console.log('[DEBUG] Entering handleCreatePost with received payload:', JSON.stringify(payload, null, 2));
 
-        const { targetId, targetType, content, images, video, title } = payload;
-        if (!targetId || !targetType || !content) {
-            console.error('[DEBUG] Validation failed in handleCreatePost:', { targetId, targetType, contentExists: !!content });
-            return response.status(400).json({ error: 'Missing targetId, targetType, or content for creating post.' });
+        // Make the function more flexible by handling both formats from the UI and the scheduler.
+        let { targetId, targetType, content, images, video, title, author } = payload;
+        let authorUrn;
+
+        if (author) {
+            // Format sent by the scheduler, which already has the full URN.
+            authorUrn = author;
+        } else if (targetId && targetType) {
+            // Format sent by the user-facing UI.
+            authorUrn = `urn:li:${targetType === 'organization' ? 'organization' : 'person'}:${targetId}`;
         }
 
-        const authorUrn = `urn:li:${targetType === 'organization' ? 'organization' : 'person'}:${targetId}`;
+        // Validate that we have the necessary information to proceed.
+        if (!authorUrn || !content) {
+             console.error('[DEBUG] Validation failed in handleCreatePost:', { authorUrn, contentExists: !!content });
+             return response.status(400).json({ error: 'Missing author information or content for creating post.' });
+        }
 
         // Base structure for the new Posts API
         const postData = {


### PR DESCRIPTION
This commit resolves a bug where the scheduler would fail to publish a post with the error "Missing targetId, targetType, or content for creating post."

This was caused by a data format mismatch between the scheduler (`api/schedule.js`) and the API proxy (`api/linkedin-proxy.js`). The scheduler was sending a payload containing an `author` field (a full URN), while the proxy's `handleCreatePost` function was expecting `targetId` and `targetType` as separate fields.

The `handleCreatePost` function in `api/linkedin-proxy.js` has been updated to be more flexible. It now intelligently checks for either the `author` field or the `targetId`/`targetType` pair, making it compatible with both the scheduler and the user-facing UI without requiring changes to the scheduler's payload construction.