### PR TITLE
fix(upload)!: Move `allowOverwrite` para o servidor

### DIFF
--- a/api/upload-client.js
+++ b/api/upload-client.js
@@ -61,6 +61,7 @@ const handler = async (req, res) => {
           tokenPayload: JSON.stringify({
             userId: userId,
           }),
+          allowOverwrite: true,
         };
       },
       onUploadCompleted: async ({ blob, tokenPayload }) => {

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -25,7 +25,6 @@ export const uploadAsset = async (blob, filename, campaignId, userId) => {
       access: 'public',
       handleUploadUrl: '/api/upload-client',
       multipart: true,
-      allowOverwrite: true,
     });
 
     console.log(`[uploadAsset] Successfully uploaded ${filename} via client-side method. Full response:`, newBlob);


### PR DESCRIPTION
Este commit move a opção `allowOverwrite: true` do cliente para a rota da API do servidor (`/api/upload-client.js`).

A permissão para sobrescrever arquivos no Vercel Blob deve ser concedida no momento da geração do token de upload no servidor, não na chamada do cliente. Esta correção move a lógica para o local correto, o que deve finalmente resolver o erro `This blob already exists`.

Este commit é o culminar de uma longa série de correções para estabilizar o fluxo de geração e upload de vídeo.