### PR TITLE
feat: Add unsaved changes dialog for LinkedIn auth

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BdQ7zyiK.js"></script>
+  <script type="module" crossorigin src="/assets/index-Do7RAUCo.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
 </head>
 

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -21,7 +21,7 @@ import GoogleDriveFolderPicker from './GoogleDriveFolderPicker';
 import { useUserAuth } from '../context/UserAuthContext';
 import LinkedinInfobox from './LinkedinInfobox';
 
-const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
+const LinkedinAuthSetup = ({ onConnect }) => {
   const { settings, updateSetting } = useSettings();
   const { googleAccessToken, setGoogleAccessToken } = useUserAuth();
 
@@ -101,14 +101,16 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
     setPickerOpen(true);
   };
 
-  const handleConnect = async () => {
+  const handleConnect = () => {
     if (clientId) {
-      if (onBeforeRedirect) await onBeforeRedirect();
-
-      const redirectUri = window.location.origin;
-      const scope = encodeURIComponent('r_basicprofile r_organization_social w_member_social w_organization_social rw_organization_admin');
-      const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&prompt=select_account`;
-      window.location.href = authUrl;
+      const performRedirect = () => {
+        const redirectUri = window.location.origin;
+        const scope = encodeURIComponent('r_basicprofile r_organization_social w_member_social w_organization_social rw_organization_admin');
+        const authUrl = `https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&prompt=select_account`;
+        window.location.href = authUrl;
+      };
+      // Delegate the connection logic (including dirty check) to the parent modal
+      onConnect(performRedirect);
     } else {
       setError('O Client ID do LinkedIn não está configurado no servidor.');
     }

--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useIsMobile } from '../hooks/use-mobile.js';
+import isEqual from 'lodash.isequal';
 import {
   Dialog,
   DialogTitle,
@@ -36,6 +37,7 @@ import GeminiAuthSetup from './GeminiAuthSetup';
 import GoogleCloudTTSAuth from './GoogleCloudTTSAuth';
 import WordpressAuthSetup from './WordpressAuthSetup';
 import LinkedinAuthSetup from './LinkedinAuthSetup';
+import UnsavedChangesDialog from './UnsavedChangesDialog';
 
 // The old file-based manager is replaced with the new DB-based one.
 import { useSettings } from '../context/SettingsContext';
@@ -101,7 +103,22 @@ const GeneralSettings = () => {
 const SetupModal = ({ open, onClose }) => {
   const isMobile = useIsMobile();
   const [value, setValue] = useState(0);
-  const { saveSettings, isLoading } = useSettings();
+  const { settings, saveSettings, isLoading } = useSettings();
+  const [initialSettings, setInitialSettings] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      // Create a deep copy of the settings when the modal opens.
+      setInitialSettings(JSON.parse(JSON.stringify(settings)));
+    } else {
+      // Reset when modal closes
+      setInitialSettings(null);
+    }
+  }, [open, settings]);
+
+  const isDirty = !isEqual(initialSettings, settings);
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const [redirectAction, setRedirectAction] = useState(null);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
@@ -110,10 +127,42 @@ const SetupModal = ({ open, onClose }) => {
   const handleSave = async () => {
     try {
       await saveSettings();
-      onClose();
+      // After saving, the state is no longer dirty relative to the new baseline
+      setInitialSettings(JSON.parse(JSON.stringify(settings)));
+      return true; // Indicate success
     } catch (error) {
       // Error is already toasted in the context
+      return false; // Indicate failure
     }
+  };
+
+  const handleConnectWithLinkedIn = (connectFn) => {
+    if (isDirty) {
+      setRedirectAction(() => connectFn);
+      setShowUnsavedDialog(true);
+    } else {
+      connectFn();
+    }
+  };
+
+  const handleCloseConfirmation = () => {
+    setShowUnsavedDialog(false);
+    setRedirectAction(null);
+  };
+
+  const handleConfirmDiscard = () => {
+    if (redirectAction) {
+      redirectAction();
+    }
+    handleCloseConfirmation();
+  };
+
+  const handleConfirmSave = async () => {
+    const success = await handleSave();
+    if (success && redirectAction) {
+      redirectAction();
+    }
+    handleCloseConfirmation();
   };
 
   const a11yProps = (index) => {
@@ -162,20 +211,32 @@ const SetupModal = ({ open, onClose }) => {
           <WordpressAuthSetup />
         </TabPanel>
         <TabPanel value={value} index={4}>
-          <LinkedinAuthSetup onBeforeRedirect={handleSave} />
+          <LinkedinAuthSetup onConnect={handleConnectWithLinkedIn} />
         </TabPanel>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Fechar</Button>
         <Button
           variant="contained"
-          onClick={handleSave}
-          disabled={isLoading}
+          onClick={async () => {
+            const success = await handleSave();
+            if (success) {
+              toast.success("Configurações salvas!");
+              onClose();
+            }
+          }}
+          disabled={isLoading || !isDirty}
           startIcon={isLoading ? <CircularProgress size={20} color="inherit" /> : <CloudUploadIcon />}
         >
           {isLoading ? 'Salvando...' : 'Salvar na Nuvem'}
         </Button>
       </DialogActions>
+      <UnsavedChangesDialog
+        open={showUnsavedDialog}
+        onClose={handleCloseConfirmation}
+        onConfirmDiscard={handleConfirmDiscard}
+        onConfirmSave={handleConfirmSave}
+      />
     </Dialog>
   );
 };


### PR DESCRIPTION
This commit introduces a confirmation dialog that prompts the user to save their changes before being redirected to LinkedIn for authentication.

Key changes:
- The `SetupModal` now tracks the "dirty" state of the settings by comparing the current settings with a snapshot taken when the modal was opened.
- If the user clicks the "Connect to LinkedIn" button while there are unsaved changes, an `UnsavedChangesDialog` is displayed.
- The user can choose to save and continue, discard and continue, or cancel the action.
- This improves the user experience by preventing accidental data loss and making the save process explicit.