### PR TITLE
feat: Add palette selection to campaign page

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -24,10 +24,14 @@ import {
   CircularProgress,
   Tabs,
   Tab,
+  Divider,
 } from '@mui/material';
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { getCampaignPrompt } from '../utils/campaignPrompt';
 import { useSettings } from '../context/SettingsContext';
+import { useCampaign as useCampaignContext } from '../context/CampaignContext';
+import { getPalettes, savePalette, updatePalette } from '../utils/paletteState';
+import PaletteWizard from './PaletteWizard';
 import { uploadImageToDrive, getOrCreateBackgroundsFolderId } from '../utils/googleApi';
 import {
     Campaign as CampaignIcon,
@@ -193,6 +197,12 @@ const Campaign = ({
     setSelectedPersonaForCampaign,
 }) => {
     useSettings();
+    const {
+        paletteId,
+        setPaletteId,
+        customPalette,
+        setCustomPalette,
+    } = useCampaignContext();
     const [activeTab, setActiveTab] = useState(0);
     const [isHintModalOpen, setHintModalOpen] = React.useState(false);
     const [isSolucaoHintModalOpen, setSolucaoHintModalOpen] = React.useState(false);
@@ -204,6 +214,8 @@ const Campaign = ({
     const [isLoadingSolutions, setIsLoadingSolutions] = React.useState(false);
     const [solutionsError, setSolutionsError] = React.useState(null);
     const [imageTabError, setImageTabError] = React.useState('');
+    const [palettes, setPalettes] = useState([]);
+    const [isPaletteWizardOpen, setPaletteWizardOpen] = useState(false);
 
     const emptyLabelStyle = {
         '& .MuiInputLabel-root:not(.Mui-focused):not(.MuiFormLabel-filled)': {
@@ -321,6 +333,19 @@ const Campaign = ({
             fetchSolutionsOnOpen();
         }
     }, [isSolucaoHintModalOpen, fetchSolutionsOnOpen]);
+
+    useEffect(() => {
+        const fetchAndSetPalettes = async () => {
+            try {
+                const fetchedPalettes = await getPalettes();
+                setPalettes(fetchedPalettes);
+            } catch (error) {
+                console.error("Failed to fetch palettes:", error);
+                // Optionally, show an error to the user
+            }
+        };
+        fetchAndSetPalettes();
+    }, []);
 
     const handleSaveToDrive = async () => {
         setIsSavingToDrive(true);
@@ -646,10 +671,37 @@ const Campaign = ({
                 <TabPanel value={activeTab} index={2}>
                     {campaignContent && (
                         <Box sx={{ mt: 2 }}>
-                             <Grid item xs={12} md={6}>
-                                <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
-                                    <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
-                                    <Select
+                            <Grid container spacing={2}>
+                                <Grid item xs={12} md={6}>
+                                    <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
+                                        <InputLabel id="palette-select-label">Paleta de Cores</InputLabel>
+                                        <Select
+                                            labelId="palette-select-label"
+                                            value={paletteId || 'custom'}
+                                            onChange={(e) => setPaletteId(e.target.value)}
+                                            label="Paleta de Cores"
+                                        >
+                                            <MenuItem value="custom">Paleta Customizada da Campanha</MenuItem>
+                                            <Divider />
+                                            {palettes.map((p) => (
+                                                <MenuItem key={p.id} value={p.id}>
+                                                    {p.name}
+                                                </MenuItem>
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                                <Grid item xs={12} md={6}>
+                                    {paletteId === 'custom' && (
+                                        <Button onClick={() => setPaletteWizardOpen(true)} variant="contained">
+                                            {customPalette ? 'Editar Paleta Customizada' : 'Criar Paleta Customizada'}
+                                        </Button>
+                                    )}
+                                </Grid>
+                                <Grid item xs={12} md={6}>
+                                    <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
+                                        <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
+                                        <Select
                                         labelId="aspect-ratio-label"
                                         value={aspectRatio}
                                         onChange={(e) => setAspectRatio(e.target.value)}
@@ -670,7 +722,12 @@ const Campaign = ({
                                             <Button onClick={handleSaveToDrive} disabled={isSavingToDrive || isGeneratingImage} startIcon={<SaveIcon />}>
                                                 {isSavingToDrive ? 'Salvando...' : 'Salvar na Coleção'}
                                             </Button>
-                                            <Button onClick={() => handleGenerateImage(campaignContent)} disabled={isGeneratingImage || isSavingToDrive} startIcon={<GeminiIcon />} sx={{ ml: 1 }}>
+                                            <Button onClick={() => {
+                                                const selectedPalette = paletteId === 'custom'
+                                                    ? customPalette
+                                                    : palettes.find(p => p.id === paletteId);
+                                                handleGenerateImage(campaignContent, selectedPalette?.colors || []);
+                                            }} disabled={isGeneratingImage || isSavingToDrive} startIcon={<GeminiIcon />} sx={{ ml: 1 }}>
                                                 {isGeneratingImage ? 'Gerando...' : 'Regerar Página'}
                                             </Button>
                                         </Box>
@@ -689,7 +746,12 @@ const Campaign = ({
                                     <Button
                                         variant="contained"
                                         color="secondary"
-                                        onClick={() => handleGenerateImage(campaignContent)}
+                                        onClick={() => {
+                                            const selectedPalette = paletteId === 'custom'
+                                                ? customPalette
+                                                : palettes.find(p => p.id === paletteId);
+                                            handleGenerateImage(campaignContent, selectedPalette?.colors || []);
+                                        }}
                                         startIcon={<ImageIcon />}
                                         disabled={isGeneratingImage}
                                     >
@@ -706,7 +768,12 @@ const Campaign = ({
                                         variant="contained"
                                         color="secondary"
                                         size="large"
-                                        onClick={() => handleGenerateImage(campaignContent)}
+                                        onClick={() => {
+                                            const selectedPalette = paletteId === 'custom'
+                                                ? customPalette
+                                                : palettes.find(p => p.id === paletteId);
+                                            handleGenerateImage(campaignContent, selectedPalette?.colors || []);
+                                        }}
                                         disabled={isGeneratingImage}
                                         startIcon={<ImageIcon />}
                                     >
@@ -714,6 +781,7 @@ const Campaign = ({
                                     </Button>
                                 </Box>
                             )}
+                            </Grid>
                         </Box>
                     )}
                 </TabPanel>
@@ -975,6 +1043,20 @@ const Campaign = ({
                         <Button onClick={() => setSolucaoHintModalOpen(false)}>Fechar</Button>
                     </DialogActions>
                 </Dialog>
+                {isPaletteWizardOpen && (
+                    <PaletteWizard
+                        open={isPaletteWizardOpen}
+                        onClose={() => setPaletteWizardOpen(false)}
+                        onSave={async (paletteData) => {
+                            // For custom palettes, we just update the context state
+                            setCustomPalette(paletteData);
+                            setPaletteWizardOpen(false);
+                        }}
+                        paletteData={customPalette || { name: 'Paleta da Campanha', colors: [], harmony: '', harmony_justification: '' }}
+                        onPaletteDataChange={setCustomPalette}
+                        initialStep={0} // Always start from the beginning for the campaign's custom palette
+                    />
+                )}
             </CardContent>
         </Card>
     );

--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -32,6 +32,8 @@ export const CampaignProvider = ({ children }) => {
   const [aspectRatio, setAspectRatio] = useState('1:1');
   const [pendingAssets, setPendingAssets] = useState({});
   const [colors, setColors] = useState([]);
+  const [paletteId, setPaletteId] = useState(null);
+  const [customPalette, setCustomPalette] = useState(null);
 
 
   const value = useMemo(() => ({
@@ -49,6 +51,8 @@ export const CampaignProvider = ({ children }) => {
     aspectRatio,
     pendingAssets,
     colors,
+    paletteId,
+    customPalette,
 
     // Setters
     setCsvData,
@@ -64,6 +68,8 @@ export const CampaignProvider = ({ children }) => {
     setAspectRatio,
     setPendingAssets,
     setColors,
+    setPaletteId,
+    setCustomPalette,
 
     // Constants
     defaultPageTemplate,
@@ -81,6 +87,8 @@ export const CampaignProvider = ({ children }) => {
     aspectRatio,
     pendingAssets,
     colors,
+    paletteId,
+    customPalette,
   ]);
 
   return (

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 // Re-submitting the fix for the persona saving bug.
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {
@@ -22,6 +22,7 @@ import { getCampaigns, saveCampaign, loadCampaign, updateCampaign } from '../uti
 import { checkAuthStatus } from '../utils/auth';
 import { getPersonas, savePersona, updatePersona } from '../utils/personaState';
 import { getAutores } from '../utils/autorState';
+import { getPalettes } from '../utils/paletteState';
 
 import MyCampaignsStep from '../components/MyCampaignsStep';
 import PersonasPage from './PersonasPage';
@@ -114,9 +115,12 @@ function HomePage() {
     aspectRatio, setAspectRatio,
     pendingAssets, setPendingAssets,
     defaultPageTemplate,
+    paletteId,
+    customPalette,
   } = useCampaign();
 
   // Component State
+  const [palettes, setPalettes] = useState([]);
   const [personaList, setPersonaList] = useState([]);
   const [autorList, setAutorList] = useState([]);
   const [currentView, setCurrentView] = useState('campaigns');
@@ -528,6 +532,7 @@ function HomePage() {
     if (user) {
       fetchPersonasForCampaign();
       fetchAutoresForCampaign();
+      getPalettes().then(setPalettes).catch(err => toast.error("Failed to load palettes."));
     }
   }, [user, fetchPersonasForCampaign, fetchAutoresForCampaign]);
 
@@ -1100,7 +1105,7 @@ function HomePage() {
       setGenerationStatus('');
     }
   };
-  const handleGenerateImage = useCallback(async (content) => {
+  const handleGenerateImage = useCallback(async (content, colors = []) => {
     const finalContent = content || campaignContentRef.current;
     if (!finalContent) {
       toast.error("Por favor, gere o conteúdo do texto primeiro.");
@@ -1109,10 +1114,10 @@ function HomePage() {
     setIsGeneratingImage(true);
     try {
       const finalAutor = autorList.find(a => a.id === selectedAutorForCampaign);
-      const imagePrompt = await generateCampaignImagePrompt({ content: finalContent, aspectRatio, autor: finalAutor });
+      const imagePrompt = await generateCampaignImagePrompt({ content: finalContent, aspectRatio, autor: finalAutor, colors });
 
       // 1. Get the raw base64 data from the generation service
-      const base64Data = await generateCampaignImage({ prompt: imagePrompt, aspectRatio });
+      const base64Data = await generateCampaignImage({ prompt: imagePrompt, aspectRatio, colors });
 
       // 2. Convert base64 to a Blob
       const blob = dataURLtoBlob(base64Data);
@@ -1343,7 +1348,19 @@ function HomePage() {
     }
   };
   const currentTheme = darkMode ? darkTheme : lightTheme;
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: standardsColors, generatedPagesData, };
+
+  const memorialColors = useMemo(() => {
+    if (paletteId && paletteId !== 'custom') {
+      const selectedPalette = palettes.find(p => p.id === paletteId);
+      return selectedPalette ? selectedPalette.colors : standardsColors;
+    }
+    if (customPalette) {
+      return customPalette.colors;
+    }
+    return standardsColors;
+  }, [paletteId, customPalette, palettes, standardsColors]);
+
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: memorialColors, generatedPagesData, };
 
   return (
     <ThemeProvider theme={currentTheme}>

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -170,7 +170,7 @@ export const generateCampaignContent = async ({ problema, solucao, objetivo, tom
 /**
  * Generates a prompt for the campaign image using an AI API.
  */
-export const generateCampaignImagePrompt = async ({ content, aspectRatio, autor = null }) => {
+export const generateCampaignImagePrompt = async ({ content, aspectRatio, autor = null, colors = [] }) => {
     if (!content) {
         throw new Error("O conteúdo da campanha deve ser gerado primeiro.");
     }
@@ -184,12 +184,17 @@ export const generateCampaignImagePrompt = async ({ content, aspectRatio, autor 
     const finalAutor = autor || defaultAutor;
     const autorString = formatObjectForPrompt(finalAutor);
 
+    const colorPalettePrompt = colors && colors.length > 0
+        ? `A imagem deve usar predominantemente a seguinte paleta de cores: ${colors.map(c => `${c.name} (${c.hex})`).join(', ')}. Justificativa da paleta: ${colors[0]?.palette_justification || 'N/A'}`
+        : 'A paleta de cores é livre e deve ser escolhida pelo artista para melhor se adequar ao tema.';
+
     const promptTemplate = await getPrompt('generateCampaignImagePrompt');
     const prompt = fillPrompt(promptTemplate, {
       titulo: stripHtml(content.titulo),
       conteudo: stripHtml(content.conteudo),
       autorString: autorString,
       aspectRatio: aspectRatio,
+      colorPalettePrompt: colorPalettePrompt,
     });
 
     const imagePrompt = await geminiAPI.generateContent(prompt, 'Geração de Prompt de Imagem de Campanha');
@@ -199,7 +204,7 @@ export const generateCampaignImagePrompt = async ({ content, aspectRatio, autor 
 /**
  * Generates an image for the campaign using an AI API.
  */
-export const generateCampaignImage = async ({ prompt, aspectRatio }) => {
+export const generateCampaignImage = async ({ prompt, aspectRatio, colors = [] }) => {
   if (!prompt) {
     throw new Error("O prompt da imagem deve ser gerado primeiro.");
   }
@@ -208,8 +213,6 @@ export const generateCampaignImage = async ({ prompt, aspectRatio }) => {
     throw new Error('Chave de API Gemini não configurada.');
   }
   geminiAPI.initialize(apiKey);
-
-  const { colors } = getCampaignPrompt();
 
   const colorPalettePrompt = colors && colors.length > 0
     ? `The image should predominantly use the following color palette: ${colors.map(c => c.hex).join(', ')}.`


### PR DESCRIPTION
This commit introduces a feature that allows users to select a color palette for a campaign.

Key features:
- In the campaign editing "page" tab, users can now select a palette from a predefined list.
- A "Custom Palette" option is available, allowing users to create a campaign-specific palette using the `PaletteWizard` component.
- The selected palette (either predefined or custom) is used to influence the colors of the generated campaign image.
- The campaign memorial ("Memorial Descritivo") has been updated to display the colors from the selected palette.

To achieve this, the following changes were made:
- The `CampaignContext` has been extended to manage `paletteId` and `customPalette` state.
- The `Campaign.jsx` component has been updated with the UI for palette selection and the `PaletteWizard` dialog.
- The `HomePage.jsx` component now fetches the list of palettes and passes the correct colors to the campaign memorial.
- The `generationHandlers.js` file has been updated to incorporate the selected palette's colors into the image generation prompts.