### PR TITLE
fix: Corrige persistência do modo escuro e UI de geração de vídeo

### DIFF
--- a/src/components/VideoGenerator/NarrationSettings.jsx
+++ b/src/components/VideoGenerator/NarrationSettings.jsx
@@ -6,6 +6,7 @@ import {
   Switch,
   Slider
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { UploadFile } from '@mui/icons-material';
 
 const NarrationSettings = ({
@@ -22,9 +23,11 @@ const NarrationSettings = ({
   useChromaKey,
   setUseChromaKey,
 }) => {
+  const theme = useTheme();
+
   return (
-    <Paper elevation={0} sx={{ p: 2, mt: 2, backgroundColor: 'rgba(255,255,255,0.05)', borderRadius: 1 }}>
-      <Typography variant="h6" sx={{ mb: 2, color: 'white' }}>
+    <Paper elevation={0} sx={{ p: 2, mt: 2, backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)', borderRadius: 1 }}>
+      <Typography variant="h6" sx={{ mb: 2, color: 'text.primary' }}>
         Configurações da Narração
       </Typography>
       <Grid container spacing={2}>
@@ -34,7 +37,7 @@ const NarrationSettings = ({
             component="label"
             fullWidth
             startIcon={<UploadFile />}
-            sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)' }}
+            sx={{ color: 'text.primary', borderColor: 'divider' }}
           >
             Carregar Vídeo de Narração
             <input
@@ -45,7 +48,7 @@ const NarrationSettings = ({
             />
           </Button>
           {narrationVideoData.file && (
-            <Typography variant="caption" sx={{ mt: 1, display: 'block' }}>
+            <Typography variant="caption" sx={{ mt: 1, display: 'block', color: 'text.secondary' }}>
               Arquivo: {narrationVideoData.file.name}
             </Typography>
           )}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -236,7 +236,6 @@ function HomePage() {
     console.log("Applying loaded state:", state);
 
     setActiveStep(state.activeStep ?? 0);
-    setDarkMode(state.darkMode ?? false);
     setSidebarOpen(state.sidebarOpen ?? !isMobile);
 
     setCsvData(Array.isArray(state.csvData) ? state.csvData : []);


### PR DESCRIPTION
- Impede que o modo de exibição (escuro/claro) seja salvo e restaurado com o estado da campanha, removendo a lógica de `applyAppState`.
- Ajusta a seção "Modo de Geração" na tela de vídeo para usar cores do tema, garantindo que o texto seja legível no modo claro.