### PR TITLE
fix(linkedin): Convert post text to single line to prevent truncation

### DIFF
--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -16,8 +16,8 @@ export async function publishPost(fetch, post, accessToken) {
         'x-internal-secret': process.env.INTERNAL_API_SECRET,
     };
 
-    const postText = [
-        (postContent.titulo || '').toUpperCase().replace(/[()]/g, ''),
+    let postText = [
+        (postContent.titulo || '').toUpperCase(),
         '',
         markdownToLinkedinText(postContent.conteudo),
         '',
@@ -26,6 +26,10 @@ export async function publishPost(fetch, post, accessToken) {
         '----',
         (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
     ].join('\n');
+
+    // Replace all newlines with spaces to create a single-line string,
+    // as a workaround for a suspected API issue with multi-line text in multi-image posts.
+    postText = postText.replace(/\n/g, ' ').trim();
 
     const images = post.post_content?.images || [];
     const imageUrns = [];


### PR DESCRIPTION
Fixes a bug where post text was being truncated on LinkedIn when publishing with multiple images.

The root cause appears to be an issue with the LinkedIn API's handling of multi-line strings in the `commentary` field for multi-image posts.

This fix converts the entire post text into a single line by replacing all newline characters (` `) with spaces. This workaround ensures the full text is sent and published without being truncated.