### PR TITLE
fix(editor): Fix color swatch display and application

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -37,6 +37,7 @@ const PageEditor = ({
   pageData,
   onSave,
   colorPalette,
+  imagePalette,
   originalImageSize,
   aspectRatio,
   onOpenImageGallery,
@@ -247,6 +248,7 @@ const PageEditor = ({
             <Grid item xs={12} md={4}>
               <FormattingPanel
                 colorPalette={colorPalette}
+                imagePalette={imagePalette}
                 selectedField={selectedFieldInternal}
                 setSelectedField={setSelectedFieldInternal}
                 fieldStyles={editedStyles}

--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -58,6 +58,7 @@ const PageGeneratorFrontendOnly = ({
   aspectRatio,
   handleImageUpload, // New prop
   onOpenImageGallery,
+  imagePalette,
 }) => {
   const {
     csvData,
@@ -665,6 +666,7 @@ const PageGeneratorFrontendOnly = ({
           pageData={safeDeepClone(pageToEdit)}
           onSave={handleSaveIndividualModifications}
           colorPalette={colorPalette}
+          imagePalette={imagePalette}
           aspectRatio={aspectRatio}
           originalImageSize={originalImageSize}
           onOpenImageGallery={() => onOpenImageGallery(editingGeneratedPageIndex)}

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -102,21 +102,27 @@ const TextFormatting = ({
               <Grid item xs={12}>
                 <Typography variant="caption">Cores da Imagem</Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
-                  {imagePalette.map((color, index) => (
-                    <Tooltip title={color} key={index}>
-                      <Box
-                        sx={{
-                          width: 24,
-                          height: 24,
-                          borderRadius: '50%',
-                          backgroundColor: color,
-                          border: '1px solid #ddd',
-                          cursor: 'pointer',
-                        }}
-                        onClick={() => updateFieldStyle('color', color)}
-                      />
-                    </Tooltip>
-                  ))}
+                  {imagePalette.map((color, index) => {
+                    // Safeguard against non-string values in the palette
+                    if (typeof color !== 'string') {
+                      return null;
+                    }
+                    return (
+                      <Tooltip title={color} key={index}>
+                        <Box
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: '50%',
+                            backgroundColor: color,
+                            border: '1px solid #ddd',
+                            cursor: 'pointer',
+                          }}
+                          onClick={() => updateFieldStyle('color', color)}
+                        />
+                      </Tooltip>
+                    );
+                  })}
                 </Box>
               </Grid>
             )}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -133,7 +133,7 @@ function HomePage() {
   const [personaDrawerOpen, setPersonaDrawerOpen] = useState(!isMobile);
   const [autorDrawerOpen, setAutorDrawerOpen] = useState(!isMobile);
   const [paletteDrawerOpen, setPaletteDrawerOpen] = useState(!isMobile);
-  const [colorPalette, setColorPalette] = useState([]);
+  const [imageColorPalette, setImageColorPalette] = useState([]);
   const [problema, setProblema] = useState('');
   const [solucao, setSolucao] = useState('');
   const [objetivo, setObjetivo] = useState('');
@@ -241,7 +241,7 @@ function HomePage() {
 
     setCsvData(Array.isArray(state.csvData) ? state.csvData : []);
     setCsvHeaders(Array.isArray(state.csvHeaders) ? state.csvHeaders : []);
-    setColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
+    setImageColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
     setFollowupPosts(Array.isArray(state.followupPosts) ? state.followupPosts : []);
     const sanitizedPagesData = (Array.isArray(state.generatedPagesData) ? state.generatedPagesData : [])
       .filter(page => {
@@ -309,20 +309,20 @@ function HomePage() {
             try {
                 const colorThief = new ColorThief();
                 const palette = colorThief.getPalette(img, 5);
-                setColorPalette(palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2])));
+                setImageColorPalette(palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2])));
             } catch (e) {
                 console.error("Error extracting palette from loaded image:", e);
-                setColorPalette([]);
+                setImageColorPalette([]);
             }
         };
         img.onerror = () => {
             setOriginalImageSize(DEFAULT_IMAGE_SIZE);
-            setColorPalette([]);
+            setImageColorPalette([]);
         };
         img.src = firstImageSrc;
     } else {
         setOriginalImageSize(DEFAULT_IMAGE_SIZE);
-        setColorPalette([]);
+        setImageColorPalette([]);
     }
 
     setProblema(state.problema ?? '');
@@ -891,18 +891,18 @@ function HomePage() {
       try {
         const colorThief = new ColorThief();
         const palette = colorThief.getPalette(img, 5);
-        setColorPalette(palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2])));
+        setImageColorPalette(palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2])));
       } catch (error) {
         console.error("Error extracting color palette:", error);
-        setColorPalette([]);
+        setImageColorPalette([]);
       }
     };
     img.onerror = (err) => {
       console.error("Error loading image to extract colors:", err);
-      setColorPalette([]);
+      setImageColorPalette([]);
     };
     img.src = imageUrl;
-  }, [imageGalleryTargetIndex, pageTemplate, setPageTemplate, setGeneratedPagesData, setColorPalette]);
+  }, [imageGalleryTargetIndex, pageTemplate, setPageTemplate, setGeneratedPagesData, setImageColorPalette]);
 
   const parseImageFile = (file) => {
     if (!file) return;
@@ -1535,7 +1535,7 @@ function HomePage() {
                     initialFieldStyles={initialFieldStyles}
                     onImageDisplayedSizeChange={setDisplayedImageSize}
                     colorPalette={memorialColors}
-                    imagePalette={colorPalette}
+                    imagePalette={imageColorPalette}
                     onCsvDataUpdate={handleCsvRecordContentUpdate}
                     originalImageSize={originalImageSize}
                     onZIndexChange={handleZIndexChange}
@@ -1555,7 +1555,7 @@ function HomePage() {
                   <PageGeneratorFrontendOnly
                     displayedImageSize={displayedImageSize}
                     colorPalette={memorialColors}
-                    imagePalette={colorPalette}
+                    imagePalette={imageColorPalette}
                     initialGeneratedPagesData={generatedPagesData}
                     onThumbnailRecordTextUpdate={handleThumbnailRecordTextUpdate}
                     originalImageSize={originalImageSize}


### PR DESCRIPTION
This commit fixes a bug where color swatches extracted from an image were not being displayed correctly in the page editor. Applying a swatch would cause a `TypeError: e.startsWith is not a function`.

The root cause was twofold:
1. The `imagePalette` prop was not being correctly passed down from the `HomePage` component to the `FormattingPanel` in the editor.
2. The code did not handle cases where the color palette extraction might result in non-string values, causing rendering issues and runtime errors.

The following changes were made:
- In `HomePage.jsx`, the state holding the extracted image colors was renamed from `colorPalette` to `imageColorPalette` for clarity and passed down as a prop.
- The `imagePalette` prop is now correctly propagated through `PageGeneratorFrontendOnly.jsx` and `PageEditor.jsx` to the `FormattingPanel`.
- A safeguard was added in `TextFormatting.jsx` to ensure that only valid string values from the `imagePalette` are used to render the color swatches.