### PR TITLE
fix: Correct dirty checking logic in settings modal

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-Do7RAUCo.js"></script>
+  <script type="module" crossorigin src="/assets/index-Dv2fwTpx.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
 </head>
 

--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -114,7 +114,7 @@ const SetupModal = ({ open, onClose }) => {
       // Reset when modal closes
       setInitialSettings(null);
     }
-  }, [open, settings]);
+  }, [open]);
 
   const isDirty = !isEqual(initialSettings, settings);
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);


### PR DESCRIPTION
This commit fixes a bug where the 'Save' button in the settings modal was incorrectly disabled after making changes. It also resolves an issue where settings appeared to disappear.

The root cause was that the `useEffect` responsible for snapshotting the initial state of the settings was re-running every time the settings changed, causing the `isDirty` check to always evaluate to false.

The fix removes the `settings` object from the `useEffect` dependency array, ensuring the snapshot is only taken once when the modal is opened. This allows the dirty check to function correctly, enabling the save button when changes are made.