### PR TITLE
fix: Resolve multiple bugs in campaign load, save, and edit workflows

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -305,10 +305,24 @@ function HomePage() {
         img.crossOrigin = 'Anonymous';
         img.onload = () => {
             setOriginalImageSize({ width: img.width, height: img.height });
+            // Also extract colors from this loaded image
+            try {
+                const colorThief = new ColorThief();
+                const palette = colorThief.getPalette(img, 5);
+                setColorPalette(palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2])));
+            } catch (e) {
+                console.error("Error extracting palette from loaded image:", e);
+                setColorPalette([]);
+            }
+        };
+        img.onerror = () => {
+            setOriginalImageSize(DEFAULT_IMAGE_SIZE);
+            setColorPalette([]);
         };
         img.src = firstImageSrc;
     } else {
         setOriginalImageSize(DEFAULT_IMAGE_SIZE);
+        setColorPalette([]);
     }
 
     setProblema(state.problema ?? '');


### PR DESCRIPTION
This commit provides a comprehensive set of fixes to address multiple issues in the campaign management workflow.

1.  **State Update Order:** Fixes a bug where loading a campaign didn't set its state correctly before UI re-rendering. This was fixed by reordering state updates in `handleLoadCampaign` in `src/pages/HomePage.jsx`. This resolves the disabled 'memorial' button and ensures updates don't create new campaigns.

2.  **API Crash on Save:** Fixes a 500 error when saving a campaign with a custom palette. The API endpoints in `api/campaigns/` now correctly convert a `palette_id` of "custom" to `null` before the database query.

3.  **Custom Palette Persistence:** Fixes a bug where custom palette colors were not being saved or loaded. `HomePage.jsx` now includes the `customPalette` object when saving and correctly restores it when loading a campaign.

4.  **Custom Palette Display:** Fixes a bug where loaded custom palettes were not displayed correctly. `HomePage.jsx` now correctly sets the `paletteId` state to "custom" when it detects loaded custom palette data, ensuring the UI displays the correct colors.

5.  **Dual Palettes in Editors:** Fixes a bug where the campaign's color palette was not available in the page template editor (Step 3) or the generated page editor (Step 4), and ensures that both the campaign palette and the image-derived palette are displayed. This was done by modifying `FormattingPanel` and `TextFormatting` to accept and render both palettes.

6.  **Image Palette on Load:** Fixes a bug where the image-derived color palette was not being generated when a campaign with an existing image was loaded. The `applyAppState` function now re-extracts colors from the loaded image.