### PR TITLE
fix(editor): Correctly pass imagePalette to ImageStepUI

### DIFF
--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -34,6 +34,7 @@ const ImageStepUI = ({
   initialFieldStyles,
   onImageDisplayedSizeChange,
   colorPalette,
+  imagePalette,
   onCsvDataUpdate,
   originalImageSize,
   onZIndexChange,
@@ -148,6 +149,7 @@ const ImageStepUI = ({
           <Stack spacing={2}>
             <FormattingPanel
               colorPalette={colorPalette}
+              imagePalette={imagePalette}
               showImageLoaders={true}
               handleImageUpload={handleImageUpload}
               onOpenImageGallery={onOpenImageGallery}


### PR DESCRIPTION
This commit completes the fix for the color swatch display bug. The previous commit had only fixed the issue in the 'Edit Generated Page' flow, but not in the 'Edit Page Template' flow (ImageStep).

This change modifies `ImageStepUI.jsx` to correctly receive and pass the `imagePalette` prop to the `FormattingPanel`. This ensures that the color swatches extracted from the image are available in both editing contexts, as originally intended.