### PR TITLE
refactor: Remove Campaign Standards and fix related bugs

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -29,7 +29,6 @@ import {
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { useSettings } from '../context/SettingsContext';
 import { useCampaign as useCampaignContext } from '../context/CampaignContext';
-import { getPalettes } from '../utils/paletteState';
 import PaletteWizard from './PaletteWizard';
 import { uploadImageToDrive, getOrCreateBackgroundsFolderId } from '../utils/googleApi';
 import {
@@ -393,7 +392,7 @@ const Campaign = ({
                                     <MenuItem value="">
                                         <em>Não especificar</em>
                                     </MenuItem>
-                                    {personaList.map((p) => (
+                                    {(personaList || []).map((p) => (
                                         <MenuItem key={p.id} value={p.id}>
                                             {p.name}
                                         </MenuItem>
@@ -435,7 +434,7 @@ const Campaign = ({
                                             <MenuItem value="">
                                                 <em>Não especificar</em>
                                             </MenuItem>
-                                            {autorList.map((p) => (
+                                            {(autorList || []).map((p) => (
                                                 <MenuItem key={p.id} value={p.id}>
                                                     {p.name}
                                                 </MenuItem>
@@ -655,12 +654,17 @@ const Campaign = ({
                                         <Select
                                             labelId="palette-select-label"
                                             value={paletteId || 'custom'}
-                                            onChange={(e) => setPaletteId(e.target.value)}
+                                            onChange={(e) => {
+                                                setPaletteId(e.target.value);
+                                                if (e.target.value !== 'custom') {
+                                                    setCustomPalette(null); // Clear custom palette when a global one is chosen
+                                                }
+                                            }}
                                             label="Paleta de Cores"
                                         >
                                             <MenuItem value="custom">Paleta Customizada da Campanha</MenuItem>
                                             <Divider />
-                                            {palettes.map((p) => (
+                                            {(palettes || []).map((p) => (
                                                 <MenuItem key={p.id} value={p.id}>
                                                     {p.name}
                                                 </MenuItem>
@@ -668,14 +672,14 @@ const Campaign = ({
                                         </Select>
                                     </FormControl>
                                 </Grid>
-                                <Grid item xs={12} md={6}>
+                                <Grid item xs={12} md={6} sx={{ display: 'flex', alignItems: 'center' }}>
                                     {paletteId === 'custom' && (
                                         <Button onClick={() => setPaletteWizardOpen(true)} variant="contained">
                                             {customPalette ? 'Editar Paleta Customizada' : 'Criar Paleta Customizada'}
                                         </Button>
                                     )}
                                 </Grid>
-                                <Grid item xs={12} md={6}>
+                                <Grid item xs={12}>
                                     <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
                                         <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>
                                         <Select
@@ -798,7 +802,7 @@ const Campaign = ({
                                     {isGeneratingFollowup ? 'Gerando...' : 'Regerar Posts'}
                                 </Button>
                             </Box>
-                            {followupPosts.map((post, index) => (
+                            {(followupPosts || []).map((post, index) => (
                                 <Accordion key={index}>
                                     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
@@ -815,7 +819,7 @@ const Campaign = ({
                                         </Typography>
                                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
                                             <Chip icon={<InfoIcon />} label={post.tipo_gancho || 'Gancho'} size="small" variant="outlined" />
-                                            {post.hashtags_sugeridas.map((tag, i) => (
+                                            {(post.hashtags_sugeridas || []).map((tag, i) => (
                                                 <Chip key={i} label={`#${tag}`} size="small" />
                                             ))}
                                         </Box>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -244,6 +244,15 @@ function HomePage() {
     setCsvHeaders(Array.isArray(state.csvHeaders) ? state.csvHeaders : []);
     setColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
     setFollowupPosts(Array.isArray(state.followupPosts) ? state.followupPosts : []);
+
+    // Also load the custom palette if it exists in the saved state
+    if (state.customPalette) {
+      setCustomPalette(state.customPalette);
+    } else {
+      // If no custom palette is in the saved state, ensure the context is cleared.
+      setCustomPalette(null);
+    }
+
     const sanitizedPagesData = (Array.isArray(state.generatedPagesData) ? state.generatedPagesData : [])
       .filter(page => {
         if (!page || page.record === null || page.record === undefined) {
@@ -398,6 +407,7 @@ function HomePage() {
 
     const campaignDataToSave = {
       activeStep,
+      customPalette: paletteId === 'custom' ? customPalette : null,
       problema,
       solucao,
       objetivo,


### PR DESCRIPTION
This commit delivers a comprehensive refactoring to remove the legacy 'Padrões de Campanha' (Campaign Standards) feature and address several critical bugs that arose during the process.

The key changes are:
- Deletes the `CampaignStandardsModal.jsx` component and its corresponding utility `campaignPrompt.js`, removing all usage of this feature and its `localStorage` dependency.
- Re-implements the color palette selection UI directly within the `Campaign.jsx` component, allowing users to select a global palette or create a campaign-specific custom palette.
- Fixes the save/load logic in `HomePage.jsx` to correctly persist and restore the `customPalette` object within the campaign's main JSON data blob.
- Adds defensive guards to all `.map()` calls that render lists from loaded campaign data (`campaigns`, `hashtags`, `followupPosts`, `hashtags_sugeridas`) to prevent crashes from missing or malformed data.
- Ensures the `MemorialDescritivo` correctly displays the persona, author, and color palette associated with the loaded campaign.