### PR TITLE
feat(palettes): Add image extraction and descriptive fields

### DIFF
--- a/src/components/PaletteEditor.jsx
+++ b/src/components/PaletteEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Box, TextField, Typography, IconButton, Button,
+  Box, TextField, Typography, IconButton, Button, Paper, Grid,
 } from '@mui/material';
 import { Add, DeleteForever as DeleteForeverIcon } from '@mui/icons-material';
 
@@ -11,16 +11,23 @@ const PaletteEditor = ({ paletteData, onPaletteDataChange }) => {
     onPaletteDataChange({ ...paletteData, name: event.target.value });
   };
 
-  const handleColorChange = (index, newColor) => {
+  const handleColorFieldChange = (index, field, value) => {
     const newColors = [...colors];
-    newColors[index] = newColor;
+    newColors[index] = { ...newColors[index], [field]: value };
     onPaletteDataChange({ ...paletteData, colors: newColors });
   };
 
   const handleAddColor = () => {
-    // Palettes are capped at 5 colors for now.
-    if (colors.length < 5) {
-      const newColors = [...colors, '#000000'];
+    // Limit the number of colors to avoid overly complex palettes.
+    // The AI generates 5, so we can cap it at 6 or 7.
+    if (colors.length < 7) {
+      const newColor = {
+        hex: '#000000',
+        name: 'Nova Cor',
+        role: 'Acento',
+        justification: 'Adicionada manualmente pelo usuário.',
+      };
+      const newColors = [...colors, newColor];
       onPaletteDataChange({ ...paletteData, colors: newColors });
     }
   };
@@ -42,25 +49,68 @@ const PaletteEditor = ({ paletteData, onPaletteDataChange }) => {
         value={name}
         onChange={handleNameChange}
         required
+        sx={{ mb: 2 }}
       />
-      <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>Cores</Typography>
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+      <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>Cores e Descrições</Typography>
+      <Grid container spacing={2}>
         {colors.map((color, index) => (
-          <Box key={index} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <input
-              type="color"
-              value={color}
-              onChange={(e) => handleColorChange(index, e.target.value)}
-              style={{ width: '50px', height: '50px', border: 'none', cursor: 'pointer', backgroundColor: 'transparent' }}
-              title="Clique para escolher uma cor"
-            />
-            <Typography variant="caption" sx={{ mt: 0.5 }}>{color}</Typography>
-            <IconButton onClick={() => handleRemoveColor(index)} size="small" title="Remover Cor">
-              <DeleteForeverIcon />
-            </IconButton>
-          </Box>
+          <Grid item xs={12} key={index}>
+            <Paper variant="outlined" sx={{ p: 2, display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <input
+                  type="color"
+                  value={color.hex || '#000000'}
+                  onChange={(e) => handleColorFieldChange(index, 'hex', e.target.value)}
+                  style={{ width: '60px', height: '60px', border: '1px solid #ccc', cursor: 'pointer', backgroundColor: 'transparent' }}
+                  title="Clique para escolher uma cor"
+                />
+                <Typography variant="caption" sx={{ mt: 0.5, fontFamily: 'monospace' }}>{color.hex}</Typography>
+              </Box>
+              <Box sx={{ flexGrow: 1 }}>
+                <Grid container spacing={1}>
+                  <Grid item xs={12} sm={6}>
+                    <TextField
+                      label="Nome da Cor"
+                      value={color.name || ''}
+                      onChange={(e) => handleColorFieldChange(index, 'name', e.target.value)}
+                      fullWidth
+                      size="small"
+                      variant="standard"
+                    />
+                  </Grid>
+                  <Grid item xs={12} sm={6}>
+                    <TextField
+                      label="Papel na Paleta"
+                      value={color.role || ''}
+                      onChange={(e) => handleColorFieldChange(index, 'role', e.target.value)}
+                      fullWidth
+                      size="small"
+                      variant="standard"
+                    />
+                  </Grid>
+                  <Grid item xs={12}>
+                    <TextField
+                      label="Justificativa / Descrição"
+                      value={color.justification || ''}
+                      onChange={(e) => handleColorFieldChange(index, 'justification', e.target.value)}
+                      fullWidth
+                      multiline
+                      rows={2}
+                      size="small"
+                      variant="standard"
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+              <IconButton onClick={() => handleRemoveColor(index)} size="small" title="Remover Cor" sx={{ alignSelf: 'center' }}>
+                <DeleteForeverIcon />
+              </IconButton>
+            </Paper>
+          </Grid>
         ))}
-        {colors.length < 5 && (
+      </Grid>
+      <Box sx={{ mt: 2 }}>
+        {colors.length < 7 && (
           <Button variant="outlined" onClick={handleAddColor} startIcon={<Add />}>
             Adicionar Cor
           </Button>

--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -55,7 +55,6 @@ const PaletteWizard = ({
   initialStep = 0
 }) => {
   const isMobile = useIsMobile();
-  const isMobile = useIsMobile();
   const [activeStep, setActiveStep] = useState(initialStep);
   const [briefing, setBriefing] = useState({});
   const [isGenerating, setIsGenerating] = useState(false);

--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useIsMobile } from '../hooks/use-mobile';
 import {
   Dialog,
@@ -19,7 +19,11 @@ import {
   MenuItem,
   CircularProgress,
   Alert,
+  Divider,
 } from '@mui/material';
+import { UploadFile as UploadFileIcon } from '@mui/icons-material';
+import { toast } from 'sonner';
+import ColorThief from 'colorthief';
 import PaletteEditor from './PaletteEditor';
 import * as generationHandlers from '../utils/generationHandlers';
 
@@ -51,10 +55,13 @@ const PaletteWizard = ({
   initialStep = 0
 }) => {
   const isMobile = useIsMobile();
+  const isMobile = useIsMobile();
   const [activeStep, setActiveStep] = useState(initialStep);
   const [briefing, setBriefing] = useState({});
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isExtracting, setIsExtracting] = useState(false);
   const [generationError, setGenerationError] = useState(null);
+  const imageInputRef = useRef(null);
 
   // --- Internal State for Uncontrolled Mode ---
   const [internalPaletteData, setInternalPaletteData] = useState(null);
@@ -125,7 +132,7 @@ const PaletteWizard = ({
       // Transform the AI response into the format expected by the frontend UI.
       const transformedData = {
         name: `Paleta ${harmonyName}`, // Creates a short, safe name like "Paleta Triádica".
-        colors: generatedData.palette ? generatedData.palette.map(c => c.hex) : [],
+        colors: generatedData.palette || [], // Keep the full color objects
       };
 
       // Handle cases where the AI might return a valid JSON structure but with no colors.
@@ -145,6 +152,60 @@ const PaletteWizard = ({
     }
   };
 
+  const handleImageUpload = (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    setIsExtracting(true);
+    setGenerationError(null);
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => {
+        try {
+          const colorThief = new ColorThief();
+          // Extract 5 colors from the image
+          const palette = colorThief.getPalette(img, 5);
+
+          // Format the extracted colors into the required data structure
+          const newColors = palette.map((rgb, index) => ({
+            hex: `#${rgb.map(c => c.toString(16).padStart(2, '0')).join('')}`,
+            name: `Cor Extraída ${index + 1}`,
+            role: 'Extraída',
+            justification: 'Cor extraída de imagem de referência.',
+          }));
+
+          setPaletteData({
+            name: 'Paleta da Imagem',
+            colors: newColors,
+          });
+
+          toast.success('Cores extraídas com sucesso!');
+          setActiveStep(1); // Move to the next step to show the editor
+        } catch (error) {
+          console.error("Erro ao extrair paleta da imagem:", error);
+          toast.error('Não foi possível extrair as cores. Tente outra imagem.');
+          setGenerationError('Falha ao processar a imagem.');
+        } finally {
+          setIsExtracting(false);
+        }
+      };
+      img.onerror = () => {
+        toast.error('O arquivo selecionado não é uma imagem válida.');
+        setIsExtracting(false);
+      };
+      img.src = e.target.result;
+    };
+
+    reader.onerror = () => {
+      toast.error('Falha ao ler o arquivo.');
+      setIsExtracting(false);
+    };
+
+    reader.readAsDataURL(file);
+  };
+
   const handleSave = () => {
     // onSave should receive the current palette data, regardless of mode.
     onSave(paletteData);
@@ -154,6 +215,10 @@ const PaletteWizard = ({
   const handleBack = () => {
     setGenerationError(null);
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
+  };
+
+  const handleNext = () => {
+    setActiveStep((prevActiveStep) => prevActiveStep + 1);
   };
 
   const handleChange = (event) => {
@@ -192,6 +257,35 @@ const PaletteWizard = ({
               placeholder="Ex: 'Evitar tons de vermelho', 'Incluir um dourado metálico', etc."
               margin="normal"
             />
+
+            <Divider sx={{ my: 3 }}>
+              <Typography variant="overline">OU</Typography>
+            </Divider>
+
+            <Box sx={{ textAlign: 'center' }}>
+              <input
+                type="file"
+                hidden
+                accept="image/*"
+                ref={imageInputRef}
+                onChange={handleImageUpload}
+                disabled={isExtracting || isGenerating}
+              />
+              <Button
+                variant="outlined"
+                startIcon={<UploadFileIcon />}
+                onClick={() => imageInputRef.current.click()}
+                disabled={isExtracting || isGenerating}
+              >
+                Extrair de Imagem
+              </Button>
+              {isExtracting && (
+                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', mt: 1 }}>
+                  <CircularProgress size={20} />
+                  <Typography sx={{ ml: 1 }} variant="body2">Extraindo cores...</Typography>
+                </Box>
+              )}
+            </Box>
           </Box>
         );
       case 1:
@@ -249,13 +343,24 @@ const PaletteWizard = ({
         <Button onClick={onClose} color="secondary">Cancelar</Button>
         <Box sx={{ flex: '1 1 auto' }} />
         {activeStep > 0 && (
-          <Button onClick={handleBack} disabled={isGenerating}>Voltar</Button>
+          <Button onClick={handleBack} disabled={isGenerating || isExtracting}>Voltar</Button>
         )}
         {activeStep === 0 && (
-          <Button onClick={handleGenerate} variant="contained" disabled={isNextDisabled()}>Gerar Paleta</Button>
+          <>
+            {paletteData && paletteData.colors?.length > 0 && (
+              <Button onClick={handleNext}>
+                Ajustar Paleta Atual
+              </Button>
+            )}
+            <Button onClick={handleGenerate} variant="contained" disabled={isNextDisabled() || isExtracting}>
+              Gerar Nova Paleta
+            </Button>
+          </>
         )}
         {activeStep === 1 && (
-          <Button onClick={handleSave} variant="contained" disabled={isSaveDisabled()}>Salvar Paleta</Button>
+          <Button onClick={handleSave} variant="contained" disabled={isSaveDisabled()}>
+            Salvar Paleta
+          </Button>
         )}
       </DialogActions>
     </Dialog>

--- a/src/utils/paletteState.js
+++ b/src/utils/paletteState.js
@@ -37,7 +37,7 @@ export const getPaletteById = async (id) => {
 /**
  * Saves a new palette to the database.
  * @param {string} name - The name of the new palette.
- * @param {Array<string>} colors - An array of hex color strings.
+ * @param {Array<object>} colors - An array of color objects, each with hex, name, role, etc.
  * @returns {Promise<object>} The newly created palette object.
  */
 export const savePalette = async (name, colors) => {
@@ -53,7 +53,7 @@ export const savePalette = async (name, colors) => {
  * Updates an existing palette.
  * @param {number} id - The ID of the palette to update.
  * @param {string} name - The new name for the palette.
- * @param {Array<string>} colors - The new array of hex color strings.
+ * @param {Array<object>} colors - The new array of color objects.
  * @returns {Promise<object>} The updated palette object.
  */
 export const updatePalette = async (id, name, colors) => {


### PR DESCRIPTION
This commit introduces several enhancements to the color palette creation and management feature, based on user requirements.

1.  **Image-based Color Extraction:**
    -   Users can now upload an image in the Palette Wizard.
    -   The application uses the `colorthief` library to extract the 5 most prominent colors from the image, creating a new palette.
    -   This provides a quick and intuitive way to create palettes based on visual references.

2.  **Detailed Color Information ("Memorial Descritivo"):**
    -   The color data structure has been expanded from a simple hex string to an object containing `hex`, `name`, `role`, and `justification`.
    -   The `PaletteEditor` has been completely redesigned to allow users to view and edit this detailed information for each color.
    -   The AI generation prompt was already providing this data; the application now correctly utilizes and stores it.

3.  **Improved Wizard Navigation:**
    -   The state of the palette is now preserved when navigating between steps in the wizard.
    -   A new button allows users to return to the editor with their existing palette without needing to regenerate it, improving the user workflow.