### PR TITLE
Corrige um bug que impedia o download de áudios e a geração de vídeos…

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -9,6 +9,7 @@ import {
 import { Movie, GetApp, Info, ErrorOutline, Refresh, Download, Palette } from '@mui/icons-material';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
+import { useCampaign } from '../context/CampaignContext';
 import ProgressModal from './ProgressModal';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile } from '@ffmpeg/util';
@@ -65,6 +66,19 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
   const isCancelledRef = useRef(false);
 
+  const { pendingAssets } = useCampaign();
+
+  const getPlayableBlob = (audio) => {
+    // Priority 1: The blob property on the audio object itself (for newly generated audio)
+    if (audio.blob instanceof Blob) {
+      return audio.blob;
+    }
+    // Priority 2: Look in pendingAssets using the audio's URL (for loaded audio)
+    if (audio.url && audio.url.startsWith('blob:') && pendingAssets[audio.url] instanceof Blob) {
+      return pendingAssets[audio.url];
+    }
+    return null;
+  };
   const ffmpegRef = useRef(null);
   const imageContainerRef = useRef(null);
   const bgImageDimsRef = useRef(null);
@@ -372,18 +386,16 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
       if (hasAudio) {
         await Promise.all(
           generatedAudioData.map(async (audio, i) => {
-            let audioSource = null;
-            if (audio.blob) {
-              audioSource = await fetchFile(URL.createObjectURL(audio.blob));
-            } else if (audio.url) {
+            const blob = getPlayableBlob(audio);
+            if (blob) {
               try {
-                audioSource = await fetchFile(audio.url);
+                const audioSource = await fetchFile(blob);
+                await ffmpeg.writeFile(`audio${i}.mp3`, audioSource);
               } catch (e) {
-                console.warn(`Failed to fetch audio from URL for slide ${i}: ${audio.url}`, e);
+                console.warn(`Failed to process audio blob for slide ${i}:`, e);
               }
-            }
-            if (audioSource) {
-              await ffmpeg.writeFile(`audio${i}.mp3`, audioSource);
+            } else {
+              console.warn(`No playable blob found for audio on slide ${i}`);
             }
           })
         );
@@ -412,8 +424,8 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
             inputs.push("-i", "transition.mp3");
           }
         }
-        generatedAudioData.forEach((_, i) => {
-          if (generatedAudioData[i].blob) {
+        generatedAudioData.forEach((audio, i) => {
+          if (getPlayableBlob(audio)) {
             inputs.push("-i", `audio${i}.mp3`);
           }
         });
@@ -471,7 +483,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         // followed by its transition sound (or silence).
         for (let i = 0; i < generatedImages.length; i++) {
           const audioData = generatedAudioData[i];
-          const hasNarration = audioData && audioData.blob;
+          const hasNarration = audioData && getPlayableBlob(audioData);
           const isLastSlide = i === generatedImages.length - 1;
 
           let slideContentAudio;
@@ -641,7 +653,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
   const generateSingleVideo = async (imageData, audioData, index) => {
     const ffmpeg = ffmpegRef.current;
-    const hasAudio = audioData && audioData.length > 0 && audioData[0].blob;
+    const hasAudio = audioData && audioData.length > 0 && getPlayableBlob(audioData[0]);
     const duration = hasAudio ? audioData[0].duration : slideDuration;
     const outputFilename = `output_${index}.mp4`;
 
@@ -655,19 +667,15 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
     const inputs = ["-loop", "1", "-t", duration.toString(), "-i", imgFile];
     if (hasAudio) {
-      let audioSource = null;
-      if (audioData[0].blob) {
-        audioSource = await fetchFile(URL.createObjectURL(audioData[0].blob));
-      } else if (audioData[0].url) {
+      const blob = getPlayableBlob(audioData[0]);
+      if (blob) {
         try {
-          audioSource = await fetchFile(audioData[0].url);
+          const audioSource = await fetchFile(blob);
+          await ffmpeg.writeFile(audioFile, audioSource);
+          inputs.push("-i", audioFile);
         } catch (e) {
-          console.warn(`Failed to fetch single audio from URL: ${audioData[0].url}`, e);
+          console.warn(`Failed to process single audio blob:`, e);
         }
-      }
-      if (audioSource) {
-        await ffmpeg.writeFile(audioFile, audioSource);
-        inputs.push("-i", audioFile);
       }
     }
 


### PR DESCRIPTION
… com som ao carregar uma campanha salva.

A causa raiz era uma inconsistência na forma como o Blob de áudio era localizado. Diferentes partes da aplicação (reprodução, download, geração de vídeo) procuravam o Blob em locais diferentes. Para áudios recém-gerados, o Blob estava em `audio.blob`, mas para áudios carregados, estava em um mapa `pendingAssets`.

Esta alteração unifica a lógica em toda a aplicação:
1.  Uma função auxiliar `getPlayableBlob` foi implementada e usada em `AudioGenerator.jsx` e `VideoGenerator2.jsx`. Essa função localiza o Blob de áudio corretamente, independentemente de ser novo ou carregado.
2.  A lógica de download no `AudioGenerator` foi corrigida para usar `getPlayableBlob`.
3.  A lógica de processamento de áudio no `VideoGenerator2` foi corrigida para usar `getPlayableBlob`.
4.  A lógica de carregamento de campanha em `HomePage.jsx` foi melhorada para garantir que os metadados de duração do áudio sejam calculados de forma assíncrona, evitando que os dados sejam descartados.

Com essas mudanças, os áudios de campanhas salvas agora funcionam corretamente para reprodução, download e geração de vídeo.