### PR TITLE
fix(Publisher): Fetch remote blobs before publishing

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -54,7 +54,7 @@ import { toast } from 'sonner';
 import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { getTimezone } from '../utils/timezone';
 import { publishToWordPress } from '../utils/wordpressAPI';
-import { dataURLtoBlob } from '../utils/imageComposer';
+import { dataURLtoBlob, urlToBlob } from '../utils/imageComposer';
 import { getLinkedInProfiles, publishToLinkedIn, uploadImagesForLinkedIn } from '../utils/linkedinAPI';
 import { useUserAuth } from '../context/UserAuthContext';
 import { createSchedule, getSchedulesForUser, deleteSchedule, getSchedule, updateSchedule } from '../utils/scheduleAPI';
@@ -371,18 +371,28 @@ const Publisher = ({
         throw new Error('Configuração do WordPress não encontrada ou incompleta. Por favor, configure-a primeiro.');
       }
       if (!campaignContent || !campaignContent.conteudoFormatado || !generatedPagesData || generatedPagesData.length === 0) {
-        throw new Error('Dados da campanha ou imagens não estão disponíveis.');
+        throw new Error('Dados da campanha ou páginas não estão disponíveis.');
       }
 
-      const firstImage = { ...generatedPagesData[0] }; // Make a copy to avoid state mutation
+      let firstImage = { ...generatedPagesData[0] }; // Make a copy to avoid state mutation
 
-      // If blob is missing but URL (dataUrl) exists, regenerate the blob
+      // If blob is missing, try to get it.
       if (!firstImage.blob && firstImage.url) {
-        firstImage.blob = dataURLtoBlob(firstImage.url);
+        setPublishingStatusWp('Preparando imagem para upload...');
+        toast.info("Preparando imagem para upload...");
+        if (firstImage.url.startsWith('data:')) {
+            firstImage.blob = dataURLtoBlob(firstImage.url);
+        } else {
+            try {
+              firstImage.blob = await urlToBlob(firstImage.url);
+            } catch (e) {
+              throw new Error(`Falha ao baixar a imagem da URL: ${firstImage.url}. ${e.message}`);
+            }
+        }
       }
 
       if (!firstImage || !firstImage.blob) {
-        throw new Error('A primeira imagem gerada não contém um blob válido.');
+        throw new Error('A primeira página gerada não contém uma imagem (blob) válida ou não pôde ser baixada.');
       }
 
       const campaignData = {
@@ -488,7 +498,34 @@ const Publisher = ({
       const selectedImageIndexes = Object.keys(selectedImages).filter(index => selectedImages[index]);
 
       if (selectedImageIndexes.length > 0) {
-        const imageBlobsToUpload = selectedImageIndexes.map(index => unifiedMedia[parseInt(index)].blob);
+        setPublishingStatusLi('Preparando imagens para upload...');
+        const toastId = toast.loading("Preparando imagens para o upload...");
+
+        const imageBlobsToUpload = await Promise.all(
+          selectedImageIndexes.map(async (index, i) => {
+            const media = unifiedMedia[parseInt(index)];
+            if (media.blob) {
+              return media.blob;
+            }
+            toast.info(`Baixando imagem ${i + 1}/${selectedImageIndexes.length}...`);
+            try {
+              const blob = await urlToBlob(media.url);
+              return blob;
+            } catch (e) {
+              toast.error(`Falha ao baixar a imagem ${i + 1}.`);
+              console.error(`Failed to fetch blob for ${media.url}`, e);
+              return null; // Return null on failure
+            }
+          })
+        );
+
+        toast.dismiss(toastId);
+
+        // Check if all blobs were fetched successfully
+        if (imageBlobsToUpload.some(blob => !blob)) {
+            throw new Error("Falha ao baixar uma ou mais imagens. Verifique o console para detalhes e tente novamente.");
+        }
+
         const authorUrn = `urn:li:${selectedTarget.type === 'organization' ? 'organization' : 'person'}:${selectedTarget.id}`;
 
         imageUrns = await uploadImagesForLinkedIn(settings?.linkedin, imageBlobsToUpload, authorUrn, setPublishingStatusLi);

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -3,6 +3,20 @@ import { applyColorHighlight } from './filterUtils';
 
 // Helper functions moved from PageGeneratorFrontendOnly.jsx and adapted for utility use
 
+export const urlToBlob = async (url) => {
+  try {
+    const response = await fetch(url, { mode: 'cors' });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch image: ${response.statusText}`);
+    }
+    const blob = await response.blob();
+    return blob;
+  } catch (error) {
+    console.error(`[urlToBlob] Error fetching URL ${url}:`, error);
+    throw error;
+  }
+};
+
 export const dataURLtoBlob = (dataurl) => {
     if (!dataurl) return null;
     const arr = dataurl.split(',');


### PR DESCRIPTION
This commit fixes the "Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'" error that occurs when trying to publish.

The root cause is that the application stores generated pages as remote URLs (in Vercel Blob Storage), but the publishing functions for LinkedIn and WordPress require a local `Blob` object to upload. The `Publisher` component was attempting to use a non-existent `.blob` property from the page data.

This commit introduces a solution by:
1.  Adding a `urlToBlob` utility function to `imageComposer.js` to download a file from a URL and return it as a `Blob`.
2.  Modifying `handlePublishLinkedIn` and `handlePublishWordPress` in `Publisher.jsx` to use this function. Before attempting to upload, the functions now check for a local blob. If it's missing, they download it from the remote URL on demand.

This ensures that the publishing functions always have a valid `Blob` object to work with, resolving the `FileReader` error and allowing publishing to succeed.