### PR TITLE
fix(wordpress): Relax publish button check to enable publishing

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -1058,7 +1058,7 @@ const Publisher = ({
                 size="large"
                 color="secondary"
                 onClick={handlePublishWordPress}
-                disabled={isPublishingWp || isPublishingLi || generatedPagesData.length === 0 || !generatedPagesData.every(img => img.blob)}
+                disabled={isPublishingWp || isPublishingLi || generatedPagesData.length === 0}
               >
                 {isPublishingWp ? 'Publicando...' : 'Publicar no WordPress'}
               </Button>


### PR DESCRIPTION
The "Publicar no WordPress" button was disabled because of an overly strict check that required every generated page to have a `blob` property in the state.

However, the `handlePublishWordPress` function is designed to be more robust. It only requires the first page and can fetch the image blob from its URL if it's not immediately available in the state. This is crucial for campaigns that have been saved and reloaded, as blobs are not persisted to the database.

This commit removes the unnecessary `!generatedPagesData.every(img => img.blob)` check from the button's `disabled` property. The button is now correctly enabled as long as at least one page has been generated, aligning the UI with the actual requirements of the publishing logic and fixing the user-reported issue.