### PR TITLE
fix: Implement robust asset handling and fix server limits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,14 @@
     }
   ],
   "functions": {
+    "api/campaigns/**": {
+      "maxDuration": 45,
+      "memory": 1024,
+      "bodyLimit": "4.5mb"
+    },
     "api/upload.js": {
+      "maxDuration": 45,
+      "memory": 1024,
       "includeFiles": "api/node_modules/@vercel/blob/**"
     }
   }


### PR DESCRIPTION
This commit provides a definitive, multi-pronged solution to a series of critical bugs related to saving, reloading, and processing campaigns with media assets.

The core fixes are:

1.  **Server Configuration (`vercel.json`)**: Increased the request body size limit for the `/api/campaigns/**` route to 4.5MB. This resolves the "413 Payload Too Large" error that occurred when saving campaigns with a large amount of text and media metadata.

2.  **Data Sanitization on Save (`HomePage.jsx`)**: Implemented a thorough sanitization process within the `handleSaveCampaign` function. A new `sanitizeMediaArray` helper strips all transient client-side data (like `blob` and `file` objects) from `pageTemplate`, `brandElements`, `generatedAudioData`, and `generatedVideosData` before they are sent to the server. This prevents data corruption at the source, which was the root cause of the broken media issues on reload.

3.  **Robust Component Logic**:
    - **Video Generator**: `VideoGenerator2.jsx` is now resilient to reloaded campaign state, checking for `audio.url` as a fallback if `audio.blob` is not present, thus fixing the `createObjectURL` crash.
    - **Page Editor**: The `PageEditor` component in `PageGeneratorFrontendOnly.jsx` is now rendered with a unique `key` prop, ensuring it fully re-mounts with a clean state for each page, preventing UI state corruption.
    - **Step Validation**: The `canProceedToStep` logic in `HomePage.jsx` now correctly validates reloaded pages by checking for either a `blob` or a `url`, fixing an erroneous error message.