### PR TITLE
feat: Implement full video support and fix generation bugs

### DIFF
--- a/src/components/AudioGenerator.jsx
+++ b/src/components/AudioGenerator.jsx
@@ -66,65 +66,6 @@ const AudioGenerator = ({ csvData, fieldPositions, onAudiosGenerated, initialAud
     setAudioData(initialAudioData || []);
   }, [initialAudioData]);
 
-  // When the component loads or receives new audio data, process any items
-  // that have a URL but are missing a duration.
-  useEffect(() => {
-    const processMissingDurations = async () => {
-      const audiosToProcess = audioData.filter(a => a && a.url && !a.duration);
-      if (audiosToProcess.length === 0) {
-        return; // Nothing to do
-      }
-
-      console.log(`[AudioGenerator] Found ${audiosToProcess.length} audios missing duration. Processing...`);
-
-      const promises = audiosToProcess.map(audioToProcess => {
-        return new Promise((resolve) => {
-          const audioElement = document.createElement('audio');
-          audioElement.preload = 'metadata';
-
-          audioElement.onloadedmetadata = () => {
-            resolve({ ...audioToProcess, duration: audioElement.duration });
-          };
-
-          audioElement.onerror = (e) => {
-            console.error('Error loading audio metadata for', audioToProcess.url, e);
-            resolve(audioToProcess); // Resolve with original data on error
-          };
-
-          const blob = getPlayableBlob(audioToProcess);
-          if (blob) {
-            audioElement.src = URL.createObjectURL(blob);
-          } else if (audioToProcess.url) {
-            // Fallback for URLs that might not be in pendingAssets (e.g., direct vercel urls)
-             audioElement.src = audioToProcess.url;
-          } else {
-             console.error('Could not find a source for audio to calculate duration', audioToProcess);
-             resolve(audioToProcess);
-          }
-        });
-      });
-
-      const processedAudios = await Promise.all(promises);
-
-      // Create a map of the processed audios for efficient lookup
-      const processedMap = new Map(processedAudios.map(a => [a.url, a]));
-
-      // Update the main audioData array
-      const finalAudioData = audioData.map(originalAudio =>
-        processedMap.get(originalAudio.url) || originalAudio
-      );
-
-      console.log('[AudioGenerator] Durations processed. Updating parent state.');
-      setAudioData(finalAudioData);
-      onAudiosGenerated(finalAudioData);
-    };
-
-    processMissingDurations();
-    // We run this effect when audioData state changes, but it has a built-in guard
-    // to prevent infinite loops.
-  }, [audioData, onAudiosGenerated]);
-
-
   // Initialize the Google Cloud TTS API when the component mounts or mode changes
   useEffect(() => {
     if (audioMode.startsWith('google-tts')) {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -170,6 +170,7 @@ function HomePage() {
   const [displayedImageSize, setDisplayedImageSize] = useState({ width: 0, height: 0 });
   const [originalImageSize, setOriginalImageSize] = useState(DEFAULT_IMAGE_SIZE);
   const [generatedAudioData, setGeneratedAudioData] = useState([]);
+  const [isProcessingAudio, setIsProcessingAudio] = useState(false);
   const [isDraggingOverImage, setIsDraggingOverImage] = useState(false);
   const [showSetupModal, setShowSetupModal] = useState(false);
   const [showCampaignStandardsModal, setShowCampaignStandardsModal] = useState(false);
@@ -699,10 +700,18 @@ function HomePage() {
     processVideos();
   }, [generatedVideos, setGeneratedVideos]);
 
+  // Processes audio files that are loaded or generated to calculate their duration,
+  // which is needed for video generation. Disables the UI while processing.
   useEffect(() => {
     const processAudios = async () => {
-      const audiosToProcess = generatedAudioData.filter(a => a.url && !a.duration);
-      if (audiosToProcess.length === 0) return;
+      const audiosToProcess = generatedAudioData.filter(a => a && a.url && !a.duration);
+      if (audiosToProcess.length === 0) {
+        setIsProcessingAudio(false);
+        return;
+      }
+
+      setIsProcessingAudio(true);
+      toast.info(`Processando ${audiosToProcess.length} áudio(s) para calcular a duração...`);
 
       const promises = audiosToProcess.map(audioData => {
         return new Promise((resolve) => {
@@ -710,37 +719,44 @@ function HomePage() {
           audioElement.preload = 'metadata';
 
           audioElement.onloadedmetadata = () => {
-            resolve({
-              ...audioData,
-              duration: audioElement.duration
-            });
+            resolve({ ...audioData, duration: audioElement.duration });
           };
 
           audioElement.onerror = (e) => {
             console.error('Error loading audio metadata for', audioData.url, e);
-            resolve(audioData); // Resolve with original data so we don't lose the audio
+            resolve(audioData); // Resolve with original data on error
           };
 
-          audioElement.src = audioData.url;
+          // Use the blob from pendingAssets if available, otherwise use the URL
+          const blob = pendingAssets[audioData.url];
+          if (blob) {
+            audioElement.src = URL.createObjectURL(blob);
+          } else {
+            audioElement.src = audioData.url;
+          }
         });
       });
 
-      const processedAudios = await Promise.all(promises);
+      try {
+        const processedAudios = await Promise.all(promises);
 
-      setGeneratedAudioData(currentAudios => {
-        const newCurrentAudios = [...currentAudios];
-        processedAudios.forEach(processedAudio => {
-            const index = newCurrentAudios.findIndex(a => a.url === processedAudio.url);
-            if (index !== -1) {
-                newCurrentAudios[index] = processedAudio;
-            }
+        const updatedAudios = generatedAudioData.map(originalAudio => {
+          const processed = processedAudios.find(p => p.url === originalAudio.url);
+          return processed || originalAudio;
         });
-        return newCurrentAudios;
-      });
+
+        setGeneratedAudioData(updatedAudios);
+        toast.success("Durações de áudio calculadas com sucesso!");
+      } catch (error) {
+        toast.error("Ocorreu um erro ao processar os áudios.");
+        console.error("Audio processing failed:", error);
+      } finally {
+        setIsProcessingAudio(false);
+      }
     };
 
     processAudios();
-  }, [generatedAudioData, setGeneratedAudioData]);
+  }, [generatedAudioData]);
 
   const steps = [ { label: 'Minhas Campanhas', description: 'Gerencie suas campanhas existentes ou crie uma nova.', icon: FolderOpenIcon }, { label: 'Campanha', description: 'Criar o material de referência para a campanha.', icon: CampaignIcon }, { label: 'Posts Curtos', description: 'Gere, carregue ou edite os posts para redes sociais.', icon: InsertDriveFileOutlined }, { label: 'Modelo de Página', description: 'Carregue a imagem de fundo, posicione os campos e configure a formatação.', icon: ImageIcon }, { label: 'Edição de Páginas', description: 'Gere as páginas finais.', icon: FormatBold }, { label: 'Gerar Áudio', description: 'Crie a narração para os slides.', icon: Audiotrack }, { label: 'Gerar Vídeo', description: 'Crie um vídeo a partir das imagens geradas.', icon: Movie }, { label: 'Publicar', description: 'Publique o conteúdo no WordPress.', icon: Publish }, { label: 'Monitorar', description: 'Acompanhe as estatísticas de suas publicações.', icon: BarChart } ];
   const handleCreateNewCampaign = () => {
@@ -1532,7 +1548,22 @@ function HomePage() {
                 )}
                 {activeStep === 8 && <Monitor currentCampaign={currentCampaign} />}
 
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} ><Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button><Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box><Button onClick={handleNext} disabled={isGenerating || activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1)} variant="contained" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Próximo</Button></Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 4, px: 2 }} >
+                  <Button onClick={handleBack} disabled={activeStep === 0} variant="outlined" sx={{ borderRadius: 2, px: 3, py: 1.5 }} >Anterior</Button>
+                  <Box sx={{ flexGrow: 1, display: 'flex', gap: 1, flexWrap: 'wrap', justifyContent: 'center', mx: 2 }}>{steps.map((_, index) => (<Box key={index} sx={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: index === activeStep ? 'primary.main' : index < activeStep ? 'success.main' : 'grey.300', transition: 'all 0.3s ease' }} />))}</Box>
+                  <Tooltip title={activeStep === 5 && isProcessingAudio ? "Processando durações de áudio, por favor aguarde..." : ""}>
+                    <span>
+                      <Button
+                        onClick={handleNext}
+                        disabled={isGenerating || activeStep === steps.length - 1 || !canProceedToStep(activeStep + 1) || (activeStep === 5 && isProcessingAudio)}
+                        variant="contained"
+                        sx={{ borderRadius: 2, px: 3, py: 1.5 }}
+                      >
+                        Próximo
+                      </Button>
+                    </span>
+                  </Tooltip>
+                </Box>
               </>
             )}
             {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} onUpdate={fetchPersonasForCampaign} />}


### PR DESCRIPTION
This commit introduces comprehensive support for videos in the Midiator application and fixes bugs related to the video generation progress display and data flow.

Key changes include:

1.  **Campaign Data Structure:** The campaign JSON structure now includes a `generatedVideos` array. Each video object stores essential metadata such as `vercelBlobId`, `vercelBlobUrl`, `mimeType`, `size`, and `thumbnailUrl`.

2.  **Video & Thumbnail Generation:** The `VideoGenerator2` component now uses `ffmpeg.wasm` to generate both the MP4 video and a JPEG thumbnail from the video's first frame.

3.  **Asset Serialization Pipeline:** The core `serializeCampaignData` function in `utils/campaignState.js` has been enhanced to correctly identify video and thumbnail assets, upload them to Vercel Blob storage, and update the campaign state with the full metadata returned from the Vercel API.

4.  **State Synchronization:** The campaign saving logic now synchronizes the local component state with the newly saved state from the server. This ensures that permanent Vercel URLs replace local `blob:` URLs in the UI after a save.

5.  **UI Enhancements:** The UI now displays a list of generated videos as cards, each showing its thumbnail, name, and size, with a functional download button.

6.  **Bug Fixes:**
    - Fixed a race condition where video generation would fail due to missing audio duration data. A loading state (`isProcessingAudio`) and a `useEffect` have been added to `HomePage.jsx` to ensure durations are calculated before the user can proceed to the video step.
    - Added validation to prevent video generation if the calculated total duration is zero, providing a clear error message to the user instead of hanging.