### PR TITLE
fix(ui): Add missing DialogActions import in PaletteEditModal

### DIFF
--- a/src/components/PaletteEditModal.jsx
+++ b/src/components/PaletteEditModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, Button, Box, TextField, Typography, IconButton,
+  Dialog, DialogTitle, DialogContent, Button, Box, TextField, Typography, IconButton, DialogActions,
 } from '@mui/material';
 import { Add, DeleteForever as DeleteForeverIcon } from '@mui/icons-material';
 


### PR DESCRIPTION
This commit fixes a `ReferenceError: DialogActions is not defined` that occurred when creating or editing a color palette. The error was caused by the `DialogActions` component being used in `PaletteEditModal.jsx` without being imported from `@mui/material`.

This also includes the previous fix for a similar missing `Palette` icon import in `MainAppBar.jsx`.