### PR TITLE
Refatorado o salvamento de configurações para o banco de dados

### DIFF
--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -34,7 +34,6 @@ const ImageStepUI = ({
   initialFieldStyles,
   onImageDisplayedSizeChange,
   colorPalette,
-  standardsColors,
   onCsvDataUpdate,
   originalImageSize,
   onZIndexChange,
@@ -59,6 +58,7 @@ const ImageStepUI = ({
     brandElements, setBrandElements,
     pageTemplate, setPageTemplate,
     selectedField, setSelectedField,
+    colors,
   } = useCampaign();
 
   const handleNextPreview = () => {
@@ -109,7 +109,7 @@ const ImageStepUI = ({
             csvData={csvData}
             onImageDisplayedSizeChange={onImageDisplayedSizeChange}
             colorPalette={colorPalette}
-            standardsColors={standardsColors}
+            standardsColors={colors}
             onCsvDataUpdate={onCsvDataUpdate}
             selectedField={selectedField}
             setSelectedField={setSelectedField}
@@ -166,7 +166,7 @@ const ImageStepUI = ({
               setPageTemplate={setPageTemplate}
               onZIndexChange={onZIndexChange}
               onOpenHtmlEditor={onOpenHtmlEditor}
-              standardsColors={standardsColors}
+              standardsColors={colors}
               templateFieldStyles={templateFieldStyles}
               activeStep={activeStep}
               isCropping={isCropping}
@@ -204,7 +204,7 @@ const ImageStepUI = ({
             setPageTemplate={setPageTemplate}
             onZIndexChange={onZIndexChange}
             onOpenHtmlEditor={onOpenHtmlEditor}
-            standardsColors={standardsColors}
+            standardsColors={colors}
             templateFieldStyles={templateFieldStyles}
             activeStep={activeStep}
             isCropping={isCropping}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -128,7 +128,6 @@ function HomePage() {
   const [personaDrawerOpen, setPersonaDrawerOpen] = useState(!isMobile);
   const [autorDrawerOpen, setAutorDrawerOpen] = useState(!isMobile);
   const [colorPalette, setColorPalette] = useState([]);
-  const [standardsColors, setStandardsColors] = useState([]);
   const [problema, setProblema] = useState('');
   const [solucao, setSolucao] = useState('');
   const [objetivo, setObjetivo] = useState('');
@@ -488,17 +487,6 @@ function HomePage() {
     }
   };
 
-  const loadCampaignStandards = useCallback(() => {
-    const { formato: formatoData, colors: colorsData } = getCampaignPrompt();
-    setFormato(formatoData || '');
-    setStandardsColors(colorsData || []);
-  }, []);
-
-  useEffect(() => {
-    loadCampaignStandards();
-    // A inicialização da API Gemini agora é tratada em um useEffect separado que depende das configurações.
-  }, [loadCampaignStandards]);
-
   const fetchPersonasForCampaign = useCallback(() => {
     return getPersonas()
       .then(setPersonaList)
@@ -789,7 +777,7 @@ function HomePage() {
           fieldStyles: {},
           csvData: newCsvData,
           effectiveImageSize: originalImageSize,
-          standardsColors,
+          standardsColors: colors,
         });
 
         setFieldPositions(newPositions);
@@ -1210,7 +1198,7 @@ function HomePage() {
         fieldStyles: {},
         csvData: csvDataResult,
         effectiveImageSize: originalImageSize,
-        standardsColors,
+        standardsColors: colors,
       });
 
       const newGeneratedPagesData = csvDataResult.map((record, index) => ({
@@ -1346,7 +1334,7 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, generatedPagesData, };
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors, generatedPagesData, };
 
   return (
     <ThemeProvider theme={currentTheme}>
@@ -1482,7 +1470,6 @@ function HomePage() {
                     initialFieldStyles={initialFieldStyles}
                     onImageDisplayedSizeChange={setDisplayedImageSize}
                     colorPalette={colorPalette}
-                    standardsColors={standardsColors}
                     onCsvDataUpdate={handleCsvRecordContentUpdate}
                     originalImageSize={originalImageSize}
                     onZIndexChange={handleZIndexChange}


### PR DESCRIPTION
- Remove o uso de `localStorage` para configurações da campanha
- Centraliza o estado da campanha em `CampaignContext`
- Adiciona migração de configurações de `localStorage` para o banco de dados
- Remove `localStorage` para `campaignPrompt` e o substitui por `CampaignContext`
- Refatora `generationHandlers` para não depender de `localStorage`
- Passa `formato`, `colors`, `persona` e `autor` como parâmetros para as funções de geração
- Remove o código de migração de persona de `App.jsx`
- Remove o arquivo `campaignPrompt.js` que não é mais necessário