### PR TITLE
fix: Corrige a barra de progresso da geração de vídeo por registro

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -696,8 +696,9 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
         const audioData = generatedAudioData[i] ? [generatedAudioData[i]] : null;
         const framesForThisVideo = Math.floor((audioData?.[0]?.duration || slideDuration) * fps);
 
-        const handleSubProgress = ({ frame }) => {
-          const currentTotalProgress = framesCompletedSoFar + (frame || 0);
+        const handleSubProgress = ({ time, frame }) => {
+          const framesProcessed = frame || Math.round((time || 0) / 1000000 * fps) || 0;
+          const currentTotalProgress = framesCompletedSoFar + framesProcessed;
           setProgress(Math.min(totalFramesAllVideos, currentTotalProgress));
         };
 


### PR DESCRIPTION
A barra de progresso da geração de vídeo por registro avançava aos saltos, em vez de suavemente, por frame.

A causa era dupla:
1. A função de callback de progresso (`handleSubProgress`) não era robusta e falhava em calcular o progresso quando a propriedade `frame` não estava presente no evento do FFmpeg.
2. Uma chamada `setProgress` ao final de cada vídeo sobrescrevia o progresso, causando o "salto".

Esta correção:
- Torna a função `handleSubProgress` mais robusta, adicionando um fallback para calcular os frames a partir da propriedade `time`.
- Mantém a linha que causava o "salto" comentada, garantindo que apenas a atualização por frame seja utilizada.