### PR TITLE
Fix: Apply correct font scale on page generation

### DIFF
--- a/npm_output.log
+++ b/npm_output.log
@@ -1,9 +1,0 @@
-
-> midiator-google-drive-frontend@0.0.0 dev
-> vite
-
-
-  VITE v5.4.19  ready in 737 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -250,13 +250,8 @@ const FieldPositioner = ({
       const previewScale = renderedImageMetrics.width / effectiveImageSize.width;
       setFontScale(previewScale); // Local scale for preview rendering
 
-      // The font scale for the final render should be 1 unless explicitly changed by the user.
-      // The preview scaling is for display purposes only.
       if (onFontScaleChange) {
-        // We are not passing any scale factor here, so it will use the default (1)
-        // which is what we want for the final render unless the user changes it via a UI control.
-        // For now, let's ensure it's always 1 from here.
-        onFontScaleChange(1);
+        onFontScaleChange(previewScale);
       }
     } else {
       setFontScale(1);


### PR DESCRIPTION
The font scale factor calculated for the template preview was not being used during the final page generation. Instead, a hardcoded value of 1 was used, causing fonts in generated pages to be disproportionately large compared to the preview.

This change modifies the FieldPositioner component to propagate the calculated `previewScale` to its parent component. This ensures the same scaling factor is used for both the preview and the final generation, maintaining the correct font proportions.