### PR TITLE
Fix(api): Correct import path for utils.js in linkedin-proxy

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -1,7 +1,7 @@
 import { withAuth } from './middleware/auth.js';
 import { query } from './db.js';
 import { kv } from './kv.js';
-import { markdownToLinkedinText } from '../utils.js';
+import { markdownToLinkedinText } from './utils.js';
 
 const LINKEDIN_API_VERSION = '202411';
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
The `linkedin-proxy` serverless function was failing with a `Cannot find module '../utils.js'` error. This was caused by an incorrect relative path in the import statement.

This commit corrects the path from `../utils.js` to `./utils.js`, as both `linkedin-proxy.js` and `utils.js` reside in the same `/api` directory. This resolves the module resolution error and allows the function to execute correctly.

This also retains the previous fix for robustly handling different localizations in LinkedIn profile names.