### PR TITLE
fix: Correct state, save, and palette logic for campaigns

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -113,8 +113,8 @@ function HomePage() {
     aspectRatio, setAspectRatio,
     pendingAssets, setPendingAssets,
     defaultPageTemplate,
-    paletteId,
-    customPalette,
+    paletteId, setPaletteId,
+    customPalette, setCustomPalette,
   } = useCampaign();
 
   // Component State
@@ -331,6 +331,7 @@ function HomePage() {
     setPromptText(state.promptText ?? '');
     setFieldPositions(state.fieldPositions ?? {});
     setTemplateFieldStyles(state.templateFieldStyles ?? {});
+    setCustomPalette(state.customPalette ?? null);
 
     const loadedStyles = state.fieldStyles ?? {};
     const completeStyles = {};
@@ -416,6 +417,7 @@ function HomePage() {
       generatedVideos: sanitizedVideos,
       csvData,
       csvHeaders,
+      customPalette,
     };
     console.log("[HomePage] Campaign data object created:", campaignDataToSave);
 


### PR DESCRIPTION
This commit addresses a series of related bugs in the campaign loading and saving workflow.

1. Fixes a state update order issue in `HomePage.jsx` by moving `setCurrentCampaign` before `applyAppState`. This ensures the app correctly recognizes a loaded campaign, fixing a disabled button and an issue where updates were being saved as new campaigns.

2. Fixes a server-side crash by handling a `palette_id` of "custom" in the API. The `POST` and `PUT` endpoints in `api/campaigns/` now convert this string to `null` before the database query, preventing a type error.

3. Fixes a bug where custom palette colors were not being saved or loaded. `HomePage.jsx` now includes the `customPalette` object when saving and correctly restores it when loading a campaign.