### PR TITLE
feat: Add button to create persona from campaign page

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -237,15 +237,20 @@ const Campaign = ({
     const prevCampaignContent = prevCampaignContentRef.current;
 
     useEffect(() => {
-        if (location.state?.newAutorId) {
-            setSelectedAutorForCampaign(location.state.newAutorId);
+        if (location.state?.newAutorId || location.state?.newPersonaId) {
+            if (location.state.newAutorId) {
+                setSelectedAutorForCampaign(location.state.newAutorId);
+            }
+            if (location.state.newPersonaId) {
+                setSelectedPersonaForCampaign(location.state.newPersonaId);
+            }
             if (problemaRef.current) {
                 problemaRef.current.focus();
             }
             // Limpa o estado para evitar re-acionamento
-            navigate(location.pathname, { replace: true });
+            navigate(location.pathname, { state: {}, replace: true });
         }
-    }, [location.state, setSelectedAutorForCampaign, navigate, location.pathname]);
+    }, [location.state, setSelectedAutorForCampaign, setSelectedPersonaForCampaign, navigate, location.pathname]);
 
     useEffect(() => {
         if (campaignContent && !prevCampaignContent && !isGeneratingCampaign) {
@@ -399,24 +404,35 @@ const Campaign = ({
                 <TabPanel value={activeTab} index={0}>
                     <Grid container spacing={3} sx={{ mt: 2 }}>
                         <Grid item xs={12}>
-                            <FormControl fullWidth variant="outlined" sx={{ mb: 2 }} disabled={campaignContent !== null}>
-                                <InputLabel id="persona-select-label">Selecionar Persona</InputLabel>
-                                <Select
-                                    labelId="persona-select-label"
-                                    value={selectedPersonaForCampaign}
-                                    onChange={(e) => setSelectedPersonaForCampaign(e.target.value)}
-                                    label="Selecionar Persona"
-                                >
-                                    <MenuItem value="">
-                                        <em>Não especificar</em>
-                                    </MenuItem>
-                                    {(personaList || []).map((p) => (
-                                        <MenuItem key={p.id} value={p.id}>
-                                            {p.name}
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+                                <FormControl fullWidth variant="outlined" disabled={campaignContent !== null}>
+                                    <InputLabel id="persona-select-label">Selecionar Persona</InputLabel>
+                                    <Select
+                                        labelId="persona-select-label"
+                                        value={selectedPersonaForCampaign}
+                                        onChange={(e) => setSelectedPersonaForCampaign(e.target.value)}
+                                        label="Selecionar Persona"
+                                    >
+                                        <MenuItem value="">
+                                            <em>Não especificar</em>
                                         </MenuItem>
-                                    ))}
-                                </Select>
-                            </FormControl>
+                                        {(personaList || []).map((p) => (
+                                            <MenuItem key={p.id} value={p.id}>
+                                                {p.name}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                                <Tooltip title="Adicionar nova persona">
+                                    <IconButton
+                                        color="primary"
+                                        onClick={() => navigate('/personas/new', { state: { from: location.pathname } })}
+                                        disabled={campaignContent !== null}
+                                    >
+                                        <AddIcon />
+                                    </IconButton>
+                                </Tooltip>
+                            </Box>
                         </Grid>
                         <Grid item xs={12}>
                             <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {
@@ -25,6 +26,8 @@ import geminiAPI from '../utils/geminiAPI';
 const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected, onUpdate }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const navigate = useNavigate();
+  const location = useLocation();
 
   // State for Persona View
   const [personaList, setPersonaList] = useState([]);
@@ -116,10 +119,18 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
         return false;
     }
     try {
+        const isNewPersona = !personaToSave.id;
         const saved = personaToSave.id
             ? await updatePersona(personaToSave.id, personaToSave.name, personaToSave.persona_data)
             : await savePersona(personaToSave.name, personaToSave.persona_data);
+
         toast.success("Persona salva com sucesso!");
+
+        if (isNewPersona && location.state?.from) {
+            navigate(location.state.from, { state: { newPersonaId: saved.id }, replace: true });
+            return true;
+        }
+
         await fetchPersonas();
         if (onUpdate) onUpdate();
         setSelectedPersona(saved);


### PR DESCRIPTION
This commit introduces a new feature that allows users to create a new persona directly from the campaign creation page.

- A '+' button has been added next to the 'Selecionar Persona' dropdown on the campaign page.
- Clicking this button navigates the user to the new persona creation page.
- After the new persona is saved, the user is redirected back to the campaign page.
- The newly created persona is automatically selected in the dropdown.
- The focus is set to the 'Problema' field for a smoother user experience.

This change mirrors the functionality previously added for creating authors and further streamlines the campaign setup process.