### PR TITLE
fix: Correct state update on video deletion

### DIFF
--- a/src/components/VideoGenerator2.jsx
+++ b/src/components/VideoGenerator2.jsx
@@ -21,7 +21,7 @@ import SlidesSettings from './VideoGenerator/SlidesSettings';
 import EditableTypography from './EditableTypography';
 import { toast } from 'sonner';
 
-const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, generatedVideos = [], pendingAssets = {}, onVideoGenerated, onNewAsset }) => {
+const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, generatedVideos = [], pendingAssets = {}, onVideoGenerated, onUpdateVideos, onNewAsset }) => {
   const [video, setVideo] = useState(null);
   const [error, setError] = useState(null);
   const [progress, setProgress] = useState(0);
@@ -121,7 +121,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
   const handleRenameVideo = (index, newName) => {
     const updatedVideos = [...generatedVideos];
     updatedVideos[index].name = newName;
-    onVideoGenerated(updatedVideos);
+    onUpdateVideos(updatedVideos);
   };
 
   const handleDeleteVideo = async (index) => {
@@ -140,7 +140,7 @@ const VideoGenerator2 = ({ generatedPages: generatedImages, generatedAudioData, 
 
       // Then, remove from the local state
       const updatedVideos = generatedVideos.filter((_, i) => i !== index);
-      onVideoGenerated(updatedVideos);
+      onUpdateVideos(updatedVideos);
 
       toast.success(`Vídeo "${videoToDelete.name}" excluído com sucesso.`);
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1537,6 +1537,7 @@ function HomePage() {
                       });
                       setPendingAssets(prev => ({ ...prev, ...newPendingAssets }));
                     }}
+                    onUpdateVideos={setGeneratedVideos}
                     onNewAsset={addAssetToPendingQueue}
                   />
                 )}


### PR DESCRIPTION
This commit fixes a bug where the video list in the UI was not updating after a video was deleted.

The issue was that the `onVideoGenerated` prop was being used for both adding new videos and updating the list, but its implementation in the parent component only handled appending.

This commit introduces a new prop, `onUpdateVideos`, which is used for updating the entire video list (e.g., after deletion or renaming). The `onVideoGenerated` prop is now used exclusively for appending newly generated videos.

This ensures that the UI correctly reflects the state of the video list after any modification.