### PR TITLE
feat: Include original post link in LinkedIn follow-ups

### DIFF
--- a/add_parent_id_to_linkedin_schedules.sql
+++ b/add_parent_id_to_linkedin_schedules.sql
@@ -1,0 +1,9 @@
+-- Add a parent_id column to linkedin_schedules to link follow-up posts to a main post.
+ALTER TABLE linkedin_schedules
+ADD COLUMN parent_id INTEGER REFERENCES linkedin_schedules(id) ON DELETE SET NULL;
+
+-- Add an index for faster lookups on parent_id
+CREATE INDEX IF NOT EXISTS idx_linkedin_schedules_parent_id ON linkedin_schedules(parent_id);
+
+-- Comment to verify that the script was executed
+COMMENT ON COLUMN linkedin_schedules.parent_id IS 'ID do post original (pai) para posts de follow-up.';

--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -16,9 +16,7 @@ export async function publishPost(fetch, post, accessToken) {
         'x-internal-secret': process.env.INTERNAL_API_SECRET,
     };
 
-    // This logic now correctly concatenates the post parts into a single
-    // multi-line string, which is what the LinkedIn API expects.
-    const postText = [
+    let originalPostText = [
         postContent.titulo,
         postContent.conteudo,
         '----',
@@ -26,6 +24,18 @@ export async function publishPost(fetch, post, accessToken) {
         '----',
         (postContent.hashtags || []).map(h => h.startsWith('#') ? h : `#${h}`).join(' ')
     ].filter(Boolean).join('\n\n').trim();
+
+    if (post.parent_id) {
+        const { rows: parentRows } = await query(
+            'SELECT linkedin_post_url FROM linkedin_schedules WHERE id = $1',
+            [post.parent_id]
+        );
+        if (parentRows.length > 0 && parentRows[0].linkedin_post_url) {
+            originalPostText += `\n\nPost original: ${parentRows[0].linkedin_post_url}`;
+        }
+    }
+
+    const postText = originalPostText;
 
     const images = post.post_content?.images || [];
     const imageUrns = [];
@@ -115,7 +125,8 @@ export async function handleRunScheduler(request, response) {
              LEFT JOIN campaigns c ON ls.campaign_id = c.id
              WHERE ls.scheduled_at <= ($1 AT TIME ZONE 'UTC')
                AND ls.status = 'scheduled'
-               AND u.linkedin_access_token IS NOT NULL`,
+               AND u.linkedin_access_token IS NOT NULL
+             ORDER BY ls.parent_id ASC, ls.scheduled_at ASC`,
             [now.toISOString()]
         );
 

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -7,6 +7,7 @@ async function handleCreateSchedule(request, response) {
     try {
         const {
             campaign_id,
+            parent_id,
             scheduled_at,
             content,
             authorUrn,
@@ -26,11 +27,12 @@ async function handleCreateSchedule(request, response) {
         const linkedin_post_id = match ? match[0] : null;
 
         const { rows } = await query(
-            `INSERT INTO linkedin_schedules (user_id, campaign_id, scheduled_at, user_selected_time, post_content, status, linkedin_post_url, linkedin_post_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
+            `INSERT INTO linkedin_schedules (user_id, campaign_id, parent_id, scheduled_at, user_selected_time, post_content, status, linkedin_post_url, linkedin_post_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *`,
             [
                 userId,
                 campaign_id || null,
+                parent_id || null,
                 executionDate.toISOString(),
                 scheduled_at,
                 JSON.stringify({ ...content, authorUrn }),

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -519,7 +519,7 @@ const Publisher = ({
             images: selectedImageUrls,
         },
       };
-      await createSchedule(mainPostPayload);
+      const mainPostSchedule = await createSchedule(mainPostPayload);
       setPublishingStatusLi('Post principal agendado. Agendando follow-ups...');
 
       if (followupPosts && followupPosts.length > 0) {
@@ -542,6 +542,7 @@ const Publisher = ({
           const followupUtcDate = fromZonedTime(followupDate, userTimezone);
           const followupPayload = {
             campaign_id: selectedCampaignId || null,
+            parent_id: mainPostSchedule.id,
             scheduled_at: followupUtcDate.toISOString(),
             authorUrn: `urn:li:${selectedTarget.type}:${selectedTarget.id}`,
             content: {


### PR DESCRIPTION
This feature modifies the LinkedIn scheduling system to automatically include a link to the original post in any scheduled follow-up posts.

Key changes:
- Added a `parent_id` column to the `linkedin_schedules` table to establish a relationship between main posts and their follow-ups.
- Updated the frontend `Publisher` component to capture the schedule ID of the main post and pass it as `parent_id` when creating follow-up schedules.
- Modified the scheduling API to correctly handle and store the new `parent_id`.
- Enhanced the LinkedIn cron job to:
  - Process posts in an order that ensures parent posts are published before their children.
  - Check for a `parent_id` on a post, and if present, fetch the parent's `linkedin_post_url`.
  - Append the parent's URL to the content of the follow-up post before publishing.