### PR TITLE
Refactor: Remove campaign colors tab and integrate palette selection

### DIFF
--- a/api/campaigns/[id].js
+++ b/api/campaigns/[id].js
@@ -20,7 +20,7 @@ const handler = async (req, res) => {
   if (req.method === 'GET') {
     try {
       const { rows } = await query(
-        'SELECT id, name, campaign_data, autor_id, persona_id, updated_at FROM campaigns WHERE id = $1 AND user_id = $2',
+        'SELECT id, name, campaign_data, autor_id, persona_id, palette_id, updated_at FROM campaigns WHERE id = $1 AND user_id = $2',
         [id, userId]
       );
       if (rows.length === 0) {
@@ -33,7 +33,7 @@ const handler = async (req, res) => {
     }
   } else if (req.method === 'PUT') {
     try {
-      const { name, campaign_data, autor_id, persona_id } = await parseBody(req);
+      const { name, campaign_data, autor_id, persona_id, palette_id } = await parseBody(req);
       if (!name || !campaign_data) {
         return res.status(400).json({ error: 'Campaign name and data are required.' });
       }
@@ -41,10 +41,11 @@ const handler = async (req, res) => {
       // Ensure empty strings for foreign keys are converted to null
       const finalAutorId = autor_id === '' ? null : autor_id;
       const finalPersonaId = persona_id === '' ? null : persona_id;
+      const finalPaletteId = palette_id === '' ? null : palette_id;
 
       const { rows } = await query(
-        'UPDATE campaigns SET name = $1, campaign_data = $2, autor_id = $3, persona_id = $4, updated_at = NOW() WHERE id = $5 AND user_id = $6 RETURNING id, name, updated_at',
-        [name, campaign_data, finalAutorId, finalPersonaId, id, userId]
+        'UPDATE campaigns SET name = $1, campaign_data = $2, autor_id = $3, persona_id = $4, palette_id = $5, updated_at = NOW() WHERE id = $6 AND user_id = $7 RETURNING id, name, updated_at',
+        [name, campaign_data, finalAutorId, finalPersonaId, finalPaletteId, id, userId]
       );
       if (rows.length === 0) {
         return res.status(404).json({ error: 'Campaign not found or access denied.' });

--- a/api/campaigns/index.js
+++ b/api/campaigns/index.js
@@ -29,17 +29,18 @@ const handler = async (req, res) => {
     }
   } else if (req.method === 'POST') {
     try {
-      const { name, campaign_data, autor_id, persona_id } = await parseBody(req);
+      const { name, campaign_data, autor_id, persona_id, palette_id } = await parseBody(req);
       if (!name || !campaign_data) {
         return res.status(400).json({ error: 'Campaign name and data are required.' });
       }
       // Convert empty strings to null for foreign key fields
       const final_autor_id = autor_id === '' ? null : autor_id;
       const final_persona_id = persona_id === '' ? null : persona_id;
+      const final_palette_id = palette_id === '' ? null : palette_id;
 
       const { rows } = await query(
-        'INSERT INTO campaigns (user_id, name, campaign_data, autor_id, persona_id) VALUES ($1, $2, $3, $4, $5) RETURNING id, name, updated_at',
-        [userId, name, campaign_data, final_autor_id, final_persona_id]
+        'INSERT INTO campaigns (user_id, name, campaign_data, autor_id, persona_id, palette_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, name, updated_at',
+        [userId, name, campaign_data, final_autor_id, final_persona_id, final_palette_id]
       );
       return res.status(201).json(rows[0]);
     } catch (error) {

--- a/src/components/CampaignStandardsModal.jsx
+++ b/src/components/CampaignStandardsModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useIsMobile } from '../hooks/use-mobile.js';
 import {
   Dialog,
@@ -7,102 +7,41 @@ import {
   DialogActions,
   Button,
   Box,
-  Tabs,
-  Tab,
   Typography,
   IconButton,
-  Tooltip,
-  Chip,
-  Link as MuiLink,
-  TextField,
-  Grid,
   FormControl,
   InputLabel,
   Select,
   MenuItem,
-  CircularProgress,
-  Card,
-  CardContent,
   Divider,
-  Stack,
-  Alert,
 } from '@mui/material';
-import TextEditor from './TextEditor';
-import {
-  Close as CloseIcon,
-  TextFields as TextFieldsIcon,
-  Palette as PaletteIcon,
-  InfoOutlined as InfoOutlinedIcon,
-  UploadFile as UploadFileIcon,
-  Link as LinkIcon,
-  AutoAwesome as AutoAwesomeIcon,
-  Description as DescriptionIcon,
-  Add,
-  DeleteForever as DeleteForeverIcon,
-} from '@mui/icons-material';
+import { Close as CloseIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
-import ColorThief from 'colorthief';
 
 import TextEditorDialog from './TextEditorDialog';
 import HtmlDisplayField from './HtmlDisplayField';
-import PaletteWizard from './PaletteWizard';
-import MemorialDescritivoModal from './MemorialDescritivoModal';
-import * as generationHandlers from '../utils/generationHandlers';
-import { useSettings } from '../context/SettingsContext';
 import { useCampaign } from '../context/CampaignContext';
 import { getPalettes } from '../utils/paletteState';
-import isEqual from 'lodash.isequal';
-
-function TabPanel(props) {
-  const { children, value, index, ...other } = props;
-
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`vertical-tabpanel-${index}`}
-      aria-labelledby={`vertical-tab-${index}`}
-      style={{ width: '100%' }}
-      {...other}
-    >
-      {value === index && (
-        <Box sx={{ p: 3, width: '100%', overflowY: 'auto' }}>
-          {children}
-        </Box>
-      )}
-    </div>
-  );
-}
 
 const CampaignStandardsModal = ({ open, onClose }) => {
   const isMobile = useIsMobile();
-  const { settings } = useSettings();
-  const { formato, setFormato, colors, setColors, currentCampaign, setCurrentCampaign } = useCampaign();
-  const [value, setValue] = useState(0);
+  const { formato, setFormato, paletteId, setPaletteId } = useCampaign();
 
-  // Other states
   const [editingField, setEditingField] = useState(null);
-  const imageInputRef = useRef(null);
-  const [initialState, setInitialState] = useState(null);
-  const [isConfirmCloseOpen, setIsConfirmCloseOpen] = useState(false);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [showPaletteWizard, setShowPaletteWizard] = useState(false);
   const [palettes, setPalettes] = useState([]);
-  const [selectedPalette, setSelectedPalette] = useState('');
+  const [selectedPalette, setSelectedPalette] = useState(paletteId || '');
 
   useEffect(() => {
     if (open) {
       getPalettes().then(setPalettes).catch(err => toast.error('Failed to fetch palettes.'));
-      // The API is now initialized in a central place (e.g., HomePage)
-      // via initializeGenerationHandlers based on settings.
-      // So, no need to initialize it here.
+      setSelectedPalette(paletteId || '');
     }
-  }, [open]);
-
-  const handleChange = (event, newValue) => setValue(newValue);
+  }, [open, paletteId]);
 
   const handleSave = () => {
-    setCurrentCampaign({ ...currentCampaign, formato, palette_id: selectedPalette });
+    setPaletteId(selectedPalette);
+    // Note: formato is updated directly via its own TextEditorDialog,
+    // so we only need to explicitly save the paletteId here.
     toast.success('Padrões de campanha salvos com sucesso!');
     onClose();
   };
@@ -130,126 +69,58 @@ const CampaignStandardsModal = ({ open, onClose }) => {
     return 'Editar';
   };
 
-  const handleColorChange = (index, newColor) => {
-    const newColors = [...colors];
-    newColors[index] = { ...newColors[index], hex: newColor, rgb: `RGB(${parseInt(newColor.substr(1, 2), 16)}, ${parseInt(newColor.substr(3, 2), 16)}, ${parseInt(newColor.substr(5, 2), 16)})` };
-    setColors(newColors);
-  };
-
-  const addColor = () => {
-    if (colors.length < 5) setColors([...colors, { hex: '#000000', rgb: 'RGB(0, 0, 0)', name: 'Nova Cor', role: 'Manual', justification: 'Adicionada manualmente' }]);
-  };
-
-  const removeColor = (index) => setColors(colors.filter((_, i) => i !== index));
-
-  const handleImageUpload = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const img = new Image();
-        img.onload = () => {
-          try {
-            const colorThief = new ColorThief();
-            const palette = colorThief.getPalette(img, 5);
-            const newColors = palette.map((rgb, index) => ({ hex: `#${rgb.map(c => c.toString(16).padStart(2, '0')).join('')}`, rgb: `RGB(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`, name: `Cor Extraída ${index + 1}`, role: 'Extraída', justification: 'Extraída da imagem de referência.' }));
-            setColors(newColors);
-            toast.success('Paleta de cores extraída com sucesso!');
-          } catch (error) {
-            console.error("Erro ao extrair paleta:", error);
-            toast.error('Não foi possível extrair as cores. Tente outra imagem.');
-          }
-        };
-        img.src = e.target.result;
-      };
-      reader.readAsDataURL(file);
-    }
-  };
-
-  const a11yProps = (index) => ({ id: `vertical-tab-${index}`, 'aria-controls': `vertical-tabpanel-${index}` });
-
   return (
     <>
-      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg" fullScreen={isMobile}>
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md" fullScreen={isMobile}>
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           Padrões de Campanha
           <IconButton onClick={handleClose}><CloseIcon /></IconButton>
         </DialogTitle>
-        <DialogContent sx={{ p: 0, display: 'flex', flexDirection: 'column' }}>
-          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs orientation="horizontal" variant="scrollable" value={value} onChange={handleChange}>
-              <Tab icon={<TextFieldsIcon />} iconPosition="start" label="Formato" {...a11yProps(0)} />
-              <Tab icon={<PaletteIcon />} iconPosition="start" label="Cores" {...a11yProps(1)} />
-            </Tabs>
+        <DialogContent dividers sx={{ p: 3 }}>
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              Formato
+            </Typography>
+            <HtmlDisplayField htmlContent={formato} onClick={() => handleOpenEditor('formato')} />
           </Box>
-          <Box sx={{ flexGrow: 1, overflow: 'auto' }}>
-            <TabPanel value={value} index={0}>
-              <HtmlDisplayField title="Formato" htmlContent={formato} onClick={() => handleOpenEditor('formato')} />
-            </TabPanel>
-            <TabPanel value={value} index={1}>
-              <FormControl fullWidth sx={{ mb: 2 }}>
-                <InputLabel>Paleta de Cores Salva</InputLabel>
-                <Select
-                  value={selectedPalette}
-                  onChange={(e) => {
-                    const paletteId = e.target.value;
-                    setSelectedPalette(paletteId);
-                    const selected = palettes.find(p => p.id === paletteId);
-                    if (selected) {
-                      setColors(selected.colors.map(hex => ({ hex, name: `Cor (${hex})`, role: 'Salva', justification: '' })));
-                    } else {
-                      setColors([]);
-                    }
-                  }}
-                  label="Paleta de Cores Salva"
-                >
-                  <MenuItem value="">
-                    <em>Nenhuma</em>
+
+          <Divider sx={{ my: 3 }} />
+
+          <Box>
+            <Typography variant="h6" gutterBottom>
+              Cores
+            </Typography>
+            <FormControl fullWidth>
+              <InputLabel>Paleta de Cores da Campanha</InputLabel>
+              <Select
+                value={selectedPalette}
+                onChange={(e) => setSelectedPalette(e.target.value)}
+                label="Paleta de Cores da Campanha"
+              >
+                <MenuItem value="">
+                  <em>Nenhuma</em>
+                </MenuItem>
+                {(palettes || []).map(palette => (
+                  <MenuItem key={palette.id} value={palette.id}>
+                    {palette.name}
                   </MenuItem>
-                  {(palettes || []).map(palette => (
-                    <MenuItem key={palette.id} value={palette.id}>
-                      {palette.name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-              <Stack spacing={2} sx={{ mb: 3 }}>
-                <Button variant="contained" startIcon={<AutoAwesomeIcon />} onClick={() => setShowPaletteWizard(true)} sx={{ alignSelf: 'flex-start' }}>Gerar Paleta com IA</Button>
-              </Stack>
-              <Divider />
-              <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>Cores da Campanha Ativa</Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, mt: 2, alignItems: 'center' }}>
-                {(colors || []).map((color, index) => (
-                  <Box key={index} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-                    <input type="color" value={color.hex} onChange={(e) => handleColorChange(index, e.target.value)} style={{ width: '50px', height: '50px', border: 'none', cursor: 'pointer' }} />
-                    <Typography variant="caption">{color.name || color.hex}</Typography>
-                    <Button size="small" onClick={() => removeColor(index)}>Remover</Button>
-                  </Box>
                 ))}
-                {colors.length < 5 && <Button variant="outlined" onClick={addColor}>Adicionar Cor</Button>}
-              </Box>
-              <Box sx={{ mt: 4 }}>
-                <Typography variant="h6">Extrair Cores de Imagem</Typography>
-                <Button variant="outlined" startIcon={<UploadFileIcon />} onClick={() => imageInputRef.current.click()}>Upload</Button>
-                <input type="file" hidden accept="image/*" ref={imageInputRef} onChange={handleImageUpload} />
-              </Box>
-            </TabPanel>
+              </Select>
+            </FormControl>
           </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancelar</Button>
-          <Button onClick={handleSave} variant="contained">Salvar Padrões</Button>
+          <Button onClick={handleSave} variant="contained">Salvar</Button>
         </DialogActions>
       </Dialog>
-      <TextEditorDialog open={editingField !== null} title={getEditorTitle()} content={getCurrentContent()} onSave={handleSaveEditor} onClose={handleCloseEditor} html={true} />
-      <PaletteWizard
-        open={showPaletteWizard}
-        onClose={() => setShowPaletteWizard(false)}
-        onSave={(savedPalette) => {
-          const newColors = (savedPalette.colors || []).map(hex => ({ hex, name: `Cor (${hex})`, role: 'Gerada', justification: 'Gerada via assistente de IA.' }));
-          setColors(newColors);
-          toast.success('Paleta de cores aplicada!');
-        }}
+      <TextEditorDialog
+        open={editingField !== null}
+        title={getEditorTitle()}
+        content={getCurrentContent()}
+        onSave={handleSaveEditor}
+        onClose={handleCloseEditor}
+        html={true}
       />
     </>
   );

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -116,6 +116,7 @@ function HomePage() {
     pendingAssets, setPendingAssets,
     defaultPageTemplate,
     paletteId,
+    setPaletteId,
     customPalette,
   } = useCampaign();
 
@@ -435,12 +436,12 @@ function HomePage() {
       let result;
       if (currentCampaign) {
         console.log(`[HomePage] Updating existing campaign, ID: ${currentCampaign.id}`);
-        result = await updateCampaign(currentCampaign.id, name, campaignDataToSave, pendingAssets, setUploadProgress, user.uuid, selectedAutorForCampaign, selectedPersonaForCampaign);
+        result = await updateCampaign(currentCampaign.id, name, campaignDataToSave, pendingAssets, setUploadProgress, user.uuid, selectedAutorForCampaign, selectedPersonaForCampaign, paletteId);
         toast.success(`Campaign "${name}" updated.`);
         setCurrentCampaign(result.campaign);
       } else {
         console.log(`[HomePage] Saving new campaign.`);
-        result = await saveCampaign(name, campaignDataToSave, pendingAssets, setUploadProgress, user.uuid, selectedAutorForCampaign, selectedPersonaForCampaign);
+        result = await saveCampaign(name, campaignDataToSave, pendingAssets, setUploadProgress, user.uuid, selectedAutorForCampaign, selectedPersonaForCampaign, paletteId);
         toast.success(`Campaign "${name}" saved.`);
         setCurrentCampaign(result.campaign);
       }
@@ -487,6 +488,7 @@ function HomePage() {
       // Explicitly set the author and persona IDs from the top-level of the loaded campaign
       setSelectedAutorForCampaign(loadedCampaign.autor_id || '');
       setSelectedPersonaForCampaign(loadedCampaign.persona_id || '');
+      setPaletteId(loadedCampaign.palette_id || null);
 
       setCurrentCampaign({ id: loadedCampaign.id, name: loadedCampaign.name });
       toast.success(`Campaign "${loadedCampaign.name}" loaded successfully!`);
@@ -771,6 +773,7 @@ function HomePage() {
     setCurrentCampaign(null);
     setPageTemplate(defaultPageTemplate); // Explicitly reset page template
     setOriginalImageSize(DEFAULT_IMAGE_SIZE);
+    setPaletteId(null); // Reset palette selection
     setActiveStep(1);
   };
   const handleEditCampaign = (campaign) => {

--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -322,7 +322,7 @@ export const loadCampaign = async (id) => {
   return campaign;
 };
 
-export const saveCampaign = async (name, campaignData, pendingAssets, setProgress, userId, autorId, personaId) => {
+export const saveCampaign = async (name, campaignData, pendingAssets, setProgress, userId, autorId, personaId, paletteId) => {
   console.log('[campaignState] Starting saveCampaign process...');
   try {
     console.log('[campaignState] Step 1: Serializing and uploading assets...');
@@ -335,7 +335,8 @@ export const saveCampaign = async (name, campaignData, pendingAssets, setProgres
       name,
       campaign_data: serializedState, // Use the state with permanent URLs
       autor_id: autorId,
-      persona_id: personaId
+      persona_id: personaId,
+      palette_id: paletteId
     });
 
     const createRes = await fetchWithAuth('/api/campaigns', {
@@ -361,7 +362,7 @@ export const saveCampaign = async (name, campaignData, pendingAssets, setProgres
   }
 };
 
-export const updateCampaign = async (id, name, campaignData, pendingAssets, setProgress, userId, autorId, personaId) => {
+export const updateCampaign = async (id, name, campaignData, pendingAssets, setProgress, userId, autorId, personaId, paletteId) => {
     console.log(`[campaignState] Starting updateCampaign process for ID: ${id}...`);
     try {
         console.log('[campaignState] Step 1: Serializing and uploading assets...');
@@ -373,7 +374,8 @@ export const updateCampaign = async (id, name, campaignData, pendingAssets, setP
           name,
           campaign_data: serializedState, // Use the state with permanent URLs
           autor_id: autorId,
-          persona_id: personaId
+          persona_id: personaId,
+          palette_id: paletteId
         });
 
         const res = await fetchWithAuth(`/api/campaigns/${id}`, {


### PR DESCRIPTION
This commit removes the 'Cores' (Colors) tab from the Campaign Standards modal. The functionality for manually adding, editing, or extracting colors has been deprecated.

Instead, a dropdown menu has been added to allow users to select a pre-defined color palette for the campaign.

To support this change, the following modifications were made:
- The backend API for campaigns has been updated to save and retrieve a `palette_id`.
- Frontend state management for campaigns now includes `paletteId` in the `CampaignContext`.
- The `HomePage` now correctly loads and saves the `paletteId` associated with a campaign.
- The `CampaignStandardsModal` has been refactored to a simpler, non-tabbed interface.