### PR TITLE
fix: Ensure font size consistency in generated images

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -54,7 +54,6 @@ const PageEditor = ({
   const [selectedFieldInternal, setSelectedFieldInternal] = useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [editingField, setEditingField] = useState(null);
-  const [modalFontScale, setModalFontScale] = useState(1);
   const isMobile = useIsMobile();
 
   const handleOpenHtmlEditor = (fieldId) => {
@@ -140,10 +139,8 @@ const PageEditor = ({
         effectiveFieldStyles,
         effectiveBrandElements,
         record,
-        effectiveFontScale,
       } = pageDataFromHook;
 
-      setModalFontScale(effectiveFontScale);
       setEditedPositions(JSON.parse(JSON.stringify(effectiveFieldPositions)));
       setEditedBrandElements(safeDeepClone(effectiveBrandElements));
       setEditedRecord(JSON.parse(JSON.stringify(record)));
@@ -160,7 +157,6 @@ const PageEditor = ({
       setEditedBrandElements(null);
       setEditedRecord(null);
       setSelectedFieldInternal(null);
-      setModalFontScale(1); // Reset font scale on close
     }
   }, [open, pageData, pageDataFromHook, csvHeaders]);
 
@@ -177,7 +173,6 @@ const PageEditor = ({
       customFieldStyles: editedStyles,
       customBrandElements: editedBrandElements,
       customPageTemplate: editedPageTemplate,
-      fontScale: modalFontScale, // Pass the correct font scale on save
     };
     console.log('[PageEditor] handleSave called. Data being passed up:', savedData);
     onSave(savedData);
@@ -229,7 +224,6 @@ const PageEditor = ({
               pageTemplate={editedPageTemplate}
               setPageTemplate={setEditedPageTemplate}
               currentPreviewIndex={0}
-              onFontScaleChange={setModalFontScale} // Capture the scale from the preview
             />
           </Grid>
           {!isMobile && (

--- a/src/services/PageGenerationService.js
+++ b/src/services/PageGenerationService.js
@@ -22,7 +22,6 @@ const PageGenerationService = {
       fieldStyles: globalFieldStyles,
       aspectRatio: globalAspectRatio,
       pageTemplate: globalPageTemplate,
-      fontScale: globalFontScale = 1,
     } = campaignContext;
 
     // Prioritize page-specific customizations over global campaign settings
@@ -30,7 +29,6 @@ const PageGenerationService = {
     const fieldPositions = pageData.customFieldPositions || globalFieldPositions;
     const fieldStyles = pageData.customFieldStyles || globalFieldStyles;
     const pageTemplate = pageData.customPageTemplate || globalPageTemplate;
-    const fontScale = pageData.fontScale || globalFontScale;
     const aspectRatio = globalAspectRatio; // Aspect ratio is likely always global for a campaign
 
     try {
@@ -42,7 +40,6 @@ const PageGenerationService = {
         fieldStyles,
         aspectRatio: aspectRatio || '1:1', // Fallback
         pageTemplate,
-        fontScale,
       });
       return finalPageData;
     } catch (error) {

--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -309,7 +309,6 @@ export const drawAndComposeImage = async ({
     fieldStyles = {},
     aspectRatio,
     pageTemplate,
-    fontScale = 1,
 }) => {
 
     const finalCanvas = document.createElement('canvas');
@@ -430,7 +429,7 @@ export const drawAndComposeImage = async ({
                 ctx.translate(-centerX, -centerY);
             }
 
-            const finalStyle = { ...style, fontSize: (style.fontSize || 24) * fontScale };
+            const finalStyle = { ...style, fontSize: (style.fontSize || 24) };
             const padding = (style.padding || 0);
             const borderRadius = (style.borderRadius || 0);
             const borderWidth = (style.borderWidth || 0);
@@ -505,6 +504,5 @@ export const drawAndComposeImage = async ({
         index,
         filename: `midiator_${String(index + 1).padStart(3, '0')}.png`,
         pageTemplateUsed: pageTemplate,
-        fontScale, // Ensure the scale used is saved with the page data
     };
 };


### PR DESCRIPTION
This commit fixes a bug that caused font sizes to be inconsistent between the page editor preview and the final generated image.

The root cause was a "double scaling" issue. A `fontScale` value, calculated for the preview to adjust for its size, was being saved and then re-applied during the final image generation. This meant that the size of the preview window was affecting the font size in the final output.

The fix removes the `fontScale` from the saved page data and the final image generation process. The `fontScale` is now used only for preview purposes within the `FieldPositioner` component, as intended.

The following changes were made:
- Removed `fontScale` from the data flow in `PageEditor.jsx`.
- Updated `PageGenerationService.js` to remove `fontScale` from the page generation parameters.
- Updated `imageComposer.js` to remove the `fontScale` parameter and the corresponding scaling of the font size.

This ensures that the font size set by the user in the editor is the absolute font size used in the generated image, leading to a consistent and predictable output.