### PR TITLE
Fix(api): Make LinkedIn profile name parsing more robust

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -283,12 +283,14 @@ async function handleGetProfiles(fetch, request, response) {
   const headers = { 'Authorization': `Bearer ${accessToken}`, 'X-Restli-Protocol-Version': '2.0.0', 'LinkedIn-Version': LINKEDIN_API_VERSION };
   try {
     const [personalResponse, orgAclsResponse] = await Promise.all([
-      fetch('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))', { headers }),
+      fetch('https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,localizedFirstName,localizedLastName,profilePicture(displayImage~:playableStreams))', { headers }),
       fetch('https://api.linkedin.com/rest/organizationAcls?q=roleAssignee&state=APPROVED', { headers })
     ]);
     if (!personalResponse.ok) throw new Error(`Failed to fetch personal profile: ${personalResponse.status}`);
     const personalData = await personalResponse.json();
-    const personal = { id: personalData.id, name: `${personalData.firstName.localized.pt_BR || personalData.firstName.localized.en_US} ${personalData.lastName.localized.pt_BR || personalData.lastName.localized.en_US}`, type: 'person', profilePicture: personalData.profilePicture?.['displayImage~']?.elements?.[0]?.identifiers?.[0]?.identifier };
+    const firstName = personalData.localizedFirstName || Object.values(personalData.firstName?.localized || {})[0];
+    const lastName = personalData.localizedLastName || Object.values(personalData.lastName?.localized || {})[0];
+    const personal = { id: personalData.id, name: `${firstName || ''} ${lastName || ''}`.trim(), type: 'person', profilePicture: personalData.profilePicture?.['displayImage~']?.elements?.[0]?.identifiers?.[0]?.identifier };
     let organizations = [];
     if (orgAclsResponse.ok) {
       const orgAclsData = await orgAclsResponse.json();


### PR DESCRIPTION
The `handleGetProfiles` function in the LinkedIn proxy would crash with a 500 error if a user's profile name did not contain the `en_US` or `pt_BR` locales. This was caused by directly accessing properties on a potentially undefined `localized` object.

This commit resolves the issue by:
1.  Updating the API call to request the top-level `localizedFirstName` and `localizedLastName` fields, which provide a simpler and more reliable way to get the user's name.
2.  Implementing a safer parsing logic that prioritizes these new fields and includes fallbacks to gracefully handle their absence or the absence of specific locales in the `localized` object.

This change prevents the server from crashing and ensures that user profiles can be fetched regardless of their language settings on LinkedIn.