### PR TITLE
Corrige um bug que impedia o download de áudios ao carregar uma campa…

### DIFF
--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -321,8 +321,9 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
 
   const handleDownload = (index) => {
     const audio = audioData[index];
-    if (audio.blob) {
-      const url = URL.createObjectURL(audio.blob);
+    const blob = getPlayableBlob(audio);
+    if (blob) {
+      const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
       a.download = `audio_${index + 1}.mp3`;
@@ -334,8 +335,9 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
 
   const handleDownloadAll = () => {
     audioData.forEach((audio, index) => {
-      if (audio.blob) {
-        const url = URL.createObjectURL(audio.blob);
+      const blob = getPlayableBlob(audio);
+      if (blob) {
+        const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
         a.download = `audio_${index + 1}.mp3`;
@@ -445,7 +447,7 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
                   <Button
                     variant="outlined"
                     onClick={handleDownloadAll}
-                    disabled={isGenerating || audioData.some(a => !a.blob)}
+                    disabled={isGenerating || audioData.some(a => !getPlayableBlob(a))}
                     startIcon={<CloudDownload />}
                     sx={{ ml: 2 }}
                   >
@@ -527,7 +529,7 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
                         </IconButton>
                         <Tooltip title="Baixar áudio (somente Google TTS)">
                           <span>
-                            <IconButton onClick={() => handleDownload(index)} disabled={!audio.blob} size="small">
+                            <IconButton onClick={() => handleDownload(index)} disabled={!getPlayableBlob(audio)} size="small">
                               <SaveAlt />
                             </IconButton>
                           </span>


### PR DESCRIPTION
…nha salva.

A causa raiz era uma inconsistência na forma como o Blob de áudio era localizado. A função de reprodução usava uma lógica que buscava o Blob tanto em `audio.blob` (para áudios novos) quanto no mapa `pendingAssets` (para áudios carregados), mas a função de download e a lógica para habilitar o botão só verificavam `audio.blob`.

Esta alteração unifica a lógica:
1. Em `AudioGenerator.jsx`, as funções `handleDownload` e `handleDownloadAll`, bem como a propriedade `disabled` dos botões, agora usam a função auxiliar `getPlayableBlob` para localizar o Blob de áudio corretamente.
2. Isso garante que o download funcione para áudios recém-gerados e para áudios carregados de campanhas salvas.