### PR TITLE
.refactor(settings): Centralize state and fix bugs

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BAND6PEs.js"></script>
+  <script type="module" crossorigin src="/assets/index-BbKNbbtx.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
 </head>
 

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -25,9 +25,10 @@ import {
   Tabs,
   Tab,
 } from '@mui/material';
-import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
+import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers.js';
 import { getCampaignPrompt } from '../utils/campaignPrompt';
 import { useSettings } from '../context/SettingsContext';
+import { initializeGenerationHandlers } from '../utils/generationHandlers.js';
 import { uploadImageToDrive, getOrCreateBackgroundsFolderId } from '../utils/googleApi';
 import {
     Campaign as CampaignIcon,
@@ -192,7 +193,7 @@ const Campaign = ({
     selectedPersonaForCampaign,
     setSelectedPersonaForCampaign,
 }) => {
-    useSettings();
+    const { settings } = useSettings();
     const [activeTab, setActiveTab] = useState(0);
     const [isHintModalOpen, setHintModalOpen] = React.useState(false);
     const [isSolucaoHintModalOpen, setSolucaoHintModalOpen] = React.useState(false);
@@ -219,6 +220,12 @@ const Campaign = ({
         prevCampaignContentRef.current = campaignContent;
     });
     const prevCampaignContent = prevCampaignContentRef.current;
+
+    useEffect(() => {
+        if (settings) {
+            initializeGenerationHandlers(settings);
+        }
+    }, [settings]);
 
     useEffect(() => {
         // Only switch to tab 1 if campaignContent just became available (was null or undefined before)


### PR DESCRIPTION
This commit completes the full refactoring of the application's settings management.

Key changes:
- All settings are now managed through the `SettingsContext` and persisted to the database, completely removing the dependency on `localStorage` for credentials and other settings.
- All components that previously read from `localStorage` have been refactored to use the `useSettings` hook.
- A stale closure bug in the settings forms (`WordpressAuthSetup`, `LinkedinAuthSetup`) was fixed by using `useCallback` on the change handlers. This ensures all fields in a settings object are saved correctly.
- A `ReferenceError` in the production build was fixed by standardizing module import paths to include the `.js` extension, ensuring correct resolution by Vite/Rollup.
- Obsolete utility files related to `localStorage` have been deleted, cleaning up the codebase.