### PR TITLE
fix(video)!: Isola instâncias do FFmpeg para corrigir travamento

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -39,7 +39,6 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
   const [totalFrames, setTotalFrames] = useState(0);
   const [generatePerRecord, setGeneratePerRecord] = useState(false);
   const [generationMode, setGenerationMode] = useState('slides'); // 'slides' or 'narration'
-  const [videosForGeneration, setVideosForGeneration] = useState(0);
   
   // Parâmetros de chromakey expandidos
   const [useChromaKey, setUseChromaKey] = useState(false);
@@ -703,14 +702,20 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
           setProgress(Math.min(totalFramesAllVideos, currentTotalProgress));
         };
 
-        // Inner try-catch for individual video errors
         try {
-          const videoBlob = await generateSingleVideo(imageData, audioData, i, pendingAssets, handleSubProgress);
+          // Create a new FFmpeg instance for each video
+          const ffmpeg = new FFmpeg();
+          await ffmpeg.load();
+
+          const videoBlob = await generateSingleVideo(ffmpeg, imageData, audioData, i, pendingAssets, handleSubProgress);
+
+          await ffmpeg.terminate(); // Terminate the instance after use
 
           framesCompletedSoFar += framesForThisVideo;
           setProgress(framesCompletedSoFar);
 
           const videoUrl = URL.createObjectURL(videoBlob);
+          // Re-use the main ffmpeg instance for thumbnails as it's a simpler operation
           const thumbnailBlob = await generateThumbnail(videoBlob);
           const thumbnailUrl = thumbnailBlob ? URL.createObjectURL(thumbnailBlob) : null;
 
@@ -738,9 +743,9 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
           }
 
         } catch (err) {
-          setError(`Erro ao gerar vídeo para o registro ${i + 1}: ${err.message}`);
+          setError(`Erro ao gerar vídeo para o registro ${i + 1}: ${err.message || 'Erro desconhecido'}`);
           setSnackbarOpen(true);
-          break; // Exit the loop on error
+          break;
         }
       }
       if (onVideoGenerated && allGeneratedVideoAssets.length > 0) {
@@ -754,8 +759,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
     }
   };
 
-  const generateSingleVideo = async (imageData, audioData, index, pendingAssets, onProgress) => {
-    const ffmpeg = ffmpegRef.current;
+  const generateSingleVideo = async (ffmpeg, imageData, audioData, index, pendingAssets, onProgress) => {
     const audioObject = audioData && audioData.length > 0 ? audioData[0] : null;
     const audioBlob = getPlayableBlob(audioObject, pendingAssets);
     const hasAudio = !!audioBlob;
@@ -1210,7 +1214,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         open={showProgressModal}
         progress={
           generatePerRecord
-            ? (progress / videosForGeneration) * 100
+            ? (progress / (totalFrames || 1)) * 100
             : generationMode === 'narration'
               ? Math.min(100, Math.max(0, progress || 0))
               : totalFrames > 0


### PR DESCRIPTION
Este commit implementa a correção definitiva para a funcionalidade de 'gerar vídeo por registro', que estava travando após a primeira geração bem-sucedida.

A causa raiz foi identificada como um problema de estado interno na instância reutilizada do FFmpeg. A solução foi refatorar o código para criar uma **instância do FFmpeg nova e limpa para cada vídeo** gerado no loop. Isso garante um ambiente de execução completamente isolado para cada vídeo, eliminando o travamento.

Este commit é cumulativo e inclui todas as correções anteriores desta sessão, abrangendo:
- API de Upload do Vercel
- Erros de sintaxe e build
- Barra de progresso granular
- Erros de 'NaN' e `pendingAssets`