### PR TITLE
fix: Resolve multiple bugs in campaign workflow

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -41,6 +41,7 @@ import PositionSizeFormatting from './formatting/PositionSizeFormatting';
 
 const FormattingPanel = ({
   colorPalette,
+  imagePalette,
   initialFieldStyles,
   onOpenHtmlEditor,
   templateFieldStyles,
@@ -239,6 +240,7 @@ const FormattingPanel = ({
               <>
                 <TextFormatting
                   colorPalette={colorPalette}
+                  imagePalette={imagePalette}
                   currentElement={currentElement}
                   updateFieldStyle={updateFieldStyle}
                   resetFieldStyle={resetFieldStyle}

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -54,6 +54,7 @@ const fonts = [
 
 const TextFormatting = ({
   colorPalette,
+  imagePalette,
   currentElement,
   updateFieldStyle,
   resetFieldStyle,
@@ -76,6 +77,7 @@ const TextFormatting = ({
 
             {colorPalette && colorPalette.length > 0 && (
               <Grid item xs={12}>
+                <Typography variant="caption">Paleta da Campanha</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
                   {colorPalette.map((color, index) => (
                     <Tooltip title={color.name || color.hex} key={index}>
@@ -89,6 +91,29 @@ const TextFormatting = ({
                           cursor: 'pointer',
                         }}
                         onClick={() => updateFieldStyle('color', color.hex)}
+                      />
+                    </Tooltip>
+                  ))}
+                </Box>
+              </Grid>
+            )}
+
+            {imagePalette && imagePalette.length > 0 && (
+              <Grid item xs={12}>
+                <Typography variant="caption">Cores da Imagem</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
+                  {imagePalette.map((color, index) => (
+                    <Tooltip title={color} key={index}>
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          backgroundColor: color,
+                          border: '1px solid #ddd',
+                          cursor: 'pointer',
+                        }}
+                        onClick={() => updateFieldStyle('color', color)}
                       />
                     </Tooltip>
                   ))}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1521,6 +1521,7 @@ function HomePage() {
                     initialFieldStyles={initialFieldStyles}
                     onImageDisplayedSizeChange={setDisplayedImageSize}
                     colorPalette={memorialColors}
+                    imagePalette={colorPalette}
                     onCsvDataUpdate={handleCsvRecordContentUpdate}
                     originalImageSize={originalImageSize}
                     onZIndexChange={handleZIndexChange}
@@ -1540,6 +1541,7 @@ function HomePage() {
                   <PageGeneratorFrontendOnly
                     displayedImageSize={displayedImageSize}
                     colorPalette={memorialColors}
+                    imagePalette={colorPalette}
                     initialGeneratedPagesData={generatedPagesData}
                     onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate}
                     originalImageSize={originalImageSize}


### PR DESCRIPTION
This commit provides a comprehensive set of fixes to address multiple issues in the campaign management workflow.

1.  **State Update Order:** Fixes a bug where loading a campaign didn't set its state correctly before UI re-rendering. This was fixed by reordering state updates in `handleLoadCampaign` in `src/pages/HomePage.jsx`. This resolves the disabled 'memorial' button and ensures updates don't create new campaigns.

2.  **API Crash on Save:** Fixes a 500 error when saving a campaign with a custom palette. The API endpoints in `api/campaigns/` now correctly convert a `palette_id` of "custom" to `null` before the database query.

3.  **Custom Palette Persistence:** Fixes a bug where custom palette colors were not being saved or loaded. `HomePage.jsx` now includes the `customPalette` object when saving and correctly restores it when loading a campaign.

4.  **Custom Palette Display:** Fixes a bug where loaded custom palettes were not displayed correctly. `HomePage.jsx` now correctly sets the `paletteId` state to "custom" when it detects loaded custom palette data, ensuring the UI displays the correct colors.

5.  **Dual Palettes in Editors:** Fixes a bug where the campaign's color palette was not available in the page template editor (Step 3) or the generated page editor (Step 4), and ensures that both the campaign palette and the image-derived palette are displayed. This was done by modifying `FormattingPanel` and `TextFormatting` to accept and render both palettes.