### PR TITLE
Fixes an issue where scheduling a post with a new image would fail.

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -63,6 +63,7 @@ import { useUserAuth } from '../context/UserAuthContext';
 import { createSchedule, getSchedulesForUser, deleteSchedule, getSchedule, updateSchedule } from '../utils/scheduleAPI';
 import { getCampaigns } from '../utils/campaignState.js';
 import ConfirmationModal from './ui/ConfirmationModal/ConfirmationModal';
+import { upload } from '@vercel/blob/client';
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -122,6 +123,51 @@ const Publisher = ({
   const [schedulePreview, setSchedulePreview] = useState([]);
   const [campaigns, setCampaigns] = useState([]);
   const [selectedCampaignId, setSelectedCampaignId] = useState('');
+
+  const uploadPendingAssets = async (imageUrls) => {
+    const urlMap = {};
+    const uploadsToProcess = [];
+
+    // Find which of the selected URLs are blob URLs that need uploading.
+    for (const url of imageUrls) {
+      if (url.startsWith('blob:') && pendingAssets[url]) {
+        uploadsToProcess.push({
+          url,
+          blob: pendingAssets[url],
+          filename: `scheduled-post-${Date.now()}`,
+        });
+      } else {
+        // If it's not a blob URL, it's already a permanent URL.
+        urlMap[url] = url;
+      }
+    }
+
+    if (uploadsToProcess.length === 0) {
+      return urlMap;
+    }
+
+    const toastId = toast.loading(`Fazendo upload de ${uploadsToProcess.length} imagem(ns) para o agendamento...`);
+
+    try {
+      await Promise.all(
+        uploadsToProcess.map(async (uploadData) => {
+          const newBlob = await upload(uploadData.filename, uploadData.blob, {
+            access: 'public',
+            handleUploadUrl: '/api/upload-client',
+          });
+          // Map the original blob: URL to the new permanent URL
+          urlMap[uploadData.url] = newBlob.url;
+        })
+      );
+      toast.success('Upload de imagens concluído!', { id: toastId });
+      return urlMap;
+    } catch (error) {
+      console.error('Error uploading assets for schedule:', error);
+      toast.error(`Falha no upload de imagens: ${error.message}`, { id: toastId });
+      // If upload fails, throw the error to stop the scheduling process
+      throw new Error('Image upload failed, scheduling aborted.');
+    }
+  };
 
   useEffect(() => {
     if (currentCampaign) {
@@ -505,7 +551,11 @@ const Publisher = ({
       mainPostDate.setHours(parseInt(mainHours, 10), parseInt(mainMinutes, 10), 0, 0);
       const mainPostUtcDate = fromZonedTime(mainPostDate, userTimezone);
       const selectedImageIndexes = Object.keys(selectedImages).filter(index => selectedImages[index]);
-      const selectedImageUrls = selectedImageIndexes.map(index => unifiedMedia[parseInt(index)].url);
+      const blobImageUrls = selectedImageIndexes.map(index => unifiedMedia[parseInt(index)].url);
+
+      // Upload images with blob URLs and get their permanent URLs
+      const urlMap = await uploadPendingAssets(blobImageUrls);
+      const permanentImageUrls = blobImageUrls.map(url => urlMap[url] || url);
 
       const mainPostPayload = {
         campaign_id: selectedCampaignId || null,
@@ -516,7 +566,7 @@ const Publisher = ({
             conteudo: campaignContent?.conteudo || '',
             cta: campaignContent?.cta || '',
             hashtags: campaignContent?.hashtags || [],
-            images: selectedImageUrls,
+            images: permanentImageUrls,
         },
       };
       const mainPostSchedule = await createSchedule(mainPostPayload);


### PR DESCRIPTION
The root cause was that temporary 'blob:' URLs, created by the browser, were being saved to the database for scheduled posts. When the server-side cron job attempted to fetch this URL to publish the post, it would fail with a 'URL scheme "blob" is not supported' error because these URLs are only valid in the client's browser session.

This commit resolves the issue by implementing the following changes in the `Publisher.jsx` component:
- A new `uploadPendingAssets` function is introduced, which uses the `@vercel/blob/client` to upload any selected images that have `blob:` URLs to Vercel's Blob storage.
- The `handleScheduleLinkedIn` function is updated to call `uploadPendingAssets` before creating the schedule.
- The temporary `blob:` URLs in the payload are replaced with the new, permanent URLs returned from the blob storage.

This ensures that only permanent, publicly accessible URLs are stored in the `linkedin_schedules` table, allowing the cron job to successfully fetch and publish the images.