### PR TITLE
Fix: Generate image swatches dynamically

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -276,7 +276,6 @@ function HomePage() {
 
     setCsvData(Array.isArray(state.csvData) ? state.csvData : []);
     setCsvHeaders(Array.isArray(state.csvHeaders) ? state.csvHeaders : []);
-    setImageColorPalette(Array.isArray(state.colorPalette) ? state.colorPalette : []);
     setFollowupPosts(Array.isArray(state.followupPosts) ? state.followupPosts : []);
     const sanitizedPagesData = (Array.isArray(state.generatedPagesData) ? state.generatedPagesData : [])
       .filter(page => {
@@ -348,6 +347,9 @@ function HomePage() {
             setImageColorPalette([]);
         };
         img.src = firstImageSrc;
+    } else {
+        const campaignPalette = state.customPalette?.colors?.map(c => c.hex) || [];
+        setImageColorPalette(campaignPalette);
     }
 
     setProblema(state.problema ?? '');


### PR DESCRIPTION
The image swatches were being incorrectly loaded from the saved campaign state, which caused them to appear as empty circles.

This change removes the incorrect initialization of the image color palette from the campaign state. It also adds a fallback to use the campaign's main color palette if no image is present on the page, as requested.

This ensures that the swatches are always generated dynamically during the page editing preview.