### PR TITLE
fix: Normalize font sizes on save to prevent compounding scale

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -347,39 +347,62 @@ const PageGeneratorFrontendOnly = ({
 
   const handleSaveIndividualModifications = async (modifiedPageData) => {
     console.log('[PageGenerator] handleSaveIndividualModifications received:', modifiedPageData);
-    const { index: pageIndex } = modifiedPageData;
-    handleCloseGeneratedPageEditor();
+    const {
+      index: pageIndex,
+      fontScale: pageFontScale,
+      customFieldStyles,
+    } = modifiedPageData;
+
+    // Assumption based on user feedback: customFieldStyles arriving here have a scaled fontSize.
+    // We must therefore do two things:
+    // 1. Regenerate the image using the scaled font sizes, but with a scale factor of 1 to prevent double-scaling.
+    // 2. Normalize the font sizes back to their base value before saving them to the state.
+
     try {
-      const newPageImageData = await regenerateSinglePage(
-        pageIndex,
-        modifiedPageData.record,
-        modifiedPageData.customPageTemplate, // Use the correct prop name
-        modifiedPageData.customFieldPositions,
-        modifiedPageData.customFieldStyles,
-        modifiedPageData.customBrandElements,
-        modifiedPageData.fontScale
-      );
-      setGeneratedPagesData(currentPages =>
-        currentPages.map(page => {
-          if (page.index !== pageIndex) return page;
-          // Persist the changes
-          return {
-            ...page, // Keep old data like blob, url
-            ...newPageImageData, // Overwrite with new image data
-            record: modifiedPageData.record,
-            customFieldPositions: modifiedPageData.customFieldPositions,
-            customFieldStyles: modifiedPageData.customFieldStyles,
-            customBrandElements: modifiedPageData.customBrandElements,
-            customPageTemplate: modifiedPageData.customPageTemplate,
-            fontScale: modifiedPageData.fontScale,
-          };
-        })
-      );
-      if (onThumbnailRecordTextUpdate) {
-        onThumbnailRecordTextUpdate(pageIndex, modifiedPageData.record);
-      }
+        const newPageImageData = await regenerateSinglePage(
+            pageIndex,
+            modifiedPageData.record,
+            modifiedPageData.customPageTemplate,
+            modifiedPageData.customFieldPositions,
+            customFieldStyles, // Pass the already-scaled styles
+            modifiedPageData.customBrandElements,
+            1 // Use a scale of 1 because the font size is already scaled
+        );
+
+        const normalizedStyles = safeDeepClone(customFieldStyles);
+        if (pageFontScale && pageFontScale !== 1) {
+            for (const fieldId in normalizedStyles) {
+                if (Object.hasOwnProperty.call(normalizedStyles, fieldId)) {
+                    const style = normalizedStyles[fieldId];
+                    if (style && style.fontSize) {
+                        style.fontSize /= pageFontScale;
+                    }
+                }
+            }
+        }
+
+        setGeneratedPagesData(currentPages =>
+            currentPages.map(page => {
+                if (page.index !== pageIndex) return page;
+                return {
+                    ...page,
+                    ...newPageImageData,
+                    record: modifiedPageData.record,
+                    customFieldPositions: modifiedPageData.customFieldPositions,
+                    customFieldStyles: normalizedStyles, // Save the normalized (base) styles
+                    customBrandElements: modifiedPageData.customBrandElements,
+                    customPageTemplate: modifiedPageData.customPageTemplate,
+                    fontScale: pageFontScale, // Persist the scale that was used
+                };
+            })
+        );
+
+        if (onThumbnailRecordTextUpdate) {
+            onThumbnailRecordTextUpdate(pageIndex, modifiedPageData.record);
+        }
+        handleCloseGeneratedPageEditor();
     } catch (error) {
-      alert(`Falha ao regenerar a página: ${error.message}`);
+        alert(`Falha ao regenerar a página: ${error.message}`);
     }
   };
 


### PR DESCRIPTION
This commit resolves a persistent bug where font sizes would become distorted upon saving an edited page. The root cause was identified as a compounding scaling effect: font sizes scaled for the editor's preview were being saved, causing them to be scaled again on subsequent edits.

Based on user feedback, the fix implements a two-part strategy within the `handleSaveIndividualModifications` function:

1.  When regenerating the page image, a `fontScale` of `1` is now used. This assumes the incoming font styles are already scaled from the editor preview, thus preventing a double-scaling issue during image composition.
2.  Before updating the application state, the font sizes are normalized by dividing them by the `fontScale` from the editor. This reverts the font sizes to their unscaled, base values.

These normalized styles are then saved to the state, while the actual `fontScale` from the editor is also persisted for context. This approach ensures that the base font sizes are always stored correctly, eliminating the compounding error and ensuring visual consistency across multiple edits.