### PR TITLE
Fix(video): Correct video duration and enable LinkedIn publishing

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -55,7 +55,7 @@ import { fromZonedTime, formatInTimeZone } from 'date-fns-tz';
 import { getTimezone } from '../utils/timezone';
 import { publishToWordPress } from '../utils/wordpressAPI';
 import { dataURLtoBlob, urlToBlob } from '../utils/imageComposer';
-import { getLinkedInProfiles, publishToLinkedIn, uploadImagesForLinkedIn } from '../utils/linkedinAPI';
+import { getLinkedInProfiles, publishToLinkedIn, uploadImagesForLinkedIn, uploadVideoForLinkedIn } from '../utils/linkedinAPI';
 import { useUserAuth } from '../context/UserAuthContext';
 import { createSchedule, getSchedulesForUser, deleteSchedule, getSchedule, updateSchedule } from '../utils/scheduleAPI';
 import { getCampaigns } from '../utils/campaignState.js';


### PR DESCRIPTION
This commit addresses an issue where generated videos would appear with a zero-second duration within the application, preventing them from being published to LinkedIn. It also fixes subsequent issues found during testing, including broken video previews and a missing import for the video upload function.

The fix is multi-faceted:

1.  **Correct Video Duration:**
    - A `useEffect` hook has been added to `HomePage.jsx`.
    - This hook now processes newly generated videos by creating a temporary `<video>` element to load its metadata.
    - Once the metadata is loaded, the video's actual duration is extracted and saved to the application's state. This ensures that the UI, particularly in the `Publisher` component, displays the correct duration.

2.  **Enable LinkedIn Video Publishing:**
    - The client-side logic for LinkedIn's multi-step video upload process has been implemented in `utils/linkedinAPI.js` with a new `uploadVideoForLinkedIn` function.
    - The `Publisher.jsx` component has been updated to use this new function. It now correctly handles the selection of a video, uploads it to LinkedIn, and includes the returned video URN in the final post creation payload.
    - A missing import for `uploadVideoForLinkedIn` in `Publisher.jsx` has been added.

3.  **Fix Broken Video Preview:**
    - The video generator (`VideoGenerator2.jsx`) has been modified to pass a `blob` URL to parent components instead of a `dataURL`. This is more efficient and avoids browser limitations that caused video previews to fail.

These changes resolve the user's reported problem in its entirety, providing a correct in-app video preview and enabling the video publishing functionality, while preserving the existing functionality for text and image posts.