### PR TITLE
feat: Implement streaming proxy for LinkedIn video uploads

### DIFF
--- a/api/linkedin-video-upload.js
+++ b/api/linkedin-video-upload.js
@@ -1,0 +1,57 @@
+import { withAuth } from './middleware/auth.js';
+
+// Disable Vercel's default body parser to handle raw streams
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+async function handleUploadVideo(request, response) {
+  const fetch = (await import('node-fetch')).default;
+  const uploadUrl = decodeURIComponent(request.headers['x-upload-url']);
+  const videoContentType = request.headers['content-type'];
+  const contentLength = request.headers['content-length'];
+
+  if (!uploadUrl) {
+    return response.status(400).json({ error: 'Missing X-Upload-URL header for video part upload.' });
+  }
+
+  try {
+    const linkedinResponse = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': videoContentType,
+        'Content-Length': contentLength,
+      },
+      body: request, // Forward the raw request stream
+      duplex: 'half', // Required for streaming request bodies with node-fetch
+    });
+
+    if (!linkedinResponse.ok) {
+      const errorText = await linkedinResponse.text();
+      console.error("LinkedIn Video Part Upload Error Body:", errorText);
+      return response.status(linkedinResponse.status).json({ message: `Failed to upload video part. Status: ${linkedinResponse.status} | Body: ${errorText}` });
+    }
+
+    const eTag = linkedinResponse.headers.get('ETag');
+    if (!eTag) {
+      return response.status(500).json({ message: 'ETag missing from LinkedIn upload response.' });
+    }
+
+    // The frontend expects a JSON response
+    return response.status(200).json({ eTag: eTag.replace(/"/g, '') });
+  } catch (error) {
+    console.error('Error during video part upload:', error);
+    return response.status(500).json({ error: 'Internal Server Error', details: error.message });
+  }
+}
+
+// The main handler for this endpoint, protected by authentication
+const mainHandler = async (request, response) => {
+    // We are not using the protectedHandler wrapper from the other file,
+    // as this endpoint only does one thing. We call the handler directly.
+    return handleUploadVideo(request, response);
+};
+
+export default withAuth(mainHandler);

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -187,28 +187,28 @@ export const uploadVideoForLinkedIn = async (linkedinConfig, videoBlob, authorUr
 
         const videoPartBlob = videoBlob.slice(firstByte, lastByte + 1);
 
-        // Use a direct fetch PUT request to the URL from LinkedIn
-        const uploadResponse = await fetch(uploadUrl, {
-            method: 'PUT',
-            body: videoPartBlob,
+        // Use the new streaming proxy endpoint
+        const proxyResponse = await fetch('/api/linkedin-video-upload', {
+            method: 'POST', // POST to our proxy
             headers: {
                 'Content-Type': videoBlob.type,
+                'X-Upload-URL': encodeURIComponent(uploadUrl),
+                // The withAuth middleware uses the Authorization header from the cookie, so we don't need to set it manually
             },
+            body: videoPartBlob,
         });
 
-        if (!uploadResponse.ok) {
-            const errorText = await uploadResponse.text();
-            console.error("LinkedIn Video Part Upload Error Body:", errorText);
-            throw new Error(`Falha no upload da parte do vídeo. Status: ${uploadResponse.status} ${uploadResponse.statusText}`);
+        if (!proxyResponse.ok) {
+            const errorData = await proxyResponse.json();
+            throw new Error(`Falha no upload da parte do vídeo através do proxy: ${errorData.message || proxyResponse.statusText}`);
         }
 
-        const etag = uploadResponse.headers.get('ETag');
-        if (!etag) {
-            throw new Error('ETag não encontrado na resposta do upload da parte do vídeo.');
+        const { eTag } = await proxyResponse.json();
+        if (!eTag) {
+            throw new Error('ETag não encontrado na resposta do proxy de upload.');
         }
 
-        // The ETag must be stripped of quotes
-        etags.push(etag.replace(/"/g, ''));
+        etags.push(eTag);
     }
 
     // Step 3: Finalize Upload


### PR DESCRIPTION
This commit introduces a robust solution for uploading videos to LinkedIn, addressing two key issues:
1. CORS errors caused by direct client-to-LinkedIn requests.
2. Potential "413 Payload Too Large" errors from a non-streaming proxy.

A new dedicated API endpoint, `/api/linkedin-video-upload`, has been created. This endpoint is specifically designed to handle raw file streams. It disables Vercel's default body parser and pipes the incoming video chunk directly to the LinkedIn upload URL provided by the client.

The frontend has been updated to send video parts to this new streaming proxy instead of attempting a direct upload. This prevents CORS errors and avoids the overhead of Base64 encoding, ensuring that large video files can be uploaded without hitting serverless function payload size limits.