### PR TITLE
feat: Implement copy/paste style feature for generated pages

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -85,8 +85,26 @@ const PageEditor = ({
 
       // Basic validation
       if (pastedData && pastedData.styles && pastedData.positions) {
-        setEditedStyles(pastedData.styles);
-        setEditedPositions(pastedData.positions);
+        // Merge styles and positions field by field
+        setEditedStyles(prevStyles => {
+          const newStyles = { ...prevStyles };
+          for (const field in pastedData.styles) {
+            if (Object.prototype.hasOwnProperty.call(newStyles, field)) {
+              newStyles[field] = pastedData.styles[field];
+            }
+          }
+          return newStyles;
+        });
+
+        setEditedPositions(prevPositions => {
+          const newPositions = { ...prevPositions };
+          for (const field in pastedData.positions) {
+            if (Object.prototype.hasOwnProperty.call(newPositions, field)) {
+              newPositions[field] = pastedData.positions[field];
+            }
+          }
+          return newPositions;
+        });
 
         if (pastedData.brandElements) {
           setEditedBrandElements(pastedData.brandElements);


### PR DESCRIPTION
This commit introduces a new feature that allows users to copy the style from one generated page and paste it onto another.

The following changes were made:
- Added 'Copy Style' and 'Paste Style' buttons to the `PageEditor` component.
- Implemented `handleCopyStyle` to serialize the page style and save it to the clipboard.
- Implemented `handlePasteStyle` to read style data from the clipboard and apply it to the current page.

fix: Update paste logic to be field-by-field

The `handlePasteStyle` function has been updated to apply styles and positions on a field-by-field basis, rather than replacing the entire style objects. This ensures that only the styles for matching fields are updated, as per user feedback.

fix: Reset font scale in PageEditor when closed

This commit also fixes a bug where the font scale was not being reset when the `PageEditor` dialog was closed. This could cause the font scale of one page to affect the next one that was opened. The `modalFontScale` state is now correctly reset to 1 when the dialog is closed.