### PR TITLE
feat(palettes): Refactor palette creation to an AI-driven wizard

### DIFF
--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -47,7 +47,7 @@ import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
 import PaletteWizard from './PaletteWizard';
 import MemorialDescritivoModal from './MemorialDescritivoModal';
-import geminiAPI from '../utils/geminiAPI';
+import generationHandlers from '../utils/generationHandlers';
 import { useSettings } from '../context/SettingsContext';
 import { useCampaign } from '../context/CampaignContext';
 import { getPalettes } from '../utils/paletteState';
@@ -242,7 +242,29 @@ const CampaignStandardsModal = ({ open, onClose }) => {
         </DialogActions>
       </Dialog>
       <TextEditorDialog open={editingField !== null} title={getEditorTitle()} content={getCurrentContent()} onSave={handleSaveEditor} onClose={handleCloseEditor} html={true} />
-      <PaletteWizard open={showPaletteWizard} onClose={() => setShowPaletteWizard(false)} onSave={(newPalette) => { setColors(newPalette); toast.success('Paleta de cores aplicada!'); }} onGenerate={async (briefing, callback) => { setIsGenerating(true); try { const result = await onGeneratePalette(briefing); callback(result); } catch (error) { toast.error('Erro ao gerar paleta.'); } finally { setIsGenerating(false); } }} isGenerating={isGenerating} />
+      <PaletteWizard
+        open={showPaletteWizard}
+        onClose={() => setShowPaletteWizard(false)}
+        onSave={(savedPalette) => {
+          // The wizard now returns an object { name, colors }.
+          // We only need the colors for the campaign standards.
+          const newColors = savedPalette.colors.map(hex => ({ hex, name: `Cor (${hex})`, role: 'Gerada', justification: 'Gerada via assistente de IA.' }));
+          setColors(newColors);
+          toast.success('Paleta de cores aplicada!');
+        }}
+        onGenerate={async (briefing, callback) => {
+          setIsGenerating(true);
+          try {
+            const result = await generationHandlers.generateColorPalette(briefing);
+            callback(result);
+          } catch (error) {
+            toast.error(`Erro ao gerar paleta: ${error.message}`);
+          } finally {
+            setIsGenerating(false);
+          }
+        }}
+        isGenerating={isGenerating}
+      />
     </>
   );
 };

--- a/src/components/PaletteEditModal.jsx
+++ b/src/components/PaletteEditModal.jsx
@@ -1,82 +1,18 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, Button, Box, TextField, Typography, IconButton, DialogActions,
+  Dialog, DialogTitle, DialogContent, Button, DialogActions,
 } from '@mui/material';
-import { Add, DeleteForever as DeleteForeverIcon } from '@mui/icons-material';
+import PaletteEditor from './PaletteEditor';
 
 const PaletteEditModal = ({ open, onClose, onSave, paletteData, onPaletteDataChange }) => {
-  const [name, setName] = useState('');
-  const [colors, setColors] = useState([]);
-
-  useEffect(() => {
-    if (paletteData) {
-      setName(paletteData.name || '');
-      setColors(paletteData.colors || []);
-    }
-  }, [paletteData]);
-
-  const handleColorChange = (index, newColor) => {
-    const newColors = [...colors];
-    newColors[index] = newColor;
-    setColors(newColors);
-    onPaletteDataChange({ ...paletteData, colors: newColors });
-  };
-
-  const handleAddColor = () => {
-    if (colors.length < 5) {
-      const newColors = [...colors, '#000000'];
-      setColors(newColors);
-      onPaletteDataChange({ ...paletteData, colors: newColors });
-    }
-  };
-
-  const handleRemoveColor = (index) => {
-    const newColors = colors.filter((_, i) => i !== index);
-    setColors(newColors);
-    onPaletteDataChange({ ...paletteData, colors: newColors });
-  };
-
-  const handleNameChange = (event) => {
-    setName(event.target.value);
-    onPaletteDataChange({ ...paletteData, name: event.target.value });
-  };
-
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>{paletteData?.id ? 'Edit Palette' : 'New Palette'}</DialogTitle>
       <DialogContent>
-        <TextField
-          autoFocus
-          margin="dense"
-          label="Palette Name"
-          type="text"
-          fullWidth
-          variant="outlined"
-          value={name}
-          onChange={handleNameChange}
+        <PaletteEditor
+          paletteData={paletteData}
+          onPaletteDataChange={onPaletteDataChange}
         />
-        <Typography variant="h6" sx={{ mt: 2 }}>Colors</Typography>
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 1 }}>
-          {colors.map((color, index) => (
-            <Box key={index} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <input
-                type="color"
-                value={color}
-                onChange={(e) => handleColorChange(index, e.target.value)}
-                style={{ width: '50px', height: '50px', border: 'none', cursor: 'pointer' }}
-              />
-              <Typography variant="caption">{color}</Typography>
-              <IconButton onClick={() => handleRemoveColor(index)} size="small">
-                <DeleteForeverIcon />
-              </IconButton>
-            </Box>
-          ))}
-          {colors.length < 5 && (
-            <Button variant="outlined" onClick={handleAddColor} startIcon={<Add />}>
-              Add Color
-            </Button>
-          )}
-        </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>

--- a/src/components/PaletteEditor.jsx
+++ b/src/components/PaletteEditor.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {
+  Box, TextField, Typography, IconButton, Button,
+} from '@mui/material';
+import { Add, DeleteForever as DeleteForeverIcon } from '@mui/icons-material';
+
+const PaletteEditor = ({ paletteData, onPaletteDataChange }) => {
+  const { name = '', colors = [] } = paletteData || {};
+
+  const handleNameChange = (event) => {
+    onPaletteDataChange({ ...paletteData, name: event.target.value });
+  };
+
+  const handleColorChange = (index, newColor) => {
+    const newColors = [...colors];
+    newColors[index] = newColor;
+    onPaletteDataChange({ ...paletteData, colors: newColors });
+  };
+
+  const handleAddColor = () => {
+    if (colors.length < 5) {
+      const newColors = [...colors, '#000000'];
+      onPaletteDataChange({ ...paletteData, colors: newColors });
+    }
+  };
+
+  const handleRemoveColor = (index) => {
+    const newColors = colors.filter((_, i) => i !== index);
+    onPaletteDataChange({ ...paletteData, colors: newColors });
+  };
+
+  return (
+    <Box>
+      <TextField
+        autoFocus
+        margin="dense"
+        label="Palette Name"
+        type="text"
+        fullWidth
+        variant="outlined"
+        value={name}
+        onChange={handleNameChange}
+      />
+      <Typography variant="h6" sx={{ mt: 2 }}>Colors</Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 1 }}>
+        {colors.map((color, index) => (
+          <Box key={index} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => handleColorChange(index, e.target.value)}
+              style={{ width: '50px', height: '50px', border: 'none', cursor: 'pointer' }}
+            />
+            <Typography variant="caption">{color}</Typography>
+            <IconButton onClick={() => handleRemoveColor(index)} size="small">
+              <DeleteForeverIcon />
+            </IconButton>
+          </Box>
+        ))}
+        {colors.length < 5 && (
+          <Button variant="outlined" onClick={handleAddColor} startIcon={<Add />}>
+            Add Color
+          </Button>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default PaletteEditor;

--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -18,13 +18,12 @@ import {
   Select,
   MenuItem,
   CircularProgress,
-  Paper,
 } from '@mui/material';
-import PaletteReport from './PaletteReport';
+import PaletteEditor from './PaletteEditor'; // Use the new editor
 
 const steps = [
   'Definir Briefing',
-  'Analisar Resultado',
+  'Ajustar e Salvar', // Changed step name
 ];
 
 const briefingOptions = {
@@ -45,7 +44,7 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
   const isMobile = useIsMobile();
   const [activeStep, setActiveStep] = useState(0);
   const [briefing, setBriefing] = useState({});
-  const [generatedPalette, setGeneratedPalette] = useState(null);
+  const [editablePalette, setEditablePalette] = useState(null);
 
   useEffect(() => {
     if (open) {
@@ -56,7 +55,7 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
         atmosfera: '',
         details: '',
       });
-      setGeneratedPalette(null);
+      setEditablePalette(null);
       setActiveStep(0);
     }
   }, [open]);
@@ -70,12 +69,16 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
 - Atmosfera desejada: ${briefing.atmosfera}
 - Detalhes adicionais: ${briefing.details}
       `;
-      onGenerate(fullBriefing.trim(), (palette) => {
-        setGeneratedPalette(palette);
+      onGenerate(fullBriefing.trim(), (generatedData) => {
+        // The AI result should contain palette_name and palette_colors
+        setEditablePalette({
+          name: generatedData.palette_name || 'Nova Paleta',
+          colors: generatedData.palette_colors || [],
+        });
         setActiveStep(1);
       });
     } else {
-      onSave(generatedPalette.palette);
+      onSave(editablePalette);
       onClose();
     }
   };
@@ -119,11 +122,10 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
               label="Detalhes Adicionais do Briefing"
               multiline
               rows={4}
-              value={briefing.details}
+              value={briefing.details || ''}
               onChange={handleChange}
               fullWidth
-              placeholder="INCLUINDO:
-- Quaisquer cores proibidas ou obrigatórias"
+              placeholder="INCLUINDO:&#10;- Quaisquer cores proibidas ou obrigatórias"
               margin="normal"
             />
           </Box>
@@ -132,10 +134,13 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
         return (
           <Box>
             <Typography variant="h6" gutterBottom>Resultado da Geração</Typography>
-            {generatedPalette ? (
-              <PaletteReport paletteData={generatedPalette} briefing={briefing} />
+            {editablePalette ? (
+              <PaletteEditor
+                paletteData={editablePalette}
+                onPaletteDataChange={setEditablePalette}
+              />
             ) : (
-              <Typography>A paleta gerada será exibida aqui.</Typography>
+              <Typography>A paleta gerada será exibida aqui para edição.</Typography>
             )}
           </Box>
         );
@@ -149,7 +154,7 @@ const PaletteWizard = ({ open, onClose, onSave, onGenerate, isGenerating }) => {
           return isGenerating || !briefing.objetivo || !briefing.publicoAlvo || !briefing.mensagemPrincipal || !briefing.atmosfera;
       }
       if (activeStep === 1) {
-          return !generatedPalette;
+          return !editablePalette || !editablePalette.name.trim() || editablePalette.colors.length === 0;
       }
       return false;
   }

--- a/src/pages/PalettesPage.jsx
+++ b/src/pages/PalettesPage.jsx
@@ -11,6 +11,8 @@ import isEqual from 'lodash.isequal';
 import { getPalettes, savePalette, updatePalette, deletePalette } from '../utils/paletteState';
 import PaletteEditModal from '../components/PaletteEditModal';
 import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
+import PaletteWizard from '../components/PaletteWizard';
+import generationHandlers from '../utils/generationHandlers';
 
 const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSelected, onUpdate }) => {
   const theme = useTheme();
@@ -26,9 +28,12 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [navigationTarget, setNavigationTarget] = useState(null);
 
+  const [isWizardOpen, setIsWizardOpen] = useState(false);
+  const [isGenerating, setIsGenerating] = useState(false);
+
   useEffect(() => {
     if (selectedPalette && paletteFormData) {
-        const isDirty = !isEqual(selectedPalette.colors, paletteFormData.colors);
+        const isDirty = selectedPalette.id && !isEqual(selectedPalette, paletteFormData);
         setIsPaletteDirty(isDirty);
     } else {
         setIsPaletteDirty(false);
@@ -65,37 +70,58 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
   };
 
   const handleNewPalette = () => {
-      const newEmptyPalette = { name: '', colors: [] };
-      setSelectedPalette(newEmptyPalette);
-      setPaletteFormData(newEmptyPalette);
-      setIsPaletteDirty(false);
-      if (isMobile) setPaletteDrawerOpen(false);
+      setIsWizardOpen(true);
   };
 
-  const handleSavePalette = async () => {
-    if (!paletteFormData) {
-        toast.error('Não há dados de paleta para salvar.');
+  const handleUpdatePalette = async () => {
+    if (!paletteFormData || !paletteFormData.id) {
+        toast.error('Não há dados de paleta para atualizar.');
         return false;
     }
-    const paletteToSave = { ...selectedPalette, ...paletteFormData };
-    if (!paletteToSave.name) {
+    if (!paletteFormData.name) {
         toast.error('O nome da paleta é obrigatório.');
         return false;
     }
     try {
-        const saved = paletteToSave.id
-            ? await updatePalette(paletteToSave.id, paletteToSave.name, paletteToSave.colors)
-            : await savePalette(paletteToSave.name, paletteToSave.colors);
-        toast.success("Paleta salva com sucesso!");
+        const saved = await updatePalette(paletteFormData.id, paletteFormData.name, paletteFormData.colors);
+        toast.success("Paleta atualizada com sucesso!");
         await fetchPalettes();
         if (onUpdate) onUpdate();
         setSelectedPalette(saved);
         setPaletteFormData(saved);
         setIsPaletteDirty(false);
-        return true; // Indicate success
+        return true;
     } catch (err) {
-        toast.error(`Falha ao salvar paleta: ${err.message}`);
-        return false; // Indicate failure
+        toast.error(`Falha ao atualizar paleta: ${err.message}`);
+        return false;
+    }
+  };
+
+  const handleWizardSave = async (paletteToSave) => {
+    if (!paletteToSave || !paletteToSave.name || !paletteToSave.colors) {
+      toast.error('A paleta precisa de um nome e cores para ser salva.');
+      return;
+    }
+    try {
+      await savePalette(paletteToSave.name, paletteToSave.colors);
+      toast.success("Nova paleta criada com sucesso!");
+      await fetchPalettes();
+      if (onUpdate) onUpdate();
+      setIsWizardOpen(false);
+    } catch (err) {
+      toast.error(`Falha ao criar paleta: ${err.message}`);
+    }
+  };
+
+  const handleGeneratePalette = async (briefing, callback) => {
+    setIsGenerating(true);
+    try {
+      const result = await generationHandlers.generateColorPalette(briefing);
+      callback(result);
+    } catch (error) {
+      toast.error(`Erro ao gerar paleta: ${error.message}`);
+    } finally {
+      setIsGenerating(false);
     }
   };
 
@@ -123,7 +149,7 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
     };
 
     const handleDialogSaveAndNavigate = async () => {
-        const success = await handleSavePalette();
+        const success = await handleUpdatePalette();
         setShowUnsavedDialog(false);
         if (success && navigationTarget) {
             navigationTarget();
@@ -139,14 +165,11 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
       if (onUpdate) onUpdate();
       setSelectedPalette(null); // Deselect if the deleted one was selected
     } catch (error) {
-      // Error toast is handled inside deletePalette, but you could add more here if needed
       console.error(error);
     }
   };
 
   const handleDeleteClick = (palette) => {
-    // Stop propagation to prevent the ListItemButton's onClick from firing
-    // event.stopPropagation();
     if (window.confirm(`Tem certeza que deseja excluir a paleta "${palette.name}"? Esta ação não pode ser desfeita.`)) {
       handleConfirmDelete(palette.id);
     }
@@ -157,7 +180,7 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
             <Typography variant="h6">Paletas</Typography>
         </Box>
-        <Button variant="contained" startIcon={<Add />} onClick={handleNewPalette} fullWidth>Nova Paleta</Button>
+        <Button variant="contained" startIcon={<Add />} onClick={handleNewPalette} fullWidth>Nova Paleta com IA</Button>
         <Divider sx={{my: 2}} />
         {palettesLoading && <CircularProgress />}
         {palettesError && <Alert severity="error">{palettesError}</Alert>}
@@ -197,7 +220,7 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
                   '& .MuiDrawer-paper': {
                       width: 320,
                       boxSizing: 'border-box',
-                      position: 'absolute', // Position relative to the parent Box
+                      position: 'absolute',
                   },
               }}
           >
@@ -227,20 +250,20 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
                 {selectedPalette ? (
                   isMobile ? (
                     <PaletteEditModal
-                      key={selectedPalette.id || 'new'}
+                      key={selectedPalette.id}
                       open={Boolean(selectedPalette)}
                       onClose={() => handleNavigation(() => setSelectedPalette(null))}
-                      onSave={handleSavePalette}
+                      onSave={handleUpdatePalette}
                       paletteData={paletteFormData}
                       onPaletteDataChange={setPaletteFormData}
                     />
                   ) : (
                     <Paper elevation={2} sx={{ p: 3 }}>
                       <PaletteEditModal
-                        key={selectedPalette.id || 'new'}
+                        key={selectedPalette.id}
                         open={Boolean(selectedPalette)}
                         onClose={() => handleNavigation(() => setSelectedPalette(null))}
-                        onSave={handleSavePalette}
+                        onSave={handleUpdatePalette}
                         paletteData={paletteFormData}
                         onPaletteDataChange={setPaletteFormData}
                       />
@@ -261,6 +284,13 @@ const PalettesPage = ({ paletteDrawerOpen, setPaletteDrawerOpen, onNoPaletteSele
         onClose={handleDialogClose}
         onConfirmDiscard={handleDialogDiscard}
         onConfirmSave={handleDialogSaveAndNavigate}
+      />
+      <PaletteWizard
+        open={isWizardOpen}
+        onClose={() => setIsWizardOpen(false)}
+        onSave={handleWizardSave}
+        onGenerate={handleGeneratePalette}
+        isGenerating={isGenerating}
       />
     </>
   );


### PR DESCRIPTION
This commit completely refactors the user experience for creating color palettes, aligning it with the AI-assisted workflows for creating Personas and Autores.

Key changes:
- The 'New Palette' button on the Palettes page now launches a two-step `PaletteWizard`.
- Step 1: The user provides a briefing for the AI.
- Step 2: The AI generates a palette (name and colors), which is then presented in an editor for the user to review and adjust.
- A new reusable `PaletteEditor` component was created from the old `PaletteEditModal` to facilitate this.
- The `PaletteWizard` is now adapted for use in both the `PalettesPage` (saving a new palette to the database) and the `CampaignStandardsModal` (passing colors back to the campaign).