### PR TITLE
feat: Implement full video support and fix all generation bugs

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -754,7 +754,9 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
     const fileData = await fetchFile(imageData[0].url);
     await ffmpeg.writeFile(imgFile, fileData);
 
-    const inputs = ["-loop", "1", "-t", duration.toString(), "-i", imgFile];
+    // For a single image, -loop 1 is enough to make it an infinite stream.
+    // The -shortest flag will then cut it off when the audio ends.
+    const inputs = ["-loop", "1", "-i", imgFile];
     if (hasAudio) {
       // Wrapping the blob in createObjectURL for consistency with the other generation function.
       const audioSource = await fetchFile(URL.createObjectURL(audioBlob));
@@ -790,7 +792,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
       "-c:v", "libx264",
       "-r", fps.toString(),
       "-pix_fmt", "yuv420p",
-      "-t", duration.toString(),
+      // The -t flag is removed from output; -shortest will handle the duration.
       "-preset", "ultrafast",
       outputFilename
     );


### PR DESCRIPTION
This commit introduces comprehensive support for videos in the Midiator application and fixes a series of critical bugs related to the video generation progress display, data flow, asset persistence, and FFmpeg command execution.

Key changes include:

1.  **Campaign Data Structure:** The campaign JSON structure now includes a `generatedVideos` array. Each video object stores essential metadata such as `vercelBlobId`, `vercelBlobUrl`, `mimeType`, `size`, and `thumbnailUrl`.

2.  **Video & Thumbnail Generation:** The `VideoGenerator2` component now uses `ffmpeg.wasm` to generate both the MP4 video and a JPEG thumbnail from the video's first frame.

3.  **Symmetrical Asset Serialization/Deserialization:** The `serializeCampaignData` (saving) and `deserializeCampaignData` (loading) functions in `utils/campaignState.js` have been significantly enhanced to correctly and symmetrically handle the video asset structure. This ensures that videos and their thumbnails are uploaded, saved with the correct metadata, and then correctly re-hydrated with local blob URLs when a campaign is loaded.

4.  **Robust State Management & Sanitization:**
    - A race condition during audio processing has been fixed by adding a loading state and disabling navigation until all audio durations are calculated.
    - The `sanitizeMediaArray` function in `HomePage.jsx` is now used for all media asset arrays (including `generatedPagesData`), explicitly deleting all blob properties before saving to definitively fix `413 Payload Too Large` errors.

5.  **Robust FFmpeg Commands:**
    - The logic to detect and fetch audio blobs has been centralized in a `getPlayableBlob` helper function and is now used consistently in both video generation modes, fixing bugs where audio was missing.
    - The `-shortest` flag has been added to the FFmpeg command for per-record video generation, and conflicting `-t` duration flags have been removed to prevent the process from hanging.

6.  **UI Enhancements & Bug Fixes:**
    - The UI now displays a list of generated videos as cards, each showing its thumbnail, name, and size.
    - The progress modal and FFmpeg event listeners have been made more robust to prevent `NaN` errors.