### PR TITLE
Fix: Correctly generate and display dynamic image swatches

### DIFF
--- a/src/components/ImageStepUI.jsx
+++ b/src/components/ImageStepUI.jsx
@@ -34,6 +34,7 @@ const ImageStepUI = ({
   initialFieldStyles,
   onImageDisplayedSizeChange,
   colorPalette,
+  imagePalette,
   onCsvDataUpdate,
   originalImageSize,
   onZIndexChange,
@@ -58,7 +59,7 @@ const ImageStepUI = ({
     brandElements, setBrandElements,
     pageTemplate, setPageTemplate,
     selectedField, setSelectedField,
-    imageColorPalette, // Get the image palette from context
+    imageColorPalette,
   } = useCampaign();
 
   const handleNextPreview = () => {

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -98,34 +98,6 @@ const TextFormatting = ({
               </Grid>
             )}
 
-            {imagePalette && imagePalette.length > 0 && (
-              <Grid item xs={12}>
-                <Typography variant="caption">Cores da Imagem</Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
-                  {imagePalette.map((color, index) => {
-                    // Safeguard against non-string values in the palette
-                    if (typeof color !== 'string') {
-                      return null;
-                    }
-                    return (
-                      <Tooltip title={color} key={index}>
-                        <Box
-                          sx={{
-                            width: 24,
-                            height: 24,
-                            borderRadius: '50%',
-                            backgroundColor: color,
-                            border: '1px solid #ddd',
-                            cursor: 'pointer',
-                          }}
-                          onClick={() => updateFieldStyle('color', color)}
-                        />
-                      </Tooltip>
-                    );
-                  })}
-                </Box>
-              </Grid>
-            )}
 
             <Grid item xs={12}><ToggleButtonGroup size="small" fullWidth><ToggleButton value="bold" selected={currentElement.style.fontWeight === 'bold'} onClick={() => updateFieldStyle('fontWeight', currentElement.style.fontWeight === 'bold' ? 'normal' : 'bold')}><FormatBold /></ToggleButton><ToggleButton value="italic" selected={currentElement.style.fontStyle === 'italic'} onClick={() => updateFieldStyle('fontStyle', currentElement.style.fontStyle === 'italic' ? 'normal' : 'italic')}><FormatItalic /></ToggleButton><ToggleButton value="underline" selected={currentElement.style.textDecoration === 'underline'} onClick={() => updateFieldStyle('textDecoration', currentElement.style.textDecoration === 'underline' ? 'none' : 'underline')}><FormatUnderlined /></ToggleButton></ToggleButtonGroup></Grid>
             <Grid item xs={12}><Typography variant="caption" display="block" gutterBottom>Alinhamento</Typography><ToggleButtonGroup value={currentElement.style.textAlign || 'left'} exclusive onChange={(e, v) => v && updateFieldStyle('textAlign', v)} size="small" fullWidth><ToggleButton value="left"><FormatAlignLeft /></ToggleButton><ToggleButton value="center"><FormatAlignCenter /></ToggleButton><ToggleButton value="right"><FormatAlignRight /></ToggleButton></ToggleButtonGroup></Grid>


### PR DESCRIPTION
This commit fixes a multi-part bug related to the generation and display of color swatches derived from images.

- Implements a server-side image proxy (`/api/image-proxy.js`) to solve CORS issues when reading pixel data from images hosted on Vercel Blob Storage.
- Adds color extraction logic to `HomePage.jsx` that is triggered when the main template image changes. The extracted colors are stored in the `imageColorPalette` context.
- Adds similar local color extraction logic to `PageEditor.jsx` to handle swatches for individually generated pages.
- The `FieldPositioner` component in both editing contexts now correctly receives and displays these dynamically generated image swatches.
- The `TextFormatting.jsx` component has been modified to remove the "Image Colors" section from the side editing panel, ensuring it only displays the campaign palette as intended.

This provides a complete and robust solution, correctly handling the data flow for both the template editor and the generated page editor, and respecting the specified UI requirements.