### PR TITLE
fix(editor): Merge page templates to fix broken image previews

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -324,13 +324,16 @@ const PageGeneratorFrontendOnly = ({
   };
 
   const handleOpenGeneratedPageEditor = (pageFromClosure, index) => {
-    const template = pageFromClosure.customPageTemplate || pageTemplate;
-    // Use a shallow copy to prevent deep copy from breaking blob URLs
-    const templateCopy = {
-      ...template,
-      images: template.images ? [...template.images] : []
+    // Merge the base template with the custom page template to get the final version
+    const finalTemplate = {
+      ...pageTemplate, // Start with the global template
+      ...(pageFromClosure.customPageTemplate || {}), // Override with custom properties
     };
-    setPageTemplateForEditor(templateCopy);
+
+    // Ensure the 'images' property is always a shallow-copied array
+    finalTemplate.images = [...(finalTemplate.images || [])];
+
+    setPageTemplateForEditor(finalTemplate);
     setEditingGeneratedPageIndex(index);
     setShowGeneratedPageEditor(true);
   };


### PR DESCRIPTION
When opening a generated page in the editor, the page template was not being correctly constructed, especially when the global template had no images but the generated page did.

This change modifies `handleOpenGeneratedPageEditor` to merge the global `pageTemplate` with the page-specific `customPageTemplate`. This ensures that the editor always receives a complete template object, combining the base styles and properties with page-specific customizations, such as added images.

This resolves the bug where images on generated pages would appear broken in the editor preview if the original campaign template did not contain any images.