### PR TITLE
feat: Implement full video support and fix generation bugs

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -359,10 +359,16 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
     if (generationMode === 'narration') {
       await generateNarrationVideo();
     } else if (generatePerRecord) {
-      // Pre-calculate totalFrames for the first video to avoid NaN in progress bar
       if (generatedImages.length > 0) {
         const firstDuration = (generatedAudioData && generatedAudioData[0]) ? generatedAudioData[0].duration : slideDuration;
-        setTotalFrames(Math.floor(firstDuration * fps));
+        const firstTotalFrames = Math.floor(firstDuration * fps);
+        if (firstTotalFrames <= 0) {
+            setError("A duração do primeiro slide é zero ou inválida, impossível gerar vídeos por registro. Verifique seus dados de áudio ou a duração do slide.");
+            setSnackbarOpen(true);
+            setShowProgressModal(false);
+            return;
+        }
+        setTotalFrames(firstTotalFrames);
       }
       await generateVideoPerRecord();
     } else {
@@ -370,6 +376,14 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         const duration = (generatedAudioData && generatedAudioData[i]) ? generatedAudioData[i].duration : slideDuration;
         return acc + Math.floor(duration * fps);
       }, 0);
+
+      if (totalVideoFrames <= 0) {
+        setError("A duração total do vídeo é zero ou inválida. Verifique a duração dos seus áudios ou a configuração de duração dos slides.");
+        setSnackbarOpen(true);
+        setShowProgressModal(false);
+        return;
+      }
+
       setTotalFrames(totalVideoFrames);
 
       if (compatibilityMode || !ffmpegLoaded) {


### PR DESCRIPTION
This commit introduces comprehensive support for videos in the Midiator application and fixes bugs related to the video generation progress display.

Key changes include:

1.  **Campaign Data Structure:** The campaign JSON structure now includes a `generatedVideos` array. Each video object stores essential metadata such as `vercelBlobId`, `vercelBlobUrl`, `mimeType`, `size`, and `thumbnailUrl`.

2.  **Video & Thumbnail Generation:** The `VideoGenerator2` component now uses `ffmpeg.wasm` to generate both the MP4 video and a JPEG thumbnail from the video's first frame.

3.  **Asset Serialization Pipeline:** The `serializeCampaignData` function in `utils/campaignState.js` has been enhanced to correctly identify video and thumbnail assets, upload them to Vercel Blob storage, and update the campaign state with the full metadata returned from the Vercel API.

4.  **State Synchronization:** The campaign saving logic now synchronizes the local component state with the newly saved state from the server, ensuring that permanent Vercel URLs replace local `blob:` URLs in the UI after a save.

5.  **UI Enhancements:** The UI now displays a list of generated videos as cards, each showing its thumbnail, name, and size, with a download button.

6.  **Bug Fixes:**
    - Fixed a race condition that caused the progress bar to show "NaN%" or "0 de 0 frames".
    - Added validation to prevent video generation if the calculated total duration is zero, providing a clear error message to the user instead of hanging.