### PR TITLE
fix: Pass video URN to post creation payload

### DIFF
--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -51,13 +51,14 @@ class LinkedInAPI {
     return personal;
   }
 
-  async publishPost(content, targetId, targetType = 'personal', images = []) {
+  async publishPost(content, targetId, targetType = 'personal', images = [], video = null) {
     return this._proxyFetch('createPost', {
       payload: {
         content,
         targetId,
         targetType,
         images,
+        video,
       }
     });
   }
@@ -136,9 +137,9 @@ export const publishToLinkedIn = async (campaignData, linkedinConfig) => {
         throw new Error('Campaign data, content, and targetId are required for publishing.');
     }
 
-    const { content, targetId, targetType, images } = campaignData;
+    const { content, targetId, targetType, images, video } = campaignData;
     const api = new LinkedInAPI(linkedinConfig.accessToken);
-    const result = await api.publishPost(content, targetId, targetType, images);
+    const result = await api.publishPost(content, targetId, targetType, images, video);
 
     console.log('Post created successfully on LinkedIn!', result);
     return result; // The proxy should return the final post object with an ID or link.


### PR DESCRIPTION
This commit fixes a bug where an uploaded video was not being attached to the final LinkedIn post.

While the video upload process itself was successful, the video's URN was being dropped by the `publishToLinkedIn` and `publishPost` functions, which were not designed to handle a video parameter. As a result, the `createPost` API call was sent with only text and/or images.

The following changes have been made in `src/utils/linkedinAPI.js`:
- The `publishPost` method now accepts a `video` parameter and includes it in the payload sent to the backend.
- The `publishToLinkedIn` wrapper function now extracts the `video` URN from the campaign data and passes it to `publishPost`.

This ensures that once a video is successfully uploaded, it is correctly associated with the post upon creation.