### PR TITLE
fix(video): Handle video uploads as blobs to prevent 413 error

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -758,8 +758,11 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         const videoUrl = URL.createObjectURL(blob);
         setVideo(videoUrl);
         if (onVideoGenerated) {
-          const dataUrl = await blobToDataURL(blob);
-          onVideoGenerated([{ blob, url: dataUrl, name: `video-compat-${Date.now()}.webm` }]);
+          const videoData = { blob, url: videoUrl, name: `video-compat-${Date.now()}.webm` };
+          onVideoGenerated([videoData]);
+          if (onNewAsset) {
+            onNewAsset(videoUrl, blob);
+          }
         }
       };
 


### PR DESCRIPTION
The video generator's compatibility mode was converting generated videos into large `data:` URIs. When saving a campaign, this `data:` URI was included in the JSON payload, causing a "413 Content Too Large" error from the server.

This commit modifies the video generator to handle videos consistently with other assets like images and audio.

- In the compatibility mode, the generated video `Blob` is no longer converted to a `data:` URI.
- Instead, a temporary `blob:` URL is created and used for the local preview.
- The `onNewAsset` callback is now correctly called with the `blob:` URL and the `Blob` object. This adds the video to the pending upload queue.

This ensures that `serializeCampaignData` can intercept the video, upload it directly to Vercel Blob storage, and replace the temporary URL with a permanent one before the campaign state is sent to the backend API. This prevents the large video data from being part of the JSON payload, resolving the 413 error.