### PR TITLE
Fixes an issue with scheduled posts with multiple images on LinkedIn.…

### DIFF
--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -57,12 +57,7 @@ export async function publishPost(fetch, post, accessToken) {
                     accessToken,
                     payload: {
                         initializeUploadRequest: {
-                            owner: authorUrn,
-                            recipes: ['urn:li:digitalmediaRecipe:feedshare-image'],
-                            serviceRelationships: [{
-                                relationshipType: 'OWNER',
-                                identifier: 'urn:li:userGeneratedContent'
-                            }]
+                            owner: authorUrn
                         }
                     }
                 })


### PR DESCRIPTION
… The `initializeUploadRequest` parameter is now used with the correct payload, removing the fields that were causing API errors.

Also adds a link to the parent post in the 'Meus Agendamentos' view for follow-up posts.