### PR TITLE
Refactor: Centralize and fix style clipboard logic

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -30,8 +30,11 @@ import {
   AspectRatio,
   Image as ImageIcon,
   BrandingWatermark,
+  ContentCopy,
+  ContentPaste,
 } from '@mui/icons-material';
 import { useCampaign } from '../context/CampaignContext';
+import { copyStyleToClipboard, pasteStyleFromClipboard } from '../utils/styleClipboard';
 import BrandElementManager from './BrandElementManager';
 import ImageManager from './ImageManager';
 import TextFormatting from './formatting/TextFormatting';
@@ -211,9 +214,36 @@ const FormattingPanel = ({
 
   const isImageElement = isPageImage || isBrandElement;
 
+  const handleCopy = () => {
+    copyStyleToClipboard(fieldStyles, fieldPositions, brandElements, pageTemplate);
+  };
+
+  const handlePaste = () => {
+    pasteStyleFromClipboard(setFieldStyles, setFieldPositions, setBrandElements, setPageTemplate);
+  };
+
   return (
     <Card>
       <CardContent>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h6" component="div">
+            Formatação
+          </Typography>
+          <Box>
+            <Tooltip title="Copiar Estilo da Página">
+              <IconButton onClick={handleCopy} size="small">
+                <ContentCopy />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Colar Estilo na Página">
+              <IconButton onClick={handlePaste} size="small">
+                <ContentPaste />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+        <Divider sx={{ mb: 2 }} />
+
         {showImageLoaders && (
           <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
             <Button variant="contained" component="label" startIcon={<ImageIcon />} fullWidth>

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -21,6 +21,7 @@ import { createNewImageElement } from '../utils/elementFactory';
 import { usePageData } from '../hooks/usePageData';
 import { useCampaign } from '../context/CampaignContext';
 import { safeDeepClone } from '../lib/utils';
+import { copyStyleToClipboard, pasteStyleFromClipboard } from '../utils/styleClipboard';
 import ColorThief from 'colorthief';
 
 const rgbToHex = (r, g, b) => '#' + [r, g, b].map(x => {
@@ -118,67 +119,16 @@ const PageEditor = ({
   };
 
   const handleCopyStyle = () => {
-    const styleData = {
-      styles: editedStyles,
-      positions: editedPositions,
-      brandElements: editedBrandElements,
-      pageTemplate: editedPageTemplate,
-    };
-
-    navigator.clipboard.writeText(JSON.stringify(styleData, null, 2))
-      .then(() => {
-        alert('Estilo copiado para a área de transferência!');
-      })
-      .catch(err => {
-        console.error('Erro ao copiar estilo: ', err);
-        alert('Erro ao copiar estilo. Verifique o console para mais detalhes.');
-      });
+    copyStyleToClipboard(editedStyles, editedPositions, editedBrandElements, editedPageTemplate);
   };
 
   const handlePasteStyle = async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      const pastedData = JSON.parse(text);
-
-      // Basic validation
-      if (pastedData && pastedData.styles && pastedData.positions) {
-        // Merge styles and positions field by field
-        setEditedStyles(prevStyles => {
-          const newStyles = { ...prevStyles };
-          for (const field in pastedData.styles) {
-            if (Object.prototype.hasOwnProperty.call(newStyles, field)) {
-              newStyles[field] = pastedData.styles[field];
-            }
-          }
-          return newStyles;
-        });
-
-        setEditedPositions(prevPositions => {
-          const newPositions = { ...prevPositions };
-          for (const field in pastedData.positions) {
-            if (Object.prototype.hasOwnProperty.call(newPositions, field)) {
-              newPositions[field] = pastedData.positions[field];
-            }
-          }
-          return newPositions;
-        });
-
-        if (pastedData.brandElements) {
-          setEditedBrandElements(pastedData.brandElements);
-        }
-
-        if (pastedData.pageTemplate) {
-          setEditedPageTemplate(pastedData.pageTemplate);
-        }
-
-        alert('Estilo colado com sucesso!');
-      } else {
-        alert('Os dados da área de transferência não parecem ser um estilo válido.');
-      }
-    } catch (err) {
-      console.error('Erro ao colar estilo: ', err);
-      alert('Erro ao colar estilo. Verifique o console para mais detalhes.');
-    }
+    await pasteStyleFromClipboard(
+      setEditedStyles,
+      setEditedPositions,
+      setEditedBrandElements,
+      setEditedPageTemplate
+    );
   };
 
   const handleInternalFieldSelection = useCallback((fieldToSelect) => {

--- a/src/utils/styleClipboard.js
+++ b/src/utils/styleClipboard.js
@@ -1,0 +1,121 @@
+/**
+ * Handles copying and pasting of styles for page templates.
+ */
+import { safeDeepClone } from '../lib/utils';
+import { toast } from 'sonner';
+
+/**
+ * Copies the style and layout data to the clipboard.
+ * It sanitizes the page template to remove content-specific data like image sources.
+ *
+ * @param {object} styles - The styles object for text fields.
+ * @param {object} positions - The positions object for text fields.
+ * @param {Array} brandElements - The array of brand elements.
+ * @param {object} pageTemplate - The page template object, including images.
+ */
+export const copyStyleToClipboard = async (styles, positions, brandElements, pageTemplate) => {
+  try {
+    // Sanitize pageTemplate to remove content, keeping only style-related properties.
+    const pageTemplateForClipboard = safeDeepClone(pageTemplate);
+    if (pageTemplateForClipboard.images && Array.isArray(pageTemplateForClipboard.images)) {
+      pageTemplateForClipboard.images = pageTemplateForClipboard.images.map(img => {
+        // Omit 'id' and 'src' as they are content, not style.
+        const { id, src, ...styleAttrs } = img;
+        return styleAttrs;
+      });
+    }
+
+    const styleData = {
+      styles,
+      positions,
+      brandElements: brandElements || [],
+      pageTemplate: pageTemplateForClipboard,
+    };
+
+    await navigator.clipboard.writeText(JSON.stringify(styleData, null, 2));
+    toast.success('Estilo copiado para a área de transferência!');
+  } catch (err) {
+    console.error('Erro ao copiar estilo: ', err);
+    toast.error('Erro ao copiar estilo. Verifique o console para mais detalhes.');
+  }
+};
+
+/**
+ * Pastes style and layout data from the clipboard, merging it with the current state.
+ *
+ * @param {Function} setStyles - State setter for text field styles.
+ * @param {Function} setPositions - State setter for text field positions.
+ * @param {Function} setBrandElements - State setter for brand elements.
+ * @param {Function} setPageTemplate - State setter for the page template.
+ */
+export const pasteStyleFromClipboard = async (setStyles, setPositions, setBrandElements, setPageTemplate) => {
+  try {
+    const text = await navigator.clipboard.readText();
+    const pastedData = JSON.parse(text);
+
+    if (!pastedData || !pastedData.styles || !pastedData.positions) {
+      toast.error('Os dados da área de transferência não parecem ser um estilo válido.');
+      return;
+    }
+
+    // Merge text styles and positions field by field
+    setStyles(prevStyles => {
+      const newStyles = { ...prevStyles };
+      for (const field in pastedData.styles) {
+        if (Object.prototype.hasOwnProperty.call(newStyles, field)) {
+          newStyles[field] = pastedData.styles[field];
+        }
+      }
+      return newStyles;
+    });
+
+    setPositions(prevPositions => {
+      const newPositions = { ...prevPositions };
+      for (const field in pastedData.positions) {
+        if (Object.prototype.hasOwnProperty.call(newPositions, field)) {
+          newPositions[field] = pastedData.positions[field];
+        }
+      }
+      return newPositions;
+    });
+
+    if (pastedData.brandElements) {
+      setBrandElements(pastedData.brandElements);
+    }
+
+    // Deep merge page template styles
+    if (pastedData.pageTemplate) {
+      setPageTemplate(currentTemplate => {
+        const newTemplate = safeDeepClone(currentTemplate);
+        const sourceTemplate = pastedData.pageTemplate;
+
+        // Merge background and gradient
+        newTemplate.backgroundColor = sourceTemplate.backgroundColor;
+        newTemplate.gradient = sourceTemplate.gradient;
+
+        // Merge image styles, preserving destination content (src, id)
+        if (newTemplate.images && sourceTemplate.images) {
+          newTemplate.images = newTemplate.images.map((destImage, index) => {
+            const sourceImageStyle = sourceTemplate.images[index];
+            if (sourceImageStyle) {
+              // Keep src and id from the destination, apply styles from source
+              const { src, id } = destImage;
+              return { ...sourceImageStyle, src, id };
+            }
+            return destImage; // Keep original if no corresponding source
+          });
+        }
+        return newTemplate;
+      });
+    }
+
+    toast.success('Estilo colado com sucesso!');
+  } catch (err) {
+    console.error('Erro ao colar estilo: ', err);
+    if (err instanceof SyntaxError) {
+      toast.error('O conteúdo da área de transferência não é um JSON de estilo válido.');
+    } else {
+      toast.error('Erro ao colar estilo. Verifique o console para mais detalhes.');
+    }
+  }
+};


### PR DESCRIPTION
This commit refactors the copy/paste style functionality into a centralized utility module and fixes the core logic to meet user requirements.

The previous implementation incorrectly copied content-specific data (image `id` and `src`) and overwrote destination content on paste.

The new implementation includes:
- A new utility module `src/utils/styleClipboard.js` with `copyStyleToClipboard` and `pasteStyleFromClipboard` functions.
- `copyStyleToClipboard` now sanitizes the page template, removing `id` and `src` from image objects before copying.
- `pasteStyleFromClipboard` now performs a deep merge, applying styles from the source while preserving the `id` and `src` of destination images.
- `PageEditor.jsx` is refactored to use the new utility.
- The copy/paste functionality has been added to `FormattingPanel.jsx`, making it available in the main template editor (`ImageStep`), thus providing a consistent feature set across both editors.