### PR TITLE
feat(editor): Add diagnostic logging and fix gallery handler

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -62,6 +62,7 @@ const FormattingPanel = ({
   selectedField: selectedFieldProp,
   setSelectedField: setSelectedFieldProp,
 }) => {
+  console.log('[FormattingPanel] Received imagePalette prop:', imagePalette);
   const context = useCampaign();
 
   // Use props if provided (controlled mode), otherwise use context (standalone mode)
@@ -219,7 +220,7 @@ const FormattingPanel = ({
             <Button variant="contained" component="label" startIcon={<ImageIcon />} fullWidth>
               Carregar <input type="file" accept=".png,.jpg,.jpeg" hidden onChange={handleImageUpload} />
             </Button>
-            <Button variant="outlined" onClick={onOpenImageGallery} fullWidth> Galeria </Button>
+            <Button variant="outlined" onClick={() => onOpenImageGallery()} fullWidth> Galeria </Button>
           </Box>
         )}
         {!currentElement ? (


### PR DESCRIPTION
This commit adds detailed logging to the color extraction process to help diagnose a persistent bug where color swatches are not being displayed.

It also fixes a minor bug where the `onOpenImageGallery` event handler was being called with a React event object instead of no arguments, causing confusing logs.

Logging has been added to:
- `HomePage.jsx` in the `extractColorPalette` function.
- `FormattingPanel.jsx` to show the received `imagePalette` prop.
- `TextFormatting.jsx` to show the received `imagePalette` prop.