### PR TITLE
feat: Synchronize user settings across devices

### DIFF
--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -1,6 +1,12 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
-import { loadSettingsFromDb, saveSettingsToDb } from '../utils/credentialsManager';
+import { useUserAuth } from './UserAuthContext';
+import {
+  loadSettingsFromDb,
+  saveSettingsToDb,
+  saveSetting,
+  gatherCredentials,
+} from '../utils/credentialsManager';
 
 const SettingsContext = createContext(null);
 
@@ -15,31 +21,59 @@ export const useSettings = () => {
 export const SettingsProvider = ({ children }) => {
   const [settings, setSettings] = useState({});
   const [isLoading, setIsLoading] = useState(true);
+  const { user } = useUserAuth();
 
   const loadSettings = useCallback(async () => {
+    // Only attempt to load settings if the user is authenticated.
+    if (!user) {
+      setSettings({}); // Clear settings if user logs out
+      setIsLoading(false);
+      return;
+    }
+
     setIsLoading(true);
     try {
+      console.log('User is authenticated, loading settings from database...');
       const loadedSettings = await loadSettingsFromDb();
       setSettings(loadedSettings || {});
     } catch (error) {
-      toast.error(`Failed to load settings: ${error.message}`);
+      // Avoid showing an error toast if the user just hasn't saved any settings yet.
+      // The API should return a 404 or empty object in that case, which is handled above.
+      // This toast is for actual server errors.
+      if (!error.message.includes('Failed to load settings')) {
+          toast.error(`Failed to load settings: ${error.message}`);
+      }
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [user]); // Dependency on `user` ensures this re-runs on login/logout.
 
   useEffect(() => {
     loadSettings();
-  }, [loadSettings]);
+  }, [user, loadSettings]);
 
   const updateSetting = (key, value) => {
+    // First, persist the change to localStorage to ensure UI consistency
+    // for components that might read directly from it.
+    saveSetting(key, value);
+
+    // Then, update the context's state.
     setSettings((prev) => ({ ...prev, [key]: value }));
   };
 
   const saveSettings = async () => {
     setIsLoading(true);
     try {
-      await saveSettingsToDb(settings);
+      // Gather all settings from localStorage to ensure we have the latest values,
+      // especially from parts of the app that might not use the context.
+      const settingsToSave = gatherCredentials();
+
+      // We pass the up-to-date settings object to the DB.
+      await saveSettingsToDb(settingsToSave);
+
+      // Also, update the local context state to be in sync with what was saved.
+      setSettings(settingsToSave);
+
       toast.success('Settings saved successfully!');
     } catch (error) {
       toast.error(`Failed to save settings: ${error.message}`);

--- a/src/utils/credentialsManager.js
+++ b/src/utils/credentialsManager.js
@@ -101,6 +101,56 @@ export const applySettings = (settings) => {
 
 
 /**
+ * Saves a single setting to localStorage.
+ * This allows for granular updates to localStorage without clearing other keys.
+ * @param {string} key - The key of the setting to save.
+ * @param {*} value - The value of the setting.
+ */
+export const saveSetting = (key, value) => {
+  // Use the CREDENTIAL_KEYS to decide which specific save function to use
+  switch (key) {
+    case CREDENTIAL_KEYS.GEMINI:
+      saveGeminiApiKey(value);
+      break;
+    case CREDENTIAL_KEYS.GOOGLE_DRIVE_API_KEY:
+      localStorage.setItem(CREDENTIAL_KEYS.GOOGLE_DRIVE_API_KEY, value);
+      break;
+    case CREDENTIAL_KEYS.GOOGLE_DRIVE_CLIENT_ID:
+      localStorage.setItem(CREDENTIAL_KEYS.GOOGLE_DRIVE_CLIENT_ID, value);
+      break;
+    case CREDENTIAL_KEYS.GOOGLE_TTS:
+      saveGoogleCloudTTSCredentials(value);
+      break;
+    case CREDENTIAL_KEYS.WORDPRESS:
+      saveWordpressConfig(value);
+      break;
+    case CREDENTIAL_KEYS.TIMEZONE:
+      saveTimezone(value);
+      break;
+    case CREDENTIAL_KEYS.GEMINI_MODEL:
+      saveGeminiModel(value);
+      break;
+    case CREDENTIAL_KEYS.GEMINI_IMAGE_MODEL:
+      saveGeminiImageModel(value);
+      break;
+    default:
+      // Fallback for settings not in CREDENTIAL_KEYS.
+      // This might happen with new or temporary settings.
+      console.warn(`Attempted to save setting with unknown key: "${key}". Saving directly to localStorage.`);
+      try {
+        if (typeof value === 'object' && value !== null) {
+          localStorage.setItem(key, JSON.stringify(value));
+        } else {
+          localStorage.setItem(key, value);
+        }
+      } catch (error) {
+        console.error(`Failed to save setting "${key}" to localStorage:`, error);
+      }
+      break;
+  }
+};
+
+/**
  * Saves the current credentials from localStorage to the database via the API.
  */
 export const saveSettingsToDb = async (settings) => {


### PR DESCRIPTION
This commit fixes an issue where user settings were not being synchronized when logging in on a new device. The root cause was that settings were being stored and read from localStorage without being consistently fetched from or saved to the database based on the user's authentication state.

The following changes have been implemented:

- The `SettingsContext` is now aware of the user's authentication status via the `useUserAuth` hook. It automatically loads settings from the database on login and clears them on logout.
- The `updateSetting` function in `SettingsContext` now immediately persists changes to `localStorage` to ensure UI consistency for components that read directly from it.
- The `saveSettings` function has been made more robust. It now gathers all known credentials from `localStorage` before sending them to the database, preventing data loss from components that might not use the context correctly.
- A new utility function, `saveSetting`, has been added to `credentialsManager.js` to provide a centralized way to save individual settings to `localStorage`.

A pre-existing test failure in `test/test_scheduler_success.test.js` related to the `pg-mem` library was observed. This failure is unrelated to the changes in this commit.