### PR TITLE
feat: Implement full video support and fix generation bugs

### DIFF
--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -66,6 +66,65 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
     setAudioData(initialAudioData || []);
   }, [initialAudioData]);
 
+  // When the component loads or receives new audio data, process any items
+  // that have a URL but are missing a duration.
+  useEffect(() => {
+    const processMissingDurations = async () => {
+      const audiosToProcess = audioData.filter(a => a && a.url && !a.duration);
+      if (audiosToProcess.length === 0) {
+        return; // Nothing to do
+      }
+
+      console.log(`[AudioGenerator] Found ${audiosToProcess.length} audios missing duration. Processing...`);
+
+      const promises = audiosToProcess.map(audioToProcess => {
+        return new Promise((resolve) => {
+          const audioElement = document.createElement('audio');
+          audioElement.preload = 'metadata';
+
+          audioElement.onloadedmetadata = () => {
+            resolve({ ...audioToProcess, duration: audioElement.duration });
+          };
+
+          audioElement.onerror = (e) => {
+            console.error('Error loading audio metadata for', audioToProcess.url, e);
+            resolve(audioToProcess); // Resolve with original data on error
+          };
+
+          const blob = getPlayableBlob(audioToProcess);
+          if (blob) {
+            audioElement.src = URL.createObjectURL(blob);
+          } else if (audioToProcess.url) {
+            // Fallback for URLs that might not be in pendingAssets (e.g., direct vercel urls)
+             audioElement.src = audioToProcess.url;
+          } else {
+             console.error('Could not find a source for audio to calculate duration', audioToProcess);
+             resolve(audioToProcess);
+          }
+        });
+      });
+
+      const processedAudios = await Promise.all(promises);
+
+      // Create a map of the processed audios for efficient lookup
+      const processedMap = new Map(processedAudios.map(a => [a.url, a]));
+
+      // Update the main audioData array
+      const finalAudioData = audioData.map(originalAudio =>
+        processedMap.get(originalAudio.url) || originalAudio
+      );
+
+      console.log('[AudioGenerator] Durations processed. Updating parent state.');
+      setAudioData(finalAudioData);
+      onAudiosGenerated(finalAudioData);
+    };
+
+    processMissingDurations();
+    // We run this effect when audioData state changes, but it has a built-in guard
+    // to prevent infinite loops.
+  }, [audioData, onAudiosGenerated]);
+
+
   // Initialize the Google Cloud TTS API when the component mounts or mode changes
   useEffect(() => {
     if (audioMode.startsWith('google-tts')) {


### PR DESCRIPTION
This commit introduces comprehensive support for videos in the Midiator application and fixes bugs related to the video generation progress display.

Key changes include:

1.  **Campaign Data Structure:** The campaign JSON structure now includes a `generatedVideos` array. Each video object stores essential metadata such as `vercelBlobId`, `vercelBlobUrl`, `mimeType`, `size`, and `thumbnailUrl`.

2.  **Video & Thumbnail Generation:** The `VideoGenerator2` component now uses `ffmpeg.wasm` to generate both the MP4 video and a JPEG thumbnail from the video's first frame.

3.  **Asset Serialization Pipeline:** The core `serializeCampaignData` function in `utils/campaignState.js` has been enhanced to correctly identify video and thumbnail assets, upload them to Vercel Blob storage, and update the campaign state with the full metadata returned from the Vercel API.

4.  **State Synchronization:** The campaign saving logic now synchronizes the local component state with the newly saved state from the server. This ensures that permanent Vercel URLs replace local `blob:` URLs in the UI after a save.

5.  **UI Enhancements:** The UI now displays a list of generated videos as cards, each showing its thumbnail, name, and size, with a functional download button.

6.  **Bug Fixes:**
    - Fixed a bug where video generation would hang due to missing audio duration data by making `AudioGenerator.jsx` responsible for calculating and propagating durations to the central state.
    - Added validation to prevent video generation if the calculated total duration is zero, providing a clear error message to the user instead of hanging.