### PR TITLE
Fix: Corrects palette loading and Memorial Descritivo data flow

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -679,6 +679,41 @@ const Campaign = ({
                                         </Button>
                                     )}
                                 </Grid>
+
+                                <Grid item xs={12}>
+                                    <Box sx={{ display: 'flex', gap: 1, mt: 1, mb: 2, flexWrap: 'wrap' }}>
+                                        {(() => {
+                                            const selectedPalette = paletteId === 'custom'
+                                                ? customPalette
+                                                : (palettes || []).find(p => p.id === paletteId);
+
+                                            const colors = selectedPalette?.colors || [];
+
+                                            if (colors.length === 0) {
+                                                return (
+                                                    <Typography variant="caption" color="text.secondary">
+                                                        Nenhuma paleta selecionada ou a paleta selecionada não possui cores.
+                                                    </Typography>
+                                                );
+                                            }
+
+                                            return colors.map((color, index) => (
+                                                <Tooltip title={color} key={index}>
+                                                    <Box
+                                                        sx={{
+                                                            width: 30,
+                                                            height: 30,
+                                                            borderRadius: '50%',
+                                                            backgroundColor: color,
+                                                            border: '1px solid #ddd',
+                                                        }}
+                                                    />
+                                                </Tooltip>
+                                            ));
+                                        })()}
+                                    </Box>
+                                </Grid>
+
                                 <Grid item xs={12}>
                                     <FormControl fullWidth variant="outlined" disabled={!campaignContent}>
                                         <InputLabel id="aspect-ratio-label">Razão de Aspecto</InputLabel>

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -40,6 +40,7 @@ import BackgroundFormatting from './formatting/BackgroundFormatting';
 import PositionSizeFormatting from './formatting/PositionSizeFormatting';
 
 const FormattingPanel = ({
+  colorPalette,
   initialFieldStyles,
   onOpenHtmlEditor,
   templateFieldStyles,
@@ -237,6 +238,7 @@ const FormattingPanel = ({
             {isTextField && (
               <>
                 <TextFormatting
+                  colorPalette={colorPalette}
                   currentElement={currentElement}
                   updateFieldStyle={updateFieldStyle}
                   resetFieldStyle={resetFieldStyle}

--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -147,6 +147,7 @@ const ImageStepUI = ({
         }}>
           <Stack spacing={2}>
             <FormattingPanel
+              colorPalette={colorPalette}
               showImageLoaders={true}
               handleImageUpload={handleImageUpload}
               onOpenImageGallery={onOpenImageGallery}

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -246,6 +246,7 @@ const PageEditor = ({
           {!isMobile && (
             <Grid item xs={12} md={4}>
               <FormattingPanel
+                colorPalette={colorPalette}
                 selectedField={selectedFieldInternal}
                 setSelectedField={setSelectedFieldInternal}
                 fieldStyles={editedStyles}

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -53,6 +53,7 @@ const fonts = [
 ];
 
 const TextFormatting = ({
+  colorPalette,
   currentElement,
   updateFieldStyle,
   resetFieldStyle,
@@ -68,7 +69,40 @@ const TextFormatting = ({
       <Button variant="contained" startIcon={<Edit />} onClick={() => onOpenHtmlEditor(selectedField)} fullWidth sx={{ mb: 2 }}>Editar Conteúdo</Button>
       <Accordion expanded={expandedPanel === 'fontStyle'} onChange={handleAccordionChange('fontStyle')}>
         <AccordionSummary expandIcon={<ExpandMore />}><Typography><FormatSize sx={{ mr: 1, verticalAlign: 'middle' }} />Fonte e Estilo</Typography></AccordionSummary>
-        <AccordionDetails><Grid container spacing={2}><Grid item xs={8}><FormControl fullWidth size="small"><InputLabel>Fonte</InputLabel><Select value={currentElement.style.fontFamily || 'Arial'} label="Fonte" onChange={(e) => updateFieldStyle('fontFamily', e.target.value)} MenuProps={{ sx: { zIndex: 1500 } }}>{fonts.map(font => (<MenuItem key={font} value={font} style={{ fontFamily: font }}>{font}</MenuItem>))}</Select></FormControl></Grid><Grid item xs={4}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.style.color || '#000000')} onChange={(e) => updateFieldStyle('color', e.target.value)} fullWidth size="small" /></Grid><Grid item xs={12}><ToggleButtonGroup size="small" fullWidth><ToggleButton value="bold" selected={currentElement.style.fontWeight === 'bold'} onClick={() => updateFieldStyle('fontWeight', currentElement.style.fontWeight === 'bold' ? 'normal' : 'bold')}><FormatBold /></ToggleButton><ToggleButton value="italic" selected={currentElement.style.fontStyle === 'italic'} onClick={() => updateFieldStyle('fontStyle', currentElement.style.fontStyle === 'italic' ? 'normal' : 'italic')}><FormatItalic /></ToggleButton><ToggleButton value="underline" selected={currentElement.style.textDecoration === 'underline'} onClick={() => updateFieldStyle('textDecoration', currentElement.style.textDecoration === 'underline' ? 'none' : 'underline')}><FormatUnderlined /></ToggleButton></ToggleButtonGroup></Grid><Grid item xs={12}><Typography variant="caption" display="block" gutterBottom>Alinhamento</Typography><ToggleButtonGroup value={currentElement.style.textAlign || 'left'} exclusive onChange={(e, v) => v && updateFieldStyle('textAlign', v)} size="small" fullWidth><ToggleButton value="left"><FormatAlignLeft /></ToggleButton><ToggleButton value="center"><FormatAlignCenter /></ToggleButton><ToggleButton value="right"><FormatAlignRight /></ToggleButton></ToggleButtonGroup></Grid><Grid item xs={12}><ToggleButtonGroup value={currentElement.style.verticalAlign || 'top'} exclusive onChange={(e, v) => v && updateFieldStyle('verticalAlign', v)} size="small" fullWidth><ToggleButton value="top"><VerticalAlignTop /></ToggleButton><ToggleButton value="middle"><VerticalAlignCenter /></ToggleButton><ToggleButton value="bottom"><VerticalAlignBottom /></ToggleButton></ToggleButtonGroup></Grid><Grid item xs={12}><Typography gutterBottom>Tamanho: {currentElement.style.fontSize || 24}px</Typography><Slider value={currentElement.style.fontSize || 24} onChange={(e, v) => updateFieldStyle('fontSize', v)} min={8} max={120} /></Grid><Grid item xs={12}><Typography gutterBottom>Espaçamento Linhas: {currentElement.style.lineHeightMultiplier || 1.2}x</Typography><Slider value={currentElement.style.lineHeightMultiplier || 1.2} onChange={(e, v) => updateFieldStyle('lineHeightMultiplier', v)} min={0.8} max={3} step={0.1} /></Grid></Grid></AccordionDetails>
+        <AccordionDetails>
+          <Grid container spacing={2}>
+            <Grid item xs={8}><FormControl fullWidth size="small"><InputLabel>Fonte</InputLabel><Select value={currentElement.style.fontFamily || 'Arial'} label="Fonte" onChange={(e) => updateFieldStyle('fontFamily', e.target.value)} MenuProps={{ sx: { zIndex: 1500 } }}>{fonts.map(font => (<MenuItem key={font} value={font} style={{ fontFamily: font }}>{font}</MenuItem>))}</Select></FormControl></Grid>
+            <Grid item xs={4}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.style.color || '#000000')} onChange={(e) => updateFieldStyle('color', e.target.value)} fullWidth size="small" /></Grid>
+
+            {colorPalette && colorPalette.length > 0 && (
+              <Grid item xs={12}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
+                  {colorPalette.map((color, index) => (
+                    <Tooltip title={color} key={index}>
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          backgroundColor: color,
+                          border: '1px solid #ddd',
+                          cursor: 'pointer',
+                        }}
+                        onClick={() => updateFieldStyle('color', color)}
+                      />
+                    </Tooltip>
+                  ))}
+                </Box>
+              </Grid>
+            )}
+
+            <Grid item xs={12}><ToggleButtonGroup size="small" fullWidth><ToggleButton value="bold" selected={currentElement.style.fontWeight === 'bold'} onClick={() => updateFieldStyle('fontWeight', currentElement.style.fontWeight === 'bold' ? 'normal' : 'bold')}><FormatBold /></ToggleButton><ToggleButton value="italic" selected={currentElement.style.fontStyle === 'italic'} onClick={() => updateFieldStyle('fontStyle', currentElement.style.fontStyle === 'italic' ? 'normal' : 'italic')}><FormatItalic /></ToggleButton><ToggleButton value="underline" selected={currentElement.style.textDecoration === 'underline'} onClick={() => updateFieldStyle('textDecoration', currentElement.style.textDecoration === 'underline' ? 'none' : 'underline')}><FormatUnderlined /></ToggleButton></ToggleButtonGroup></Grid>
+            <Grid item xs={12}><Typography variant="caption" display="block" gutterBottom>Alinhamento</Typography><ToggleButtonGroup value={currentElement.style.textAlign || 'left'} exclusive onChange={(e, v) => v && updateFieldStyle('textAlign', v)} size="small" fullWidth><ToggleButton value="left"><FormatAlignLeft /></ToggleButton><ToggleButton value="center"><FormatAlignCenter /></ToggleButton><ToggleButton value="right"><FormatAlignRight /></ToggleButton></ToggleButtonGroup></Grid>
+            <Grid item xs={12}><ToggleButtonGroup value={currentElement.style.verticalAlign || 'top'} exclusive onChange={(e, v) => v && updateFieldStyle('verticalAlign', v)} size="small" fullWidth><ToggleButton value="top"><VerticalAlignTop /></ToggleButton><ToggleButton value="middle"><VerticalAlignCenter /></ToggleButton><ToggleButton value="bottom"><VerticalAlignBottom /></ToggleButton></ToggleButtonGroup></Grid>
+            <Grid item xs={12}><Typography gutterBottom>Tamanho: {currentElement.style.fontSize || 24}px</Typography><Slider value={currentElement.style.fontSize || 24} onChange={(e, v) => updateFieldStyle('fontSize', v)} min={8} max={120} /></Grid>
+            <Grid item xs={12}><Typography gutterBottom>Espaçamento Linhas: {currentElement.style.lineHeightMultiplier || 1.2}x</Typography><Slider value={currentElement.style.lineHeightMultiplier || 1.2} onChange={(e, v) => updateFieldStyle('lineHeightMultiplier', v)} min={0.8} max={3} step={0.1} /></Grid>
+          </Grid>
+        </AccordionDetails>
       </Accordion>
       <Accordion expanded={expandedPanel === 'boxStyle'} onChange={handleAccordionChange('boxStyle')}>
         <AccordionSummary expandIcon={<ExpandMore />}><Typography><CheckBoxOutlineBlank sx={{ mr: 1, verticalAlign: 'middle' }} />Caixa de Texto</Typography></AccordionSummary>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1345,7 +1345,20 @@ function HomePage() {
     return [];
   }, [paletteId, customPalette, palettes]);
 
-  const campaignData = { problema, solucao, objetivo, tomDeVoz, campaignContent, formato, aspectRatio, followupPosts, colors: memorialColors, generatedPagesData, };
+  const campaignData = {
+    problema,
+    solucao,
+    objetivo,
+    tomDeVoz,
+    campaignContent,
+    formato,
+    aspectRatio,
+    followupPosts,
+    colors: memorialColors,
+    generatedPagesData,
+    persona: personaList.find(p => p.id === selectedPersonaForCampaign),
+    autor: autorList.find(a => a.id === selectedAutorForCampaign),
+  };
 
   return (
     <ThemeProvider theme={currentTheme}>
@@ -1439,6 +1452,7 @@ function HomePage() {
                       personaList={personaList}
                       selectedPersonaForCampaign={selectedPersonaForCampaign}
                       setSelectedPersonaForCampaign={setSelectedPersonaForCampaign}
+                      palettes={palettes}
                     />
                   </Container>
                 )}


### PR DESCRIPTION
This commit addresses several critical bugs related to campaign data display and functionality.

1.  **Fixes Palette Loading in Campaign Editor:**
    - The list of saved color palettes was not appearing in the dropdown on the campaign editing page.
    - This was caused by `HomePage.jsx` failing to pass the `palettes` prop to the `Campaign` component. This has been corrected.
    - A color swatch preview has also been added below the dropdown for better UX.

2.  **Fixes 'Memorial Descritivo' Data Display:**
    - The 'Autor' and 'Persona' sections of the 'Memorial Descritivo' were appearing blank.
    - This was due to a data mismatch. The `AuthorSection` and `PersonaSection` components expect nested data (e.g., `persona.persona_data`), but the top-level `persona` object was not being passed correctly.
    - The `campaignData` object in `HomePage.jsx` has been fixed to include the full `autor` and `persona` objects, resolving the issue.

3.  **Restores Color Palette in Formatting Panel:**
    - The color palette swatches were missing from the text formatting panel in the page editor.
    - The `colorPalette` prop has been correctly passed through the component hierarchy (`ImageStepUI` -> `FormattingPanel` -> `TextFormatting`) to restore this functionality.