### PR TITLE
Fix(palette): Repair AI color palette generation

### DIFF
--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -42,24 +42,65 @@ const briefingLabels = {
     atmosfera: 'Atmosfera',
 };
 
-const PaletteWizard = ({ open, onClose, onSave, paletteData, onPaletteDataChange, initialStep = 0 }) => {
+const PaletteWizard = ({
+  open,
+  onClose,
+  onSave,
+  paletteData: controlledPaletteData, // Renamed to indicate it's a prop
+  onPaletteDataChange,
+  initialStep = 0
+}) => {
   const isMobile = useIsMobile();
   const [activeStep, setActiveStep] = useState(initialStep);
   const [briefing, setBriefing] = useState({});
   const [isGenerating, setIsGenerating] = useState(false);
   const [generationError, setGenerationError] = useState(null);
 
+  // --- Internal State for Uncontrolled Mode ---
+  const [internalPaletteData, setInternalPaletteData] = useState(null);
+
+  // --- Determine if the component is controlled ---
+  // A component is controlled if `paletteData` is not undefined.
+  const isControlled = controlledPaletteData !== undefined;
+
+  // Use the controlled data if available, otherwise use internal state.
+  const paletteData = isControlled ? controlledPaletteData : internalPaletteData;
+
+  // The function to update the state depends on whether it's controlled or not.
+  const setPaletteData = (data) => {
+    if (isControlled) {
+      // In controlled mode, we must call the prop function.
+      // We also check if it exists to prevent crashes.
+      if (typeof onPaletteDataChange === 'function') {
+        onPaletteDataChange(data);
+      }
+    } else {
+      // In uncontrolled mode, we set our own internal state.
+      setInternalPaletteData(data);
+    }
+  };
+
+
   useEffect(() => {
     if (open) {
       setActiveStep(initialStep);
-      // If we are editing (initialStep is 1), the paletteData is already set.
-      // If we are creating (initialStep is 0), we can clear the briefing.
+      setGenerationError(null);
+
       if (initialStep === 0) {
         setBriefing({});
+        // Clear internal data when starting a new creation in uncontrolled mode
+        if (!isControlled) {
+          setInternalPaletteData(null);
+        }
+      } else {
+        // If we are editing (initialStep is 1) in uncontrolled mode,
+        // we might need to initialize internal state from a source,
+        // but the current implementation doesn't support that.
+        // The parent must control it for editing.
       }
-      setGenerationError(null);
     }
-  }, [open, initialStep]);
+  }, [open, initialStep, isControlled]);
+
 
   const handleGenerate = async () => {
     setIsGenerating(true);
@@ -73,14 +114,13 @@ const PaletteWizard = ({ open, onClose, onSave, paletteData, onPaletteDataChange
     `;
     try {
       const generatedData = await generationHandlers.generateColorPalette(fullBriefing.trim());
-      // Instead of setting local state, we lift the result up to the parent
-      onPaletteDataChange({
+      setPaletteData({
         name: generatedData.palette_name || generatedData.name || 'Nova Paleta Gerada',
         colors: generatedData.palette_colors || generatedData.colors || [],
       });
     } catch (error) {
       setGenerationError(error.message || 'Ocorreu um erro desconhecido durante a geração.');
-      onPaletteDataChange(null); // Clear data on error
+      setPaletteData(null); // Clear data on error
     } finally {
       setIsGenerating(false);
       setActiveStep(1);
@@ -88,8 +128,7 @@ const PaletteWizard = ({ open, onClose, onSave, paletteData, onPaletteDataChange
   };
 
   const handleSave = () => {
-    // The parent now handles the saving logic with its own state
-    // We pass the current data back so the parent can use it.
+    // onSave should receive the current palette data, regardless of mode.
     onSave(paletteData);
     onClose();
   };
@@ -148,7 +187,7 @@ const PaletteWizard = ({ open, onClose, onSave, paletteData, onPaletteDataChange
             {paletteData ? (
               <PaletteEditor
                 paletteData={paletteData}
-                onPaletteDataChange={onPaletteDataChange}
+                onPaletteDataChange={setPaletteData} // Always use our unified setter
               />
             ) : (
               !generationError && <Typography>A paleta gerada será exibida aqui para edição.</Typography>
@@ -164,7 +203,7 @@ const PaletteWizard = ({ open, onClose, onSave, paletteData, onPaletteDataChange
     if (activeStep === 0) {
       return isGenerating || !briefing.objetivo || !briefing.publicoAlvo || !briefing.mensagemPrincipal || !briefing.atmosfera;
     }
-    return false; // The save button on step 2 will have its own logic
+    return false;
   };
 
   const isSaveDisabled = () => {

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -542,8 +542,6 @@ export const generateIAContent = async ({ promptText, promptNumRecords }) => {
 export const generateColorPalette = async (briefing) => {
   const apiKey = getGeminiApiKey();
   if (!apiKey) {
-    // The original function used toast, but in a util file, it's better to throw.
-    // The calling component will be responsible for catching the error and showing a toast.
     throw new Error('Por favor, configure sua chave de API Gemini primeiro.');
   }
   geminiAPI.initialize(apiKey);
@@ -553,11 +551,41 @@ export const generateColorPalette = async (briefing) => {
 
   try {
     const response = await geminiAPI.generateContent(prompt, 'Geração de Paleta de Cores');
-    const jsonMatch = response.match(/\{[\s\S]*\}/);
-    if (jsonMatch && jsonMatch[0]) {
-      return JSON.parse(jsonMatch[0]);
+
+    // More robust JSON parsing
+    const jsonMatch = response.match(/```json\s*([\s\S]+?)\s*```/);
+    let parsedResponse;
+
+    if (jsonMatch && jsonMatch[1]) {
+      try {
+        parsedResponse = JSON.parse(jsonMatch[1]);
+      } catch (e) {
+        console.error("Falha ao analisar o JSON do bloco de markdown:", jsonMatch[1], e);
+        throw new Error("A resposta da IA continha um bloco JSON, mas não era válido.");
+      }
+    } else {
+      // Fallback: try to parse the entire response string
+      try {
+        // Attempt to find a JSON object within the string if it's not perfectly clean
+        const cleanerMatch = response.match(/\{[\s\S]*\}/);
+        if (cleanerMatch && cleanerMatch[0]) {
+          parsedResponse = JSON.parse(cleanerMatch[0]);
+        } else {
+          // If no object is found, try to parse the whole thing
+          parsedResponse = JSON.parse(response);
+        }
+      } catch (e) {
+        console.error("Falha ao analisar a resposta da IA como JSON diretamente:", response, e);
+        throw new Error("A resposta da IA não estava em um formato JSON válido.");
+      }
     }
-    throw new Error("Não foi possível extrair o JSON da resposta da IA.");
+
+    if (typeof parsedResponse !== 'object' || parsedResponse === null) {
+        throw new Error("A resposta JSON analisada não é um objeto válido.");
+    }
+
+    return parsedResponse;
+
   } catch (error) {
     console.error("Erro ao gerar paleta de cores com IA:", error);
     // Re-throw the error to be handled by the calling component


### PR DESCRIPTION
This commit addresses a bug where the AI-powered color palette generation was failing. The feature, which previously worked in the "Campaign Standards" section, broke after being moved to a dedicated "Palettes" CRUD.

The fix involves two main changes:

1.  **Robust JSON Parsing:** The `generateColorPalette` function in `generationHandlers.js` has been updated with a more resilient parsing logic. It now correctly handles AI responses that include markdown code blocks (e.g., ```json ... ```), preventing parsing errors that were causing the generation to fail.

2.  **Flexible PaletteWizard Component:** The `PaletteWizard.jsx` component has been refactored to support both controlled and uncontrolled modes. It now manages its own internal state when not explicitly controlled by a parent component. This resolves a crash in the "Campaign Standards" modal (uncontrolled use) while maintaining functionality in the new "Palettes" page (controlled use).