### PR TITLE
fix: Correct campaign state and handle custom palette on save

### DIFF
--- a/api/campaigns/[id].js
+++ b/api/campaigns/[id].js
@@ -38,10 +38,10 @@ const handler = async (req, res) => {
         return res.status(400).json({ error: 'Campaign name and data are required.' });
       }
 
-      // Ensure empty strings for foreign keys are converted to null
+      // Ensure empty strings or "custom" for foreign keys are converted to null
       const finalAutorId = autor_id === '' ? null : autor_id;
       const finalPersonaId = persona_id === '' ? null : persona_id;
-      const finalPaletteId = palette_id === '' ? null : palette_id;
+      const finalPaletteId = (palette_id === '' || palette_id === 'custom') ? null : palette_id;
 
       const { rows } = await query(
         'UPDATE campaigns SET name = $1, campaign_data = $2, autor_id = $3, persona_id = $4, palette_id = $5, updated_at = NOW() WHERE id = $6 AND user_id = $7 RETURNING id, name, updated_at',

--- a/api/campaigns/index.js
+++ b/api/campaigns/index.js
@@ -33,10 +33,10 @@ const handler = async (req, res) => {
       if (!name || !campaign_data) {
         return res.status(400).json({ error: 'Campaign name and data are required.' });
       }
-      // Convert empty strings to null for foreign key fields
+      // Convert empty strings or "custom" to null for foreign key fields
       const final_autor_id = autor_id === '' ? null : autor_id;
       const final_persona_id = persona_id === '' ? null : persona_id;
-      const final_palette_id = palette_id === '' ? null : palette_id;
+      const final_palette_id = (palette_id === '' || palette_id === 'custom') ? null : palette_id;
 
       const { rows } = await query(
         'INSERT INTO campaigns (user_id, name, campaign_data, autor_id, persona_id, palette_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, name, updated_at',


### PR DESCRIPTION
This commit includes two fixes related to campaign management.

First, it addresses a bug where loading an existing campaign did not correctly set the `currentCampaign` state before UI re-rendering. This was fixed by reordering the state update calls in `handleLoadCampaign` in `src/pages/HomePage.jsx`. This resolves issues with disabled buttons and ensures that saving an existing campaign performs an update instead of creating a new one.

Second, it fixes a server-side bug that caused a 500 error when saving a campaign with a custom color palette. The API endpoints (`api/campaigns/index.js` and `api/campaigns/[id].js`) now correctly handle the string "custom" for the `palette_id` by converting it to `null` before the database operation.