### PR TITLE
fix(Publisher): Refactor prop and fix reference error

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -655,7 +655,7 @@ const Publisher = ({
                           <ListItemIcon>
                             <Checkbox
                               edge="start"
-                              checked={media.type === 'image' ? !!selectedImages[index] : !!selectedVideos[index - generatedImagesData.length]}
+                              checked={media.type === 'image' ? !!selectedImages[index] : !!selectedVideos[index - generatedPagesData.length]}
                               onChange={(e) => {
                                 const isChecked = e.target.checked;
                                 if (media.type === 'image') {


### PR DESCRIPTION
This commit addresses two issues to resolve the bug where generated pages were not appearing in the publisher.

1.  **Refactor for Consistency:** The `Publisher` component was expecting a prop named `generatedImagesData`, which was inconsistent with the rest of the application that uses the term `generatedPagesData`. This commit refactors the `Publisher` component to expect `generatedPagesData`, aligning it with the application's domain language as suggested by the user.

2.  **Fix ReferenceError:** A previous attempt to refactor this component missed one occurrence of the old variable name (`generatedImagesData`) inside the `checked` attribute of a `Checkbox`, causing a `ReferenceError` at runtime. This commit corrects that oversight.

By renaming the prop for consistency and fixing the resulting reference error, the `Publisher` component now correctly receives and displays the list of generated pages.