### PR TITLE
Fix: Correct LinkedIn author URN from 'personal' to 'person'

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -263,7 +263,7 @@ async function handleGetProfiles(fetch, request, response) {
     ]);
     if (!personalResponse.ok) throw new Error(`Failed to fetch personal profile: ${personalResponse.status}`);
     const personalData = await personalResponse.json();
-    const personal = { id: personalData.id, name: `${personalData.firstName.localized.pt_BR || personalData.firstName.localized.en_US} ${personalData.lastName.localized.pt_BR || personalData.lastName.localized.en_US}`, type: 'personal', profilePicture: personalData.profilePicture?.['displayImage~']?.elements?.[0]?.identifiers?.[0]?.identifier };
+    const personal = { id: personalData.id, name: `${personalData.firstName.localized.pt_BR || personalData.firstName.localized.en_US} ${personalData.lastName.localized.pt_BR || personalData.lastName.localized.en_US}`, type: 'person', profilePicture: personalData.profilePicture?.['displayImage~']?.elements?.[0]?.identifiers?.[0]?.identifier };
     let organizations = [];
     if (orgAclsResponse.ok) {
       const orgAclsData = await orgAclsResponse.json();

--- a/fix_linkedin_urns.sql
+++ b/fix_linkedin_urns.sql
@@ -1,0 +1,16 @@
+-- This script updates existing LinkedIn schedules to correct the author URN from 'personal' to 'person'.
+-- It targets the 'post_content' JSONB column in the 'linkedin_schedules' table.
+
+UPDATE linkedin_schedules
+SET
+  post_content = jsonb_set(
+    post_content,
+    '{authorUrn}',
+    to_jsonb(REPLACE(post_content ->> 'authorUrn', 'urn:li:personal:', 'urn:li:person:'))
+  )
+WHERE
+  post_content ->> 'authorUrn' LIKE 'urn:li:personal:%';
+
+-- Optional: You can run this SELECT statement before and after the UPDATE to verify the changes.
+-- SELECT id, post_content ->> 'authorUrn' as author_urn FROM linkedin_schedules WHERE post_content ->> 'authorUrn' LIKE 'urn:li:personal:%';
+-- SELECT id, post_content ->> 'authorUrn' as author_urn FROM linkedin_schedules WHERE post_content ->> 'authorUrn' LIKE 'urn:li:person:%';

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -273,7 +273,7 @@ const Publisher = ({
         const personalTarget = {
             id: linkedinProfiles.personal.id,
             name: `${linkedinProfiles.personal.name} (Perfil Pessoal)`,
-            type: 'personal'
+            type: 'person'
         };
         targets.push(personalTarget);
         addedIds.add(personalTarget.id);
@@ -317,7 +317,7 @@ const Publisher = ({
             setSelectedTarget({
                 id: profiles.personal.id,
                 name: `${profiles.personal.name} (Perfil Pessoal)`,
-                type: 'personal'
+                type: 'person'
             });
         }
     } catch (error) {

--- a/src/utils/linkedinAPI.js
+++ b/src/utils/linkedinAPI.js
@@ -51,7 +51,7 @@ class LinkedInAPI {
     return personal;
   }
 
-  async publishPost(content, targetId, targetType = 'personal', images = [], video = null) {
+  async publishPost(content, targetId, targetType = 'person', images = [], video = null) {
     return this._proxyFetch('createPost', {
       payload: {
         content,


### PR DESCRIPTION
This commit fixes a bug where the LinkedIn scheduler was failing with a 422 Unprocessable Entity error. The error was caused by an incorrect author URN being sent to the LinkedIn API (`urn:li:personal:...` instead of `urn:li:person:...`).

The following changes have been made:
- In `api/linkedin-proxy.js`, the `handleGetProfiles` function now correctly sets the author type as 'person'.
- In `src/components/Publisher.jsx`, the hardcoded 'personal' type has been corrected to 'person'.
- In `src/utils/linkedinAPI.js`, the default `targetType` for `publishPost` has been updated to 'person'.

A migration script, `fix_linkedin_urns.sql`, has also been added to the repository to correct any existing scheduled posts in the database that have the incorrect URN.