### PR TITLE
fix: Resolve multiple bugs in campaign load/save workflow

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -486,7 +486,19 @@ function HomePage() {
       // Explicitly set the author and persona IDs from the top-level of the loaded campaign
       setSelectedAutorForCampaign(loadedCampaign.autor_id || '');
       setSelectedPersonaForCampaign(loadedCampaign.persona_id || '');
-      setPaletteId(loadedCampaign.palette_id || null);
+
+      // Set palette ID: if a DB-level palette_id exists, use it. Otherwise,
+      // check if a custom palette exists in the loaded data and set the ID to "custom".
+      const dbPaletteId = loadedCampaign.palette_id;
+      const hasCustomPalette = loadedCampaign.campaign_data?.customPalette?.colors?.length > 0;
+
+      if (dbPaletteId) {
+        setPaletteId(dbPaletteId);
+      } else if (hasCustomPalette) {
+        setPaletteId('custom');
+      } else {
+        setPaletteId(null);
+      }
       toast.success(`Campaign "${loadedCampaign.name}" loaded successfully!`);
     } catch (err) {
       toast.error(err.message);


### PR DESCRIPTION
This commit provides a comprehensive set of fixes to address multiple issues in the campaign management workflow.

1.  **State Update Order:** Fixes a bug where loading a campaign didn't set its state correctly before UI re-rendering. This was fixed by reordering state updates in `handleLoadCampaign` in `src/pages/HomePage.jsx`. This resolves the disabled 'memorial' button and ensures updates don't create new campaigns.

2.  **API Crash on Save:** Fixes a 500 error when saving a campaign with a custom palette. The API endpoints in `api/campaigns/` now correctly convert a `palette_id` of "custom" to `null` before the database query.

3.  **Custom Palette Persistence:** Fixes a bug where custom palette colors were not saved or loaded. `HomePage.jsx` now includes the `customPalette` object when saving and restores it when loading.

4.  **Custom Palette Display:** Fixes a bug where loaded custom palettes were not displayed. `HomePage.jsx` now correctly sets the `paletteId` state to "custom" when it detects loaded custom palette data, ensuring the UI displays the correct colors.