### PR TITLE
fix(Publisher): Prevent scheduling of duplicate first follow-up post

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -445,10 +445,22 @@ const Publisher = ({
       };
       await createSchedule(mainPostPayload);
       setPublishingStatusLi('Post principal agendado. Agendando follow-ups...');
+
       if (followupPosts && followupPosts.length > 0) {
-        for (const [index, post] of followupPosts.entries()) {
+        // Defensive check against AI duplicating the main post as the first follow-up.
+        const mainPostContent = (campaignContent?.conteudo || '').trim();
+        const firstFollowupContent = (followupPosts[0]?.conteudo || '').trim();
+        const postsToSchedule = mainPostContent === firstFollowupContent ? followupPosts.slice(1) : followupPosts;
+
+        if (postsToSchedule.length < followupPosts.length) {
+          toast.info("Primeiro post de follow-up era um duplicado e foi ignorado.");
+        }
+
+        for (const post of postsToSchedule) {
+          // Find the original index to maintain correct date progression
+          const originalIndex = followupPosts.findIndex(p => p === post);
           const followupDate = new Date(scheduleDate);
-          followupDate.setDate(scheduleDate.getDate() + index + 1);
+          followupDate.setDate(scheduleDate.getDate() + originalIndex + 1);
           const [fHours, fMinutes] = getScheduledTime(followupDate).split(':');
           followupDate.setHours(parseInt(fHours, 10), parseInt(fMinutes, 10), 0, 0);
           const followupUtcDate = fromZonedTime(followupDate, userTimezone);


### PR DESCRIPTION
This commit adds a defensive check to the `handleScheduleLinkedIn` function to prevent an issue where the main post could be scheduled twice.

The root cause appears to be that the AI generating follow-up posts sometimes duplicates the main post's content as the first follow-up. The scheduling logic would then correctly schedule the main post and the identical follow-up post, leading to a duplication.

The fix implements a check that compares the content of the main post with the first follow-up post. If they are identical, the first follow-up is skipped during the scheduling process, and a toast notification informs the user. This ensures the main post is only scheduled once, as intended.