### PR TITLE
Fix: Refactor LinkedIn scheduler to use a dedicated cron endpoint

### DIFF
--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -1,0 +1,220 @@
+import { query } from '../db.js';
+import { markdownToLinkedinText } from '../utils.js';
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// Helper function to publish a single post to LinkedIn.
+// It returns the final response from the proxy.
+export async function publishPost(fetch, post, accessToken) {
+    const postContent = post.post_content;
+    const authorUrn = postContent.authorUrn;
+    const proxyApiBaseUrl = process.env.VITE_API_BASE_URL || 'http://localhost:5173';
+
+    // Define common headers for internal API calls to the proxy
+    const internalApiHeaders = {
+        'Content-Type': 'application/json',
+        'x-internal-secret': process.env.INTERNAL_API_SECRET,
+    };
+
+    const postText = [
+        postContent.titulo.toUpperCase(),
+        '',
+        markdownToLinkedinText(postContent.conteudo),
+        '',
+        '----',
+        postContent.cta,
+        '----',
+        (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
+    ].join('\n');
+
+    const images = post.post_content?.images || [];
+    const imageUrns = [];
+
+    if (images.length > 0) {
+        for (const imageUrl of images) {
+            const imageResponse = await fetch(imageUrl);
+            if (!imageResponse.ok) throw new Error(`Failed to fetch image from blob store: ${imageUrl}`);
+
+            const imageBuffer = await imageResponse.arrayBuffer();
+            const imageBase64 = Buffer.from(imageBuffer).toString('base64');
+            const imageType = imageResponse.headers.get('content-type');
+
+            const registerResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+                method: 'POST',
+                headers: internalApiHeaders,
+                body: JSON.stringify({
+                    action: 'registerUpload',
+                    accessToken,
+                    payload: {
+                        registerUploadRequest: {
+                            owner: authorUrn,
+                            recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
+                            serviceRelationships: [{
+                                relationshipType: 'OWNER',
+                                identifier: 'urn:li:userGeneratedContent'
+                            }]
+                        }
+                    }
+                })
+            });
+
+            if (registerResponse.status === 401) return registerResponse;
+            if (!registerResponse.ok) {
+                const errorData = await registerResponse.json();
+                throw new Error(`Failed to register image upload: ${errorData.message || 'Unknown error'}`);
+            }
+
+            const { uploadUrl, assetUrn } = await registerResponse.json();
+
+            const uploadResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+                method: 'POST',
+                headers: internalApiHeaders,
+                body: JSON.stringify({ action: 'uploadImage', accessToken, uploadUrl, imageBase64, imageType })
+            });
+
+            if (uploadResponse.status === 401) return uploadResponse;
+            if (!uploadResponse.ok) {
+                const errorData = await uploadResponse.json();
+                throw new Error(`Failed to upload image: ${errorData.message || 'Unknown error'}`);
+            }
+
+            imageUrns.push(assetUrn);
+        }
+    }
+
+    const videoUrn = post.post_content?.video;
+    const payload = {
+        author: authorUrn,
+        content: postText,
+        images: imageUrns,
+        video: videoUrn,
+        title: post.post_content?.titulo || 'Video Post'
+    };
+
+    return fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
+        method: 'POST',
+        headers: internalApiHeaders,
+        body: JSON.stringify({ action: 'createPost', accessToken, payload }),
+    });
+}
+
+
+// The main scheduler logic
+export async function handleRunScheduler(request, response) {
+    const fetch = (await import('node-fetch')).default;
+    console.log('Scheduler run initiated...');
+    let publishedCount = 0;
+    let failedCount = 0;
+
+    try {
+        const now = new Date();
+        const { rows: duePosts } = await query(
+            `SELECT ls.*, c.campaign_data, u.linkedin_access_token
+             FROM linkedin_schedules ls
+             JOIN users u ON ls.user_id = u.id
+             LEFT JOIN campaigns c ON ls.campaign_id = c.id
+             WHERE ls.scheduled_at <= ($1 AT TIME ZONE 'UTC')
+               AND ls.status = 'scheduled'
+               AND u.linkedin_access_token IS NOT NULL`,
+            [now.toISOString()]
+        );
+
+        if (duePosts.length === 0) {
+            console.log('No due posts to publish.');
+            return response.status(200).json({ message: 'No due posts to publish.' });
+        }
+
+        console.log(`Found ${duePosts.length} posts to process.`);
+
+        for (const post of duePosts) {
+            try {
+                let accessToken = post.linkedin_access_token;
+
+                // First attempt to publish
+                let proxyResponse = await publishPost(fetch, post, accessToken);
+
+                // If the token is expired (401), try to refresh it
+                if (proxyResponse.status === 401) {
+                    console.log(`Access token for user ${post.user_id} may have expired. Attempting to refresh.`);
+
+                    const refreshResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'x-internal-secret': process.env.INTERNAL_API_SECRET,
+                        },
+                        body: JSON.stringify({ action: 'refreshTokenInternal', userId: post.user_id }),
+                    });
+
+                    if (refreshResponse.ok) {
+                        const { accessToken: newAccessToken } = await refreshResponse.json();
+                        accessToken = newAccessToken; // Update token
+                        console.log(`Token refreshed successfully for user ${post.user_id}. Waiting 2s before retry...`);
+
+                        await delay(2000);
+
+                        // Second attempt to publish with the new token
+                        proxyResponse = await publishPost(fetch, post, accessToken);
+                    } else {
+                        // If refresh fails, we can't proceed with this post.
+                        const errorData = await refreshResponse.json();
+                        throw new Error(`Failed to refresh token: ${errorData.message || `Status ${refreshResponse.status}`}`);
+                    }
+                }
+
+                // Check the result of the final publish attempt
+                if (!proxyResponse.ok) {
+                    const errorData = await proxyResponse.json();
+                    console.error('[Scheduler] Full error data from proxy:', errorData);
+                    throw new Error(`LinkedIn API Error after potential refresh: ${JSON.stringify(errorData)}`);
+                }
+
+                const result = await proxyResponse.json();
+                const linkedinPostUrl = `https://www.linkedin.com/feed/update/${result.id}/`;
+
+                await query(
+                    `UPDATE linkedin_schedules
+                     SET status = 'published', linkedin_post_id = $1, linkedin_post_url = $2, updated_at = NOW()
+                     WHERE id = $3`,
+                    [result.id, linkedinPostUrl, post.id]
+                );
+                publishedCount++;
+                console.log(`Successfully published post ${post.id} for user ${post.user_id}.`);
+
+            } catch (error) {
+                console.error(`Failed to process post ${post.id} for user ${post.user_id}. Error: ${error.message}`);
+                await query(
+                    `UPDATE linkedin_schedules
+                     SET status = 'failed', error_message = $1, updated_at = NOW()
+                     WHERE id = $2`,
+                    [error.message, post.id]
+                );
+                failedCount++;
+            }
+        }
+
+        const summary = `Scheduler run finished. Published: ${publishedCount}, Failed: ${failedCount}.`;
+        console.log(summary);
+        return response.status(200).json({ message: summary });
+
+    } catch (error) {
+        console.error('Critical error in scheduler run:', error);
+        return response.status(500).json({ error: 'Internal Server Error during scheduler run' });
+    }
+}
+
+
+export default async function handler(request, response) {
+  if (request.method !== 'GET') {
+    return response.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const authHeader = request.headers.authorization;
+  if (!authHeader || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    // Log the received header for debugging, but be careful not to log secrets in production
+    console.warn('Unauthorized cron request. Mismatched or missing secret.');
+    return response.status(401).json({ error: 'Unauthorized' });
+  }
+
+  return handleRunScheduler(request, response);
+}

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -2,8 +2,6 @@ import { withAuth } from './middleware/auth.js';
 import { query } from './db.js';
 import { markdownToLinkedinText } from './utils.js';
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-
 // Helper function to create a schedule
 async function handleCreateSchedule(request, response) {
     try {
@@ -150,206 +148,6 @@ async function handleUpdateSchedule(request, response) {
     }
 }
 
-// Helper function to publish a single post to LinkedIn.
-// It returns the final response from the proxy.
-async function publishPost(fetch, post, accessToken) {
-    const postContent = post.post_content;
-    const authorUrn = postContent.authorUrn;
-    const proxyApiBaseUrl = process.env.VITE_API_BASE_URL || 'http://localhost:5173';
-
-    // Define common headers for internal API calls to the proxy
-    const internalApiHeaders = {
-        'Content-Type': 'application/json',
-        'x-internal-secret': process.env.INTERNAL_API_SECRET,
-    };
-
-    const postText = [
-        postContent.titulo.toUpperCase(),
-        '',
-        markdownToLinkedinText(postContent.conteudo),
-        '',
-        '----',
-        postContent.cta,
-        '----',
-        (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
-    ].join('\n');
-
-    const images = post.post_content?.images || [];
-    const imageUrns = [];
-
-    if (images.length > 0) {
-        for (const imageUrl of images) {
-            const imageResponse = await fetch(imageUrl);
-            if (!imageResponse.ok) throw new Error(`Failed to fetch image from blob store: ${imageUrl}`);
-
-            const imageBuffer = await imageResponse.arrayBuffer();
-            const imageBase64 = Buffer.from(imageBuffer).toString('base64');
-            const imageType = imageResponse.headers.get('content-type');
-
-            const registerResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
-                method: 'POST',
-                headers: internalApiHeaders,
-                body: JSON.stringify({
-                    action: 'registerUpload',
-                    accessToken,
-                    payload: {
-                        registerUploadRequest: {
-                            owner: authorUrn,
-                            recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
-                            serviceRelationships: [{
-                                relationshipType: 'OWNER',
-                                identifier: 'urn:li:userGeneratedContent'
-                            }]
-                        }
-                    }
-                })
-            });
-
-            if (registerResponse.status === 401) return registerResponse;
-            if (!registerResponse.ok) {
-                const errorData = await registerResponse.json();
-                throw new Error(`Failed to register image upload: ${errorData.message || 'Unknown error'}`);
-            }
-
-            const { uploadUrl, assetUrn } = await registerResponse.json();
-
-            const uploadResponse = await fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
-                method: 'POST',
-                headers: internalApiHeaders,
-                body: JSON.stringify({ action: 'uploadImage', accessToken, uploadUrl, imageBase64, imageType })
-            });
-
-            if (uploadResponse.status === 401) return uploadResponse;
-            if (!uploadResponse.ok) {
-                const errorData = await uploadResponse.json();
-                throw new Error(`Failed to upload image: ${errorData.message || 'Unknown error'}`);
-            }
-
-            imageUrns.push(assetUrn);
-        }
-    }
-
-    const videoUrn = post.post_content?.video;
-    const payload = {
-        author: authorUrn,
-        content: postText,
-        images: imageUrns,
-        video: videoUrn,
-        title: post.post_content?.titulo || 'Video Post'
-    };
-
-    return fetch(`${proxyApiBaseUrl}/api/linkedin-proxy`, {
-        method: 'POST',
-        headers: internalApiHeaders,
-        body: JSON.stringify({ action: 'createPost', accessToken, payload }),
-    });
-}
-
-
-// The main scheduler logic
-export async function handleRunScheduler(request, response) {
-    const fetch = (await import('node-fetch')).default;
-    console.log('Scheduler run initiated...');
-    let publishedCount = 0;
-    let failedCount = 0;
-
-    try {
-        const now = new Date();
-        const { rows: duePosts } = await query(
-            `SELECT ls.*, c.campaign_data, u.linkedin_access_token
-             FROM linkedin_schedules ls
-             JOIN users u ON ls.user_id = u.id
-             LEFT JOIN campaigns c ON ls.campaign_id = c.id
-             WHERE ls.scheduled_at <= ($1 AT TIME ZONE 'UTC')
-               AND ls.status = 'scheduled'
-               AND u.linkedin_access_token IS NOT NULL`,
-            [now.toISOString()]
-        );
-
-        if (duePosts.length === 0) {
-            console.log('No due posts to publish.');
-            return response.status(200).json({ message: 'No due posts to publish.' });
-        }
-
-        console.log(`Found ${duePosts.length} posts to process.`);
-
-        for (const post of duePosts) {
-            try {
-                let accessToken = post.linkedin_access_token;
-
-                // First attempt to publish
-                let proxyResponse = await publishPost(fetch, post, accessToken);
-
-                // If the token is expired (401), try to refresh it
-                if (proxyResponse.status === 401) {
-                    console.log(`Access token for user ${post.user_id} may have expired. Attempting to refresh.`);
-
-                    const refreshResponse = await fetch(`${process.env.VITE_API_BASE_URL || 'http://localhost:5173'}/api/linkedin-proxy`, {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'x-internal-secret': process.env.INTERNAL_API_SECRET,
-                        },
-                        body: JSON.stringify({ action: 'refreshTokenInternal', userId: post.user_id }),
-                    });
-
-                    if (refreshResponse.ok) {
-                        const { accessToken: newAccessToken } = await refreshResponse.json();
-                        accessToken = newAccessToken; // Update token
-                        console.log(`Token refreshed successfully for user ${post.user_id}. Waiting 2s before retry...`);
-
-                        await delay(2000);
-
-                        // Second attempt to publish with the new token
-                        proxyResponse = await publishPost(fetch, post, accessToken);
-                    } else {
-                        // If refresh fails, we can't proceed with this post.
-                        const errorData = await refreshResponse.json();
-                        throw new Error(`Failed to refresh token: ${errorData.message || `Status ${refreshResponse.status}`}`);
-                    }
-                }
-
-                // Check the result of the final publish attempt
-                if (!proxyResponse.ok) {
-                    const errorData = await proxyResponse.json();
-                    console.error('[Scheduler] Full error data from proxy:', errorData);
-                    throw new Error(`LinkedIn API Error after potential refresh: ${JSON.stringify(errorData)}`);
-                }
-
-                const result = await proxyResponse.json();
-                const linkedinPostUrl = `https://www.linkedin.com/feed/update/${result.id}/`;
-
-                await query(
-                    `UPDATE linkedin_schedules
-                     SET status = 'published', linkedin_post_id = $1, linkedin_post_url = $2, updated_at = NOW()
-                     WHERE id = $3`,
-                    [result.id, linkedinPostUrl, post.id]
-                );
-                publishedCount++;
-                console.log(`Successfully published post ${post.id} for user ${post.user_id}.`);
-
-            } catch (error) {
-                console.error(`Failed to process post ${post.id} for user ${post.user_id}. Error: ${error.message}`);
-                await query(
-                    `UPDATE linkedin_schedules
-                     SET status = 'failed', error_message = $1, updated_at = NOW()
-                     WHERE id = $2`,
-                    [error.message, post.id]
-                );
-                failedCount++;
-            }
-        }
-
-        const summary = `Scheduler run finished. Published: ${publishedCount}, Failed: ${failedCount}.`;
-        console.log(summary);
-        return response.status(200).json({ message: summary });
-
-    } catch (error) {
-        console.error('Critical error in scheduler run:', error);
-        return response.status(500).json({ error: 'Internal Server Error during scheduler run' });
-    }
-}
-
 // Handler for user-facing actions, protected by withAuth
 const userActionsHandler = async (request, response) => {
     const { action } = request.body;
@@ -371,40 +169,14 @@ const userActionsHandler = async (request, response) => {
     }
 };
 
-// Main API handler that routes requests based on method
+// This endpoint only handles user-facing actions now, which are all POST requests.
 const mainHandler = async (request, response) => {
-    // Cron job endpoint (GET) - uses Vercel's built-in cron secret
-    if (request.method === 'GET') {
-        const vercelCronSecret = process.env.VERCEL_CRON_SECRET;
-        const secretFromHeader = typeof request.headers.get === 'function'
-            ? request.headers.get('x-vercel-cron-secret')
-            : request.headers['x-vercel-cron-secret'];
-
-        // It's critical that the VERCEL_CRON_SECRET is available.
-        // Vercel automatically injects this for projects with cron jobs.
-        if (!vercelCronSecret) {
-            console.error('CRITICAL: VERCEL_CRON_SECRET environment variable not found.');
-            // This might indicate a misconfiguration or local testing without the secret.
-            return response.status(500).json({ error: 'Server configuration error for cron jobs.' });
-        }
-
-        // The request must have the x-vercel-cron-secret header and it must match.
-        if (secretFromHeader !== vercelCronSecret) {
-            console.warn('Unauthorized attempt to run scheduler: Invalid or missing x-vercel-cron-secret header.');
-            return response.status(401).json({ error: 'Unauthorized' });
-        }
-
-        return handleRunScheduler(request, response);
-    }
-
-    // User actions endpoint (POST) - uses JWT cookie auth
     if (request.method === 'POST') {
         // We wrap the user actions handler with withAuth to protect it
         return withAuth(userActionsHandler)(request, response);
     }
 
-    // If the method is not GET or POST, it's not allowed.
-    response.setHeader('Allow', ['GET', 'POST']);
+    response.setHeader('Allow', ['POST']);
     return response.status(405).end('Method Not Allowed');
 };
 

--- a/test/test_scheduler_success.test.js
+++ b/test/test_scheduler_success.test.js
@@ -1,75 +1,66 @@
+import { handleRunScheduler } from '../api/cron/linkedin.js';
 import { query } from '../api/db.js';
-import { handleRunScheduler } from '../api/schedule.js';
 import { describe, it, expect, vi } from 'vitest';
 
-// Mock the publishPost function
-vi.mock('../api/schedule.js', async () => {
-  const originalModule = await vi.importActual('../api/schedule.js');
-  return {
-    ...originalModule,
-    publishPost: vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ id: 'urn:li:share:12345' }),
-    }),
-  };
-});
+// Mock dependencies
+vi.mock('../api/db.js', () => ({
+    query: vi.fn(),
+}));
+
+// Mock node-fetch
+vi.mock('node-fetch', () => ({
+    default: vi.fn(),
+}));
 
 const createMockResponse = () => {
-    let res = {};
-    res.status = (code) => { res.statusCode = code; return res; };
-    res.json = (data) => { res.body = data; return res; };
-    res.end = () => {};
+    const res = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
     return res;
 };
 
-const createMockRequest = (headers = {}) => ({
+const createMockRequest = () => ({
     method: 'GET',
-    headers: {
-        'x-vercel-cron-secret': process.env.VERCEL_CRON_SECRET,
-        ...headers,
-    },
+    headers: {},
 });
 
+import fetch from 'node-fetch';
+
 describe('Scheduler Success Test', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('should publish a scheduled post successfully', async () => {
-        // Create a test user
-        const { rows: users } = await query(
-            "INSERT INTO users (email, password, name) VALUES ($1, $2, $3) RETURNING *",
-            ['test@example.com', 'password', 'Test User']
-        );
-        const testUser = users[0];
+        const testUser = { id: 1, linkedin_access_token: 'test_token' };
+        const testSchedule = {
+            id: 101,
+            user_id: testUser.id,
+            post_content: { titulo: 'Test Post', conteudo: 'Test Content', cta: '#test', hashtags: [] },
+            linkedin_access_token: testUser.linkedin_access_token,
+        };
 
-        // Create a test campaign
-        const { rows: campaigns } = await query(
-            "INSERT INTO campaigns (user_id, name, campaign_data) VALUES ($1, $2, $3) RETURNING *",
-            [testUser.id, 'Test Campaign', { images: [] }]
-        );
-        const testCampaign = campaigns[0];
+        // Mock database responses
+        query.mockResolvedValue({ rows: [testSchedule] });
 
-        // Create a scheduled post
-        const scheduled_at = new Date(Date.now() - 60000).toISOString();
-        const { rows: schedules } = await query(
-            `INSERT INTO linkedin_schedules (user_id, campaign_id, scheduled_at, post_content, status)
-             VALUES ($1, $2, $3, $4, 'scheduled') RETURNING *`,
-            [testUser.id, testCampaign.id, scheduled_at, { titulo: 'Test Post', conteudo: 'Test Content', cta: '#test', hashtags: [] }]
-        );
-        const testSchedule = schedules[0];
+        // Mock fetch response for createPost
+        fetch.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ id: 'urn:li:share:12345' }),
+        });
 
-        // Add linkedin access token to user
-        await query(
-            "UPDATE users SET linkedin_access_token = $1 WHERE id = $2",
-            ['test_token', testUser.id]
-        );
         const req = createMockRequest();
         const res = createMockResponse();
 
         await handleRunScheduler(req, res);
 
-        expect(res.statusCode).toBe(200);
-        expect(res.body.message).toContain('Published: 1');
+        expect(fetch).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ message: expect.stringContaining('Published: 1') });
 
-        // Verify the post status in the database
-        const { rows } = await query("SELECT status FROM linkedin_schedules WHERE id = $1", [testSchedule.id]);
-        expect(rows[0].status).toBe('published');
+        // Verify that the status was updated to 'published'
+        const updateQuery = query.mock.calls.find(call => call[0].includes('UPDATE linkedin_schedules'));
+        expect(updateQuery).toBeDefined();
+        expect(updateQuery[0]).toContain("status = 'published'");
     });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "crons": [
     {
-      "path": "/api/schedule",
+      "path": "/api/cron/linkedin",
       "schedule": "0 8-23 * * *"
     }
   ],


### PR DESCRIPTION
The LinkedIn scheduler was failing due to an `Invalid or missing x-vercel-cron-secret header` error. This indicates an issue with the Vercel-injected cron secret.

This commit refactors the scheduler to use a new, dedicated cron job endpoint at `/api/cron/linkedin.js`. This endpoint is secured with a `CRON_SECRET` environment variable, which provides a more robust and explicit authentication mechanism for the cron job.

The original scheduler logic has been moved from `api/schedule.js` to the new endpoint. The `api/schedule.js` file now only handles user-facing scheduling actions.

The `vercel.json` file has been updated to point the cron job to the new endpoint.

Additionally, the corresponding test file `test/test_scheduler_success.test.js` has been updated to reflect these changes. The test now mocks `node-fetch` to avoid actual network requests and no longer depends on a live database, making it more reliable.