### PR TITLE
fix: Persist fontScale on page edit to prevent distortion

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -371,6 +371,7 @@ const PageGeneratorFrontendOnly = ({
             customFieldStyles: modifiedPageData.customFieldStyles,
             customBrandElements: modifiedPageData.customBrandElements,
             customPageTemplate: modifiedPageData.customPageTemplate,
+            fontScale: modifiedPageData.fontScale,
           };
         })
       );


### PR DESCRIPTION
When a generated page was edited, the `fontScale` used during the preview and regeneration was not being saved along with the other page modifications. This caused inconsistencies on subsequent edits, as the system would default back to a scale of 1, leading to distorted font sizes in the regenerated images.

This commit fixes the issue by ensuring that `modifiedPageData.fontScale` is correctly persisted in the page's state within `handleSaveIndividualModifications` in `PageGeneratorFrontendOnly.jsx`.