### PR TITLE
fix: Add defensive guards to prevent UI crashes

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -608,7 +608,7 @@ const Campaign = ({
                             <Grid item xs={12}>
                                 <Typography variant="subtitle2" gutterBottom>Hashtags</Typography>
                                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                                    {campaignContent.hashtags.map((tag, index) => (
+                                    {(campaignContent.hashtags || []).map((tag, index) => (
                                         <Chip
                                             key={index}
                                             label={tag}


### PR DESCRIPTION
This commit adds defensive guards to prevent the application from crashing when rendering campaign data that might be missing expected arrays. This addresses a recurring `TypeError: Cannot read properties of undefined (reading 'map')` that was happening in production.

Specifically:
- In `MyCampaignsStep.jsx`, the component that lists all campaigns, the rendering logic is now more robust and will not crash if the API returns a malformed response.
- In `Campaign.jsx`, the component that displays the details of a single campaign, a guard has been added to the hashtag rendering to prevent a crash when loading older campaigns that were saved before the `hashtags` feature existed.

This also includes the complete removal of the legacy 'Padrões de Campanha' feature and ensures the color palette, author, and persona data flows correctly to the Memorial Descritivo.