### PR TITLE
Feat: Add error handling to video players

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -223,6 +223,32 @@ const Publisher = ({
   const [publishingStatusLi, setPublishingStatusLi] = useState('');
   const [publishedPostUrlLi, setPublishedPostUrlLi] = useState(null);
 
+  const handleVideoError = (e) => {
+    const error = e.target.error;
+    let errorMessage = 'Ocorreu um erro desconhecido no player de vídeo.';
+    if (error) {
+        switch (error.code) {
+            case error.MEDIA_ERR_ABORTED:
+                errorMessage = 'A pré-visualização do vídeo foi abortada.';
+                break;
+            case error.MEDIA_ERR_NETWORK:
+                errorMessage = 'Ocorreu um erro de rede ao carregar a pré-visualização do vídeo.';
+                break;
+            case error.MEDIA_ERR_DECODE:
+                errorMessage = 'Ocorreu um erro ao decodificar o vídeo para a pré-visualização. O arquivo pode estar corrompido.';
+                break;
+            case error.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                errorMessage = 'O formato do vídeo não é suportado para pré-visualização neste navegador.';
+                break;
+            default:
+                errorMessage = `Erro na pré-visualização do vídeo: ${error.message} (Código: ${error.code})`;
+                break;
+        }
+    }
+    console.error('Video Preview Error:', errorMessage, e);
+    toast.error(errorMessage);
+  };
+
     useEffect(() => {
         if (campaignContent) {
             const postText = [
@@ -739,7 +765,14 @@ const Publisher = ({
                           {previewedMedia.type === 'image' ? (
                             <img src={previewedMedia.url} alt="Preview" style={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }} />
                           ) : (
-                            <video src={previewedMedia.url} controls style={{ maxHeight: '100%', maxWidth: '100%' }} />
+                            <video
+                              src={previewedMedia.url}
+                              controls
+                              style={{ maxHeight: '100%', maxWidth: '100%' }}
+                              onError={handleVideoError}
+                              onStalled={handleVideoError}
+                              onSuspend={handleVideoError}
+                            />
                           )}
                         </Box>
                       </>

--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -929,6 +929,33 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
     setSnackbarOpen(false);
   };
 
+  const handleVideoError = (e) => {
+    const error = e.target.error;
+    let errorMessage = 'Ocorreu um erro desconhecido no player de vídeo.';
+    if (error) {
+        switch (error.code) {
+            case error.MEDIA_ERR_ABORTED:
+                errorMessage = 'A reprodução do vídeo foi abortada.';
+                break;
+            case error.MEDIA_ERR_NETWORK:
+                errorMessage = 'Ocorreu um erro de rede ao carregar o vídeo.';
+                break;
+            case error.MEDIA_ERR_DECODE:
+                errorMessage = 'Ocorreu um erro ao decodificar o vídeo. O arquivo pode estar corrompido.';
+                break;
+            case error.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                errorMessage = 'O formato do vídeo não é suportado por este navegador.';
+                break;
+            default:
+                errorMessage = `Erro no player de vídeo: ${error.message} (Código: ${error.code})`;
+                break;
+        }
+    }
+    console.error('Video Player Error:', errorMessage, e);
+    setError(errorMessage);
+    setSnackbarOpen(true);
+  };
+
   const handleReload = () => {
     window.location.reload();
   };
@@ -1330,6 +1357,9 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
                   autoPlay
                   loop
                   controls
+                  onError={handleVideoError}
+                  onStalled={handleVideoError}
+                  onSuspend={handleVideoError}
                   style={{
                     width: '100%',
                     height: '100%',


### PR DESCRIPTION
This commit adds error handling to the video preview elements in the application, as requested in follow-up feedback.

-   **`VideoGenerator2.jsx`**: Added `onError`, `onStalled`, and `onSuspend` event handlers to the video preview. These handlers will trigger a Snackbar notification with a user-friendly message if a playback error occurs.
-   **`Publisher.jsx`**: Added the same event handlers to the video preview in the media selection tab. These handlers will use the `toast` notification system to inform the user of any playback issues.

This change improves the robustness of the video feature by providing clear feedback to the user and logging detailed error information to the console for debugging.