### PR TITLE
Fix: Add missing Persona and Author to Memorial Descritivo

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1345,7 +1345,10 @@ function HomePage() {
     return [];
   }, [paletteId, customPalette, palettes]);
 
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, aspectRatio, followupPosts, colors: memorialColors, generatedPagesData, };
+  const selectedPersona = useMemo(() => personaList.find(p => p.id === selectedPersonaForCampaign), [personaList, selectedPersonaForCampaign]);
+  const selectedAutor = useMemo(() => autorList.find(a => a.id === selectedAutorForCampaign), [autorList, selectedAutorForCampaign]);
+
+  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, aspectRatio, followupPosts, colors: memorialColors, generatedPagesData, persona: selectedPersona, autor: selectedAutor };
 
   return (
     <ThemeProvider theme={currentTheme}>


### PR DESCRIPTION
This commit fixes a bug where the 'Persona' and 'Autor' (Author) sections were not being displayed in the 'Memorial Descritivo' (Descriptive Memo).

The `campaignData` object in `HomePage.jsx` was not being populated with the full `persona` and `autor` objects. This has been corrected by finding the selected objects from the `personaList` and `autorList` arrays and adding them to the `campaignData` object before it is passed to the `MemorialDescritivoModal`.