### PR TITLE
fix(campaign): Correct state update order on load

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -474,6 +474,10 @@ function HomePage() {
         setPendingAssets(loadedCampaign.pendingAssets);
       }
 
+      // Set the current campaign first to ensure its state is updated before any navigation
+      // or re-rendering is triggered by applyAppState.
+      setCurrentCampaign({ id: loadedCampaign.id, name: loadedCampaign.name });
+
       // Apply the rest of the general state from campaign_data
       applyAppState(loadedCampaign.campaign_data);
 
@@ -481,8 +485,6 @@ function HomePage() {
       setSelectedAutorForCampaign(loadedCampaign.autor_id || '');
       setSelectedPersonaForCampaign(loadedCampaign.persona_id || '');
       setPaletteId(loadedCampaign.palette_id || null);
-
-      setCurrentCampaign({ id: loadedCampaign.id, name: loadedCampaign.name });
       toast.success(`Campaign "${loadedCampaign.name}" loaded successfully!`);
     } catch (err) {
       toast.error(err.message);


### PR DESCRIPTION
Moves the `setCurrentCampaign` call to before the `applyAppState` call in the `handleLoadCampaign` function.

This fixes a timing issue where the `currentCampaign` state was not being set correctly before navigation and re-rendering occurred, leading to two bugs:
- The 'emit memorial' button was disabled after loading a campaign.
- Saving a loaded campaign would create a new campaign instead of updating the existing one.

By setting the `currentCampaign` state first, the application now correctly recognizes that a campaign is loaded, enabling the button and ensuring the save action performs an update.