### PR TITLE
feat: Implement full video support and fix all generation bugs

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -13,7 +13,7 @@ import ProgressModal from './ProgressModal';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile } from '@ffmpeg/util';
 
-import { blobToDataURL } from '../utils/fileUtils';
+import { getPlayableBlob } from '../utils/fileUtils';
 import NarrationSettings from './VideoGenerator/NarrationSettings';
 import Preview from './VideoGenerator/Preview';
 import SlidesSettings from './VideoGenerator/SlidesSettings';
@@ -433,18 +433,12 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
       if (hasAudio) {
         await Promise.all(
           generatedAudioData.map(async (audio, i) => {
-            let audioSource = null;
-            if (audio.blob) {
-              audioSource = await fetchFile(URL.createObjectURL(audio.blob));
-            } else if (audio.url) {
-              try {
-                audioSource = await fetchFile(audio.url);
-              } catch (e) {
-                console.warn(`Failed to fetch audio from URL for slide ${i}: ${audio.url}`, e);
-              }
-            }
-            if (audioSource) {
+            const audioBlob = getPlayableBlob(audio, pendingAssets);
+            if (audioBlob) {
+              const audioSource = await fetchFile(URL.createObjectURL(audioBlob));
               await ffmpeg.writeFile(`audio${i}.mp3`, audioSource);
+            } else {
+               console.warn(`Could not find a playable blob for audio slide ${i}. It will be silent.`);
             }
           })
         );
@@ -473,8 +467,8 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
             inputs.push("-i", "transition.mp3");
           }
         }
-        generatedAudioData.forEach((_, i) => {
-          if (generatedAudioData[i].blob) {
+        generatedAudioData.forEach((audio, i) => {
+          if (getPlayableBlob(audio, pendingAssets)) {
             inputs.push("-i", `audio${i}.mp3`);
           }
         });
@@ -532,7 +526,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         // followed by its transition sound (or silence).
         for (let i = 0; i < generatedImages.length; i++) {
           const audioData = generatedAudioData[i];
-          const hasNarration = audioData && audioData.blob;
+          const hasNarration = !!getPlayableBlob(audioData, pendingAssets);
           const isLastSlide = i === generatedImages.length - 1;
 
           let slideContentAudio;
@@ -744,17 +738,6 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
     setShowProgressModal(false);
   };
 
-  const getPlayableBlob = (audio) => {
-    if (!audio) return null;
-    if (audio.blob instanceof Blob) {
-      return audio.blob;
-    }
-    if (audio.url && audio.url.startsWith('blob:') && pendingAssets[audio.url] instanceof Blob) {
-      return pendingAssets[audio.url];
-    }
-    return null;
-  };
-
   const generateSingleVideo = async (imageData, audioData, index) => {
     const ffmpeg = ffmpegRef.current;
     const audioObject = audioData && audioData.length > 0 ? audioData[0] : null;
@@ -773,7 +756,8 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
     const inputs = ["-loop", "1", "-t", duration.toString(), "-i", imgFile];
     if (hasAudio) {
-      const audioSource = await fetchFile(audioBlob);
+      // Wrapping the blob in createObjectURL for consistency with the other generation function.
+      const audioSource = await fetchFile(URL.createObjectURL(audioBlob));
       await ffmpeg.writeFile(audioFile, audioSource);
       inputs.push("-i", audioFile);
     }

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -41,3 +41,23 @@ export const downloadExampleCsv = async () => {
     alert("Não foi possível baixar o arquivo CSV de exemplo. Verifique o console para mais detalhes.");
   }
 };
+
+/**
+ * Finds a playable Blob for a given media asset.
+ * It prioritizes a blob directly on the asset object, then checks the pendingAssets map.
+ * @param {object} asset The asset object (e.g., an audio or video object).
+ * @param {object} pendingAssets The map of pending assets (blobUrl -> Blob).
+ * @returns {Blob|null} The found Blob object or null.
+ */
+export const getPlayableBlob = (asset, pendingAssets = {}) => {
+  if (!asset) return null;
+  // Priority 1: The blob property on the asset object itself (for newly generated assets)
+  if (asset.blob instanceof Blob) {
+    return asset.blob;
+  }
+  // Priority 2: Look in pendingAssets using the asset's URL (for loaded assets)
+  if (asset.url && asset.url.startsWith('blob:') && pendingAssets[asset.url] instanceof Blob) {
+    return pendingAssets[asset.url];
+  }
+  return null;
+};


### PR DESCRIPTION
This commit introduces comprehensive support for videos in the Midiator application and fixes a series of critical bugs related to the video generation progress display, data flow, and FFmpeg command execution.

Key changes include:

1.  **Campaign Data Structure:** The campaign JSON structure now includes a `generatedVideos` array. Each video object stores essential metadata such as `vercelBlobId`, `vercelBlobUrl`, `mimeType`, `size`, and `thumbnailUrl`.

2.  **Video & Thumbnail Generation:** The `VideoGenerator2` component now uses `ffmpeg.wasm` to generate both the MP4 video and a JPEG thumbnail from the video's first frame.

3.  **Asset Serialization Pipeline:** The core `serializeCampaignData` function in `utils/campaignState.js` has been enhanced to correctly identify video and thumbnail assets, upload them to Vercel Blob storage, and update the campaign state with the full metadata returned from the Vercel API.

4.  **State Synchronization & Race Condition Fix:** The application now correctly handles the asynchronous nature of audio duration calculation. The "Next" button is disabled until all durations are processed, preventing a race condition that caused downstream failures. The local state is also synced with the server state after saving.

5.  **Robust FFmpeg Commands:**
    - The logic to detect and fetch audio blobs has been centralized in a `getPlayableBlob` helper function and is now used consistently in both video generation modes, fixing bugs where audio was missing in loaded campaigns.
    - The `-shortest` flag has been added to the FFmpeg command for per-record video generation to prevent the process from hanging.

6.  **UI Enhancements & Bug Fixes:**
    - The UI now displays a list of generated videos as cards, each showing its thumbnail, name, and size, with a functional download button.
    - The progress modal and FFmpeg event listeners have been made more robust to prevent `NaN` errors and handle inconsistent data.