### PR TITLE
feat(video): Add delete and rename actions to video list

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -157,7 +157,10 @@ export const serializeCampaignData = async (state, pendingAssets, userId, campai
               target.obj.vercelBlobId = vercelBlobResponse.pathname;
               target.obj.mimeType = vercelBlobResponse.contentType;
               target.obj.size = vercelBlobResponse.size;
-            } else {
+            } else if (target.assetType === 'thumbnail') {
+                target.obj[target.key] = vercelBlobResponse.url;
+            }
+            else {
               // This is a simple asset or a thumbnail, just replace the URL
               target.obj[target.key] = vercelBlobResponse.url;
             }
@@ -263,7 +266,11 @@ export const deserializeCampaignData = async (loadedState) => {
 
         // Update all occurrences of this URL with the new local blob URL.
         targets.forEach(target => {
-          target.obj[target.key] = tempUrl;
+            target.obj[target.key] = tempUrl;
+            // If we are updating a video object, let's also ensure its size is set from the downloaded blob.
+            if (target.obj.type === 'video' && target.key === 'vercelBlobUrl') {
+                target.obj.size = file.size;
+            }
         });
       })
       .catch(error => {


### PR DESCRIPTION
This commit introduces the ability for users to delete and rename videos in the VideoGenerator2 component. It also fixes several bugs related to state updates, list rendering, and data persistence.

- Created a new `EditableTypography` component to allow for in-place editing of the video name.
- Added a delete button to each video in the list.
- Implemented `handleRenameVideo` and `handleDeleteVideo` functions in `VideoGenerator2.jsx`.
- Added a new API endpoint `/api/blob/delete.js` to handle the deletion of blobs from Vercel Blob Storage.
- Added a `deleteBlob` utility function in `src/utils/fileUtils.js` to call the new API endpoint.
- Introduced a new prop `onUpdateVideos` to correctly handle state updates in the parent component (`HomePage.jsx`) after deletion or renaming, fixing a bug where the UI would not update correctly.
- Fixed a bug where deleting a video would remove the wrong item from the list by using a unique ID for each video as the `key` in the rendering loop instead of the array index.
- Fixed a bug where video sizes were not displayed for loaded campaigns by ensuring the `size` property is populated during the deserialization process.