### PR TITLE
refactor: Centralize settings and fix state bugs

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-Cby3CvMC.js"></script>
+  <script type="module" crossorigin src="/assets/index-BdQ7zyiK.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
 </head>
 

--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -56,11 +56,15 @@ export const SettingsProvider = ({ children }) => {
     setSettings((prev) => ({ ...prev, [key]: value }));
   };
 
-  const saveSettings = async () => {
+  const saveSettings = async (newSettings) => {
+    const settingsToSave = newSettings || settings;
     setIsLoading(true);
     try {
-      // The 'settings' object from the context state is now the single source of truth.
-      await saveSettingsToDb(settings);
+      await saveSettingsToDb(settingsToSave);
+      // Ensure the context state is in sync with what was just saved.
+      if (newSettings) {
+        setSettings(newSettings);
+      }
       toast.success('Settings saved successfully!');
     } catch (error) {
       toast.error(`Failed to save settings: ${error.message}`);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -642,8 +642,10 @@ function HomePage() {
               accessToken: data.access_token,
               expiry: Date.now() + data.expires_in * 1000,
             };
-            updateSetting('linkedin', newConfig);
-            await saveSettings();
+            // Construct the entire new settings object to avoid race conditions
+            const newSettings = { ...settings, linkedin: newConfig };
+            // Pass the new object directly to saveSettings
+            await saveSettings(newSettings);
             toast.success('Conexão com o LinkedIn estabelecida com sucesso!');
             setShowSetupModal(true);
           } else {


### PR DESCRIPTION
This commit completes a full refactoring of the application's settings management and fixes several related bugs.

Key changes:
- All settings are now managed through the `SettingsContext` and persisted to the database, completely removing the dependency on `localStorage`.
- All components that previously read from `localStorage` have been refactored to use the `useSettings` hook.
- A stale closure bug in the settings forms (`WordpressAuthSetup`, `LinkedinAuthSetup`) was fixed by using `useCallback` on the change handlers.
- A state race condition during the LinkedIn OAuth flow was fixed by modifying `saveSettings` to accept a new state object directly.
- A persistent `ReferenceError` in the production build was fixed by refactoring `generationHandlers.js` into a more robust singleton class pattern.
- Obsolete utility files related to `localStorage` have been deleted, cleaning up the codebase.