### PR TITLE
feat(palettes): Implement palette management and fix all related bugs

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1606,7 +1606,7 @@ function HomePage() {
             )}
             {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} onUpdate={fetchPersonasForCampaign} />}
             {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} onUpdate={fetchAutoresForCampaign} />}
-            {currentView === 'palettes' && <PalettesPage paletteDrawerOpen={paletteDrawerOpen} setPaletteDrawerOpen={setPaletteDrawerOpen} />}
+            {currentView === 'palettes' && <PalettesPage paletteDrawerOpen={paletteDrawerOpen} setPaletteDrawerOpen={setPaletteDrawerOpen} onNoPaletteSelected={() => setPaletteDrawerOpen(true)} />}
         </Box>
       </Box>
       <UnsavedChangesDialog

--- a/src/pages/PalettesPage.jsx
+++ b/src/pages/PalettesPage.jsx
@@ -20,7 +20,7 @@ import { getPalettes, savePalette, updatePalette, deletePalette } from '../utils
 import PaletteEditModal from '../components/PaletteEditModal';
 import PaletteWizard from '../components/PaletteWizard';
 
-const PalettesPage = () => {
+const PalettesPage = ({ onNoPaletteSelected }) => {
   const [palettes, setPalettes] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -45,6 +45,12 @@ const PalettesPage = () => {
   useEffect(() => {
     fetchPalettes();
   }, [fetchPalettes]);
+
+  useEffect(() => {
+    if (!selectedPalette && onNoPaletteSelected) {
+      onNoPaletteSelected();
+    }
+  }, [selectedPalette, onNoPaletteSelected]);
 
   const handleOpenEditModal = (palette) => {
     setSelectedPalette(palette);


### PR DESCRIPTION
This commit introduces a complete, database-backed feature for managing color palettes and includes fixes for several build, runtime, and UI bugs discovered during deployment.

Feature Implementation:
- Adds a `palettes` table to the database and corresponding CRUD API endpoints.
- Creates a new `PalettesPage` for users to manage their saved palettes, with a drawer that opens automatically on navigation.
- Implements an AI-powered `PaletteWizard` for creating new palettes from a text briefing, with a two-step flow for generation and adjustment, and robust error handling.
- Integrates the new palette system into the `CampaignStandardsModal`.

Bug Fixes:
- Resolves a build failure caused by incorrect default imports.
- Fixes a runtime error `TypeError: Cannot read properties of undefined (reading 'map')` by adding the missing `colors` state to the `CampaignContext`.
- Fixes a UI bug where the `PalettesPage` appeared blank on navigation.