### PR TITLE
fix(ui): Connect palette menu item to its view

### DIFF
--- a/src/components/MainAppBar.jsx
+++ b/src/components/MainAppBar.jsx
@@ -35,6 +35,7 @@ const MainAppBar = ({
   setDarkMode,
   onShowPersonas,
   onShowAutores,
+  onShowPalettes,
   onShowCampaigns,
   setShowSetupModal,
   setShowCampaignStandardsModal,


### PR DESCRIPTION
The "Paletas" menu item was not navigating to the palette management view because the `onShowPalettes` prop was not being passed to the `MainAppBar` component. This caused a runtime error when the menu item was clicked.

This change adds the missing `onShowPalettes` prop to the `MainAppBar`'s props list, allowing the `onClick` handler to correctly call the navigation function defined in `HomePage.jsx`. This connects the menu item to the existing logic that renders the `PalettesPage` component, resolving the bug.