### PR TITLE
fix: Normalize font sizes on save to prevent compounding scale

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -347,31 +347,45 @@ const PageGeneratorFrontendOnly = ({
 
   const handleSaveIndividualModifications = async (modifiedPageData) => {
     console.log('[PageGenerator] handleSaveIndividualModifications received:', modifiedPageData);
-    const { index: pageIndex } = modifiedPageData;
+    const { index: pageIndex, fontScale: pageFontScale } = modifiedPageData;
+
+    // Normalize font sizes before saving and regenerating
+    const normalizedStyles = safeDeepClone(modifiedPageData.customFieldStyles);
+    if (pageFontScale && pageFontScale !== 1) {
+      for (const fieldId in normalizedStyles) {
+        if (Object.hasOwnProperty.call(normalizedStyles, fieldId)) {
+          const style = normalizedStyles[fieldId];
+          if (style && style.fontSize) {
+            style.fontSize /= pageFontScale;
+          }
+        }
+      }
+    }
+
     handleCloseGeneratedPageEditor();
     try {
       const newPageImageData = await regenerateSinglePage(
         pageIndex,
         modifiedPageData.record,
-        modifiedPageData.customPageTemplate, // Use the correct prop name
+        modifiedPageData.customPageTemplate,
         modifiedPageData.customFieldPositions,
-        modifiedPageData.customFieldStyles,
+        normalizedStyles, // Use normalized styles for regeneration
         modifiedPageData.customBrandElements,
-        modifiedPageData.fontScale
+        pageFontScale
       );
       setGeneratedPagesData(currentPages =>
         currentPages.map(page => {
           if (page.index !== pageIndex) return page;
           // Persist the changes
           return {
-            ...page, // Keep old data like blob, url
-            ...newPageImageData, // Overwrite with new image data
+            ...page,
+            ...newPageImageData,
             record: modifiedPageData.record,
             customFieldPositions: modifiedPageData.customFieldPositions,
-            customFieldStyles: modifiedPageData.customFieldStyles,
+            customFieldStyles: normalizedStyles, // Use normalized styles for saving
             customBrandElements: modifiedPageData.customBrandElements,
             customPageTemplate: modifiedPageData.customPageTemplate,
-            fontScale: modifiedPageData.fontScale,
+            fontScale: pageFontScale,
           };
         })
       );


### PR DESCRIPTION
Addresses a bug where editing a generated page would distort font sizes, with the effect worsening on subsequent edits. The root cause was that the font size, scaled for the editor's preview, was being saved back into the page's state. This caused the scaling factor to be applied cumulatively on each edit.

This commit introduces normalization logic into the `handleSaveIndividualModifications` function in `PageGeneratorFrontendOnly.jsx`. When a page is saved, the font sizes in the custom styles are now divided by the `fontScale` used during the edit. This ensures that only the base, unscaled font size is persisted in the state.

This change prevents the compounding scaling issue and ensures that font sizes remain consistent and correct across multiple editing sessions.