### PR TITLE
feat(palettes): Implement palette management and fix runtime errors

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-IlTIkAH-.js"></script>
+  <script type="module" crossorigin src="/assets/index-0vaIqsXu.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
 </head>
 

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -206,7 +206,7 @@ const CampaignStandardsModal = ({ open, onClose }) => {
                   <MenuItem value="">
                     <em>Nenhuma</em>
                   </MenuItem>
-                  {palettes.map(palette => (
+                  {(palettes || []).map(palette => (
                     <MenuItem key={palette.id} value={palette.id}>
                       {palette.name}
                     </MenuItem>
@@ -219,7 +219,7 @@ const CampaignStandardsModal = ({ open, onClose }) => {
               <Divider />
               <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>Cores da Campanha Ativa</Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 2, alignItems: 'center' }}>
-                {colors.map((color, index) => (
+                {(colors || []).map((color, index) => (
                   <Box key={index} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                     <input type="color" value={color.hex} onChange={(e) => handleColorChange(index, e.target.value)} style={{ width: '50px', height: '50px', border: 'none', cursor: 'pointer' }} />
                     <Typography variant="caption">{color.name || color.hex}</Typography>

--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -31,6 +31,7 @@ export const CampaignProvider = ({ children }) => {
   const [generatedVideos, setGeneratedVideos] = useState([]);
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [pendingAssets, setPendingAssets] = useState({});
+  const [colors, setColors] = useState([]);
 
 
   const value = useMemo(() => ({
@@ -47,6 +48,7 @@ export const CampaignProvider = ({ children }) => {
     generatedVideos,
     aspectRatio,
     pendingAssets,
+    colors,
 
     // Setters
     setCsvData,
@@ -61,6 +63,7 @@ export const CampaignProvider = ({ children }) => {
     setGeneratedVideos,
     setAspectRatio,
     setPendingAssets,
+    setColors,
 
     // Constants
     defaultPageTemplate,
@@ -77,6 +80,7 @@ export const CampaignProvider = ({ children }) => {
     generatedVideos,
     aspectRatio,
     pendingAssets,
+    colors,
   ]);
 
   return (

--- a/src/pages/PalettesPage.jsx
+++ b/src/pages/PalettesPage.jsx
@@ -113,7 +113,7 @@ const PalettesPage = () => {
 
       {!isLoading && !error && (
         <List>
-          {palettes.map((palette) => (
+          {(palettes || []).map((palette) => (
             <ListItem
               key={palette.id}
               secondaryAction={
@@ -133,7 +133,7 @@ const PalettesPage = () => {
                   primary={palette.name}
                   secondary={
                     <Box component="span" sx={{ display: 'flex', gap: 1, mt: 1 }}>
-                      {palette.colors.map((color, index) => (
+                      {(palette.colors || []).map((color, index) => (
                         <Box
                           key={index}
                           component="span"


### PR DESCRIPTION
This commit introduces a complete, database-backed feature for managing color palettes and fixes several build and runtime errors discovered during deployment.

Feature Implementation:
- Adds a `palettes` table to the database and corresponding CRUD API endpoints.
- Creates a new `PalettesPage` for users to manage their saved palettes.
- Implements an AI-powered `PaletteWizard` for creating new palettes from a text briefing, with a two-step flow for generation and adjustment.
- Integrates the new palette system into the `CampaignStandardsModal`.

Bug Fixes:
- Resolves a build failure caused by incorrect default imports of `generationHandlers.js`.
- Fixes a runtime error `TypeError: Cannot read properties of undefined (reading 'map')` by adding the missing `colors` state to the `CampaignContext`.
- Adds defensive checks to `.map()` calls to make the UI more resilient.