### PR TITLE
refactor(video): Suaviza a barra de progresso da geração em lote

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -708,7 +708,9 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
           const thumbnailBlob = await generateThumbnail(ffmpeg, videoBlob);
 
           framesCompletedSoFar += framesForThisVideo;
-          setProgress(framesCompletedSoFar);
+          // This line was causing the progress to "jump" at the end of each video.
+          // The granular handleSubProgress is now solely responsible for updates.
+          // setProgress(framesCompletedSoFar);
 
           const videoUrl = URL.createObjectURL(videoBlob);
           const thumbnailUrl = thumbnailBlob ? URL.createObjectURL(thumbnailBlob) : null;


### PR DESCRIPTION
Este commit remove uma chamada redundante ao `setProgress` que fazia com que a barra de progresso "pulasse" para o final de cada segmento de vídeo, em vez de progredir suavemente.

A atualização do progresso agora é de responsabilidade exclusiva do callback granular `handleSubProgress`, que monitora o avanço frame a frame, proporcionando uma experiência de usuário mais fluida e informativa durante a geração de vídeos por registro.