### PR TITLE
Fix: Resolve multiple issues with scheduler and editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -248,23 +248,14 @@ const FieldPositioner = ({
   useEffect(() => {
     if (renderedImageMetrics.width > 0 && effectiveImageSize?.width > 0) {
       const previewScale = renderedImageMetrics.width / effectiveImageSize.width;
-      setFontScale(previewScale); // Local scale for preview rendering
-
-      // The font scale for the final render should be 1 unless explicitly changed by the user.
-      // The preview scaling is for display purposes only.
-      if (onFontScaleChange) {
-        // We are not passing any scale factor here, so it will use the default (1)
-        // which is what we want for the final render unless the user changes it via a UI control.
-        // For now, let's ensure it's always 1 from here.
-        onFontScaleChange(1);
-      }
+      setFontScale(previewScale); // This is the local scale for rendering the preview correctly.
     } else {
       setFontScale(1);
-      if (onFontScaleChange) {
-        onFontScaleChange(1);
-      }
     }
-  }, [renderedImageMetrics, effectiveImageSize, onFontScaleChange]);
+    // The onFontScaleChange prop is used to bubble up a *user-defined* scale,
+    // not the preview scale. We should not be calling it here as it was causing a bug
+    // where the saved scale was being overwritten with 1.
+  }, [renderedImageMetrics, effectiveImageSize]);
 
   useEffect(() => {
     if (isInteracting) {


### PR DESCRIPTION
This commit addresses three separate issues reported by the user:
1.  **Scheduler Authentication:** The Vercel cron job was failing due to an `x-vercel-cron-secret` error. This has been fixed by refactoring the scheduler to a dedicated endpoint (`/api/cron/linkedin.js`) that uses a more robust `Authorization: Bearer <CRON_SECRET>` authentication method.
2.  **LinkedIn URN Format:** Scheduled posts were failing with a 422 error because the author URN was being incorrectly formatted as `urn:li:personal:`. This has been corrected to `urn:li:person:` in `api/linkedin-proxy.js` and related frontend components. A migration script (`fix_linkedin_urns.sql`) is included to correct existing data.
3.  **Font Scaling Distortion:** When editing a generated page, the font size would grow larger on each save. This was caused by the editor's preview scaling factor being incorrectly managed and saved. The fix ensures that the saved `fontScale` is correctly loaded and preserved during editing, preventing the cumulative scaling effect. The `useEffect` in `FieldPositioner.jsx` that was incorrectly overwriting the scale has been corrected.