### PR TITLE
fix: Corrects the progress bar for video generation per record

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -709,7 +709,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
           framesCompletedSoFar += framesForThisVideo;
           // This line was causing the progress to "jump". The handleSubProgress is now solely responsible for updates.
-          setProgress(framesCompletedSoFar);
+          // setProgress(framesCompletedSoFar); // This line is now removed to allow for smooth progress.
 
           const videoUrl = URL.createObjectURL(videoBlob);
           const thumbnailUrl = thumbnailBlob ? URL.createObjectURL(thumbnailBlob) : null;


### PR DESCRIPTION
The progress bar for video generation per record was advancing in jumps, per record, instead of smoothly, per frame.

This was because, although the per-frame progress was correctly calculated and updated through the `handleSubProgress` function, the progress state was being overwritten with the total frames of the newly completed video at the end of each loop iteration.

This fix removes the line that overwrites the progress, allowing the smooth, frame-based update to work as expected.