### PR TITLE
feat: Add content size selection and dynamic limits to LinkedIn publi…

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -364,15 +364,20 @@ const Publisher = ({
   };
 
   useEffect(() => {
-    if (contentSize === 'medio') {
-      setCharacterLimit(1000);
-    } else if (selectedTarget) {
-      const newLimit = selectedTarget.type === 'organization' ? 700 : 3000;
-      setCharacterLimit(newLimit);
-    } else {
-      // Default limit when no target is selected and size is not 'medio'
-      setCharacterLimit(3000);
+    // Start with the highest possible limit (personal profile default)
+    let limit = 3000;
+
+    // Check for the most restrictive limit based on profile type
+    if (selectedTarget && selectedTarget.type === 'organization') {
+      limit = 700;
     }
+
+    // If the content size is 'medio', check if its limit is even more restrictive
+    if (contentSize === 'medio') {
+      limit = Math.min(limit, 1000);
+    }
+
+    setCharacterLimit(limit);
   }, [selectedTarget, contentSize]);
 
   useEffect(() => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -73,13 +73,18 @@ export const safeDeepClone = (obj) => {
 
 export const markdownToLinkedinText = (markdown) => {
     if (!markdown) return '';
-    let text = markdown;
-    text = text.replace(/<[^>]*>/g, ''); // strip html tags
-    text = text.replace(/\*\*(.*?)\*\*|\*(.*?)\*/g, '$1$2'); // strip bold/italic
-    text = text.replace(/^#+\s/gm, ''); // strip headers
-    text = text.replace(/^>\s/gm, ''); // strip blockquotes
-    text = text.replace(/\[(.*?)\]\((.*?)\)/g, '$1 ($2)'); // convert links
-    text = text.replace(/^\s*[-*]\s/gm, ''); // strip list items
-    text = text.trim().replace(/\n{3,}/g, '\n\n'); // collapse multiple newlines to just two
+
+    // First, strip any HTML tags that might be present
+    let text = stripHtml(markdown);
+
+    // Escape reserved characters for LinkedIn as per user request
+    // The characters to escape are: | { } @ [ ] ( ) < > # \ * _ ~
+    // The backslash is escaped in the regex itself.
+    const reservedCharsRegex = /([|{}@[\]()<>#\\*_~])/g;
+    text = text.replace(reservedCharsRegex, '\\$1');
+
+    // Collapse multiple newlines to just two for cleaner formatting
+    text = text.trim().replace(/\n{3,}/g, '\n\n');
+
     return text;
 };


### PR DESCRIPTION
…sher

- Adds UI to select small, medium, or large content.
- Dynamically sets post text based on the selected size.
- Implements correct, precedence-aware character limit logic (1000 for medium, 700 for company pages, 3000 for personal).
- Updates the `markdownToLinkedinText` utility to escape special characters for LinkedIn.
- Ensures all UI elements are synchronized with the dynamic limits.