### PR TITLE
feat(editor): Add detailed logging to color extraction

### DIFF
--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -65,6 +65,8 @@ const TextFormatting = ({
 }) => {
   if (!currentElement) return null;
 
+  console.log('[TextFormatting] Received imagePalette prop:', imagePalette);
+
   return (
     <>
       <Button variant="contained" startIcon={<Edit />} onClick={() => onOpenHtmlEditor(selectedField)} fullWidth sx={{ mb: 2 }}>Editar Conteúdo</Button>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -77,21 +77,27 @@ const rgbToHex = (r, g, b) => '#' + [r, g, b].map(x => {
 }).join('');
 
 const extractColorPalette = (imageUrl, paletteSetter) => {
+  console.log(`[ColorThief] 1. Starting extraction for URL: ${imageUrl}`);
   const img = new Image();
   img.crossOrigin = 'Anonymous';
 
   const processImage = () => {
+    console.log('[ColorThief] 2. processImage function called.');
     try {
       const colorThief = new ColorThief();
       const palette = colorThief.getPalette(img, 5);
+      console.log('[ColorThief] 3. Raw palette from ColorThief:', palette);
+
       if (palette) {
         const hexPalette = palette.map(rgb => rgbToHex(rgb[0], rgb[1], rgb[2]));
+        console.log('[ColorThief] 4. Converted hex palette:', hexPalette);
         paletteSetter(hexPalette);
       } else {
+        console.log('[ColorThief] 4. Palette was null or empty, setting empty array.');
         paletteSetter([]);
       }
     } catch (error) {
-      console.error("Error extracting color palette:", error);
+      console.error("[ColorThief] 5. Error during color extraction:", error);
       paletteSetter([]);
     }
   };


### PR DESCRIPTION
This commit adds detailed logging to the color extraction process to help diagnose a persistent bug where color swatches are not being displayed.

The following logs have been added:
- In `HomePage.jsx`, the `extractColorPalette` function now logs the image URL, the raw output from the `ColorThief` library, the converted hex palette, and any errors that occur.
- In `TextFormatting.jsx`, a log has been added to show the `imagePalette` prop as it is received by the component.

This will provide clear visibility into the color extraction pipeline and help identify the exact point of failure in the user's environment.