### PR TITLE
fix(ui): Add missing Palette icon import in MainAppBar

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -25,6 +25,7 @@ import {
   People as PeopleIcon,
   Home as HomeIcon,
   FolderOpen as FolderOpenIcon,
+  Palette,
 } from '@mui/icons-material';
 import { useUserAuth } from '../context/UserAuthContext';
 import { useNavigate } from 'react-router-dom';


### PR DESCRIPTION
This commit fixes a `ReferenceError: Palette is not defined` that was causing the application to crash. The error was due to the `Palette` icon component being used in `MainAppBar.jsx` without being imported from `@mui/icons-material`. This change adds the necessary import statement.