### PR TITLE
feat: Add delete and rename functionality to video list

### DIFF
--- a/api/blob/delete.js
+++ b/api/blob/delete.js
@@ -1,0 +1,25 @@
+import { del } from '@vercel/blob';
+import { withAuth } from '../middleware/auth.js';
+
+const handler = async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  try {
+    const { url } = await req.json();
+
+    if (!url) {
+      return res.status(400).json({ error: 'URL is required' });
+    }
+
+    await del(url);
+
+    return res.status(200).json({ message: 'Blob deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting blob:', error);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+export default withAuth(handler);

--- a/src/components/EditableTypography.jsx
+++ b/src/components/EditableTypography.jsx
@@ -1,0 +1,56 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Typography, TextField, IconButton } from '@mui/material';
+import { Edit, Save } from '@mui/icons-material';
+
+const EditableTypography = ({ initialValue, onSave }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+    }
+  }, [isEditing]);
+
+  const handleSave = () => {
+    setIsEditing(false);
+    onSave(value);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      handleSave();
+    } else if (event.key === 'Escape') {
+      setIsEditing(false);
+      setValue(initialValue);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <TextField
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={handleSave}
+        onKeyDown={handleKeyDown}
+        inputRef={inputRef}
+        variant="standard"
+        size="small"
+        sx={{ width: '100%' }}
+      />
+    );
+  }
+
+  return (
+    <Typography
+      variant="body1"
+      sx={{ color: 'text.primary', cursor: 'pointer', width: '100%' }}
+      onClick={() => setIsEditing(true)}
+    >
+      {value}
+    </Typography>
+  );
+};
+
+export default EditableTypography;

--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -4,19 +4,22 @@ import {
   Alert,
   Paper,
   Snackbar, CircularProgress, Tooltip, FormControlLabel,
-  Switch, Slider, Select, MenuItem, FormControl, InputLabel
+  Switch, Slider, Select, MenuItem, FormControl, InputLabel,
+  IconButton
 } from '@mui/material';
-import { Movie, GetApp, Info, ErrorOutline, Refresh, Download, Palette } from '@mui/icons-material';
+import { Movie, GetApp, Info, ErrorOutline, Refresh, Download, Palette, Delete } from '@mui/icons-material';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 import ProgressModal from './ProgressModal';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile } from '@ffmpeg/util';
 
-import { getPlayableBlob } from '../utils/fileUtils';
+import { getPlayableBlob, deleteBlob } from '../utils/fileUtils';
 import NarrationSettings from './VideoGenerator/NarrationSettings';
 import Preview from './VideoGenerator/Preview';
 import SlidesSettings from './VideoGenerator/SlidesSettings';
+import EditableTypography from './EditableTypography';
+import { toast } from 'sonner';
 
 const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, generatedVideos = [], pendingAssets = {}, onVideoGenerated, onNewAsset }) => {
   const [video, setVideo] = useState(null);
@@ -112,6 +115,38 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
       spillSuppress: 0.0,
       edgeSmoothing: 0.0,
       yuv: false
+    }
+  };
+
+  const handleRenameVideo = (index, newName) => {
+    const updatedVideos = [...generatedVideos];
+    updatedVideos[index].name = newName;
+    onVideoGenerated(updatedVideos);
+  };
+
+  const handleDeleteVideo = async (index) => {
+    const videoToDelete = generatedVideos[index];
+    if (!videoToDelete) return;
+
+    if (!window.confirm(`Tem certeza que deseja excluir o vídeo "${videoToDelete.name}"? Esta ação não pode ser desfeita.`)) {
+      return;
+    }
+
+    try {
+      // First, delete from blob storage if the URL is a vercel blob url
+      if (videoToDelete.vercelBlobUrl && videoToDelete.vercelBlobUrl.includes('blob.vercel-storage.com')) {
+        await deleteBlob(videoToDelete.vercelBlobUrl);
+      }
+
+      // Then, remove from the local state
+      const updatedVideos = generatedVideos.filter((_, i) => i !== index);
+      onVideoGenerated(updatedVideos);
+
+      toast.success(`Vídeo "${videoToDelete.name}" excluído com sucesso.`);
+
+    } catch (error) {
+      console.error('Falha ao excluir o vídeo:', error);
+      toast.error(`Falha ao excluir o vídeo: ${error.message}`);
     }
   };
 
@@ -1536,24 +1571,36 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
                   )}
                   <CardContent sx={{ flexGrow: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <Box>
-                      <Typography variant="body1" sx={{ color: 'text.primary' }}>{video.name}</Typography>
+                      <EditableTypography
+                        initialValue={video.name}
+                        onSave={(newName) => handleRenameVideo(index, newName)}
+                      />
                       <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                         {video.size ? `${(video.size / 1024 / 1024).toFixed(2)} MB` : 'Tamanho desconhecido'}
                       </Typography>
                     </Box>
-                    <Button
-                      variant="contained"
-                      color="secondary"
-                      startIcon={<Download />}
-                      onClick={() => {
-                        const a = document.createElement('a');
-                        a.href = video.url || video.vercelBlobUrl;
-                        a.download = video.name;
-                        a.click();
-                      }}
-                    >
-                      Baixar
-                    </Button>
+                    <Box>
+                      <Button
+                        variant="contained"
+                        color="secondary"
+                        startIcon={<Download />}
+                        onClick={() => {
+                          const a = document.createElement('a');
+                          a.href = video.url || video.vercelBlobUrl;
+                          a.download = video.name;
+                          a.click();
+                        }}
+                      >
+                        Baixar
+                      </Button>
+                      <IconButton
+                        aria-label="delete"
+                        onClick={() => handleDeleteVideo(index)}
+                        sx={{ ml: 1 }}
+                      >
+                        <Delete />
+                      </IconButton>
+                    </Box>
                   </CardContent>
                 </Card>
               ))}

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -61,3 +61,33 @@ export const getPlayableBlob = (asset, pendingAssets = {}) => {
   }
   return null;
 };
+
+/**
+ * Deletes a blob from Vercel Blob Storage.
+ * @param {string} url The URL of the blob to delete.
+ * @returns {Promise<void>}
+ */
+export const deleteBlob = async (url) => {
+  if (!url || !url.includes('blob.vercel-storage.com')) {
+    console.warn('Invalid or non-Vercel blob URL provided for deletion:', url);
+    return;
+  }
+
+  try {
+    const response = await fetch('/api/blob/delete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      throw new Error(errorData.error || 'Failed to delete blob');
+    }
+  } catch (error) {
+    console.error('Error deleting blob:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
This commit introduces the ability for users to delete and rename videos in the VideoGenerator2 component.

- Created a new `EditableTypography` component to allow for in-place editing of the video name.
- Added a delete button to each video in the list.
- Implemented `handleRenameVideo` and `handleDeleteVideo` functions in `VideoGenerator2.jsx`.
- Added a new API endpoint `/api/blob/delete.js` to handle the deletion of blobs from Vercel Blob Storage.
- Added a `deleteBlob` utility function in `src/utils/fileUtils.js` to call the new API endpoint.
- The `handleDeleteVideo` function now calls the `deleteBlob` utility to ensure that videos are deleted from both the UI and the blob storage.