### PR TITLE
feat: Add content size selection and dynamic limits to LinkedIn publi…

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -33,6 +33,8 @@ import {
   DialogActions,
   Tooltip,
   IconButton,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import { Language, Publish, LinkedIn, Delete, Edit, Visibility, Replay } from '@mui/icons-material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';


### PR DESCRIPTION
…sher

Introduces a UI for selecting small, medium, or large content sizes for LinkedIn posts. The medium content is truncated to 1000 characters.

Implements dynamic character limits based on the type of media attached:
- Text-only: 3000
- Single image: 3000
- Multiple images: 1300
- Video: 2600

The UI now reflects the current character limit and disables publishing if the limit is exceeded.

Fixes a ReferenceError by adding the missing imports for ToggleButtonGroup and ToggleButton.