### PR TITLE
Fix: Preserve font scale when editing generated pages

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -93,8 +93,10 @@ const PageEditor = ({
         effectiveFieldStyles,
         effectiveBrandElements,
         record,
+        effectiveFontScale,
       } = pageDataFromHook;
 
+      setModalFontScale(effectiveFontScale);
       setEditedPositions(JSON.parse(JSON.stringify(effectiveFieldPositions)));
       setEditedBrandElements(safeDeepClone(effectiveBrandElements));
       setEditedRecord(JSON.parse(JSON.stringify(record)));

--- a/src/hooks/usePageData.js
+++ b/src/hooks/usePageData.js
@@ -30,6 +30,7 @@ export const usePageData = (pageIndex) => {
       effectiveFieldStyles: pageData?.customFieldStyles || fieldStyles,
       effectiveBrandElements: pageData?.customBrandElements || brandElements,
       record: pageData?.record,
+      effectiveFontScale: pageData?.fontScale || 1,
     };
   }, [pageData, pageTemplate, fieldPositions, fieldStyles, brandElements]);
 


### PR DESCRIPTION
This commit fixes a bug where font proportions were distorted when a user edited a previously generated page.

The root cause was that the `fontScale` property, which is calculated to fit text within its bounds, was being saved correctly for each page but was not being reloaded when the page was opened in the `PageEditor`. This caused the editor to start with a default scale of 1, leading to a recalculation and a visual distortion of the fonts.

The fix involves two parts:
1.  The `usePageData` hook has been updated to return the `effectiveFontScale` for a given page, defaulting to 1 if not set.
2.  The `PageEditor` component has been updated to use this `effectiveFontScale` to initialize its internal font scale state, ensuring that the previously saved scale is correctly applied upon editing.