### PR TITLE
feat: Add in-app flow for creating authors and personas

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Card,
   CardContent,
@@ -47,6 +46,7 @@ import {
     Save as SaveIcon,
     Add as AddIcon,
 } from '@mui/icons-material';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 const problemaHint = (
     <Box sx={{ p: 2, maxWidth: 500 }}>
@@ -197,6 +197,8 @@ const Campaign = ({
     selectedPersonaForCampaign,
     setSelectedPersonaForCampaign,
     palettes,
+    onRequestNewAutor,
+    onRequestNewPersona,
 }) => {
     useSettings();
     const {
@@ -205,8 +207,6 @@ const Campaign = ({
         customPalette,
         setCustomPalette,
     } = useCampaignContext();
-    const navigate = useNavigate();
-    const location = useLocation();
     const problemaRef = useRef(null);
 
     const [activeTab, setActiveTab] = useState(0);
@@ -237,20 +237,10 @@ const Campaign = ({
     const prevCampaignContent = prevCampaignContentRef.current;
 
     useEffect(() => {
-        if (location.state?.newAutorId || location.state?.newPersonaId) {
-            if (location.state.newAutorId) {
-                setSelectedAutorForCampaign(location.state.newAutorId);
-            }
-            if (location.state.newPersonaId) {
-                setSelectedPersonaForCampaign(location.state.newPersonaId);
-            }
-            if (problemaRef.current) {
-                problemaRef.current.focus();
-            }
-            // Limpa o estado para evitar re-acionamento
-            navigate(location.pathname, { state: {}, replace: true });
+        if (problemaRef.current) {
+            problemaRef.current.focus();
         }
-    }, [location.state, setSelectedAutorForCampaign, setSelectedPersonaForCampaign, navigate, location.pathname]);
+    }, []);
 
     useEffect(() => {
         if (campaignContent && !prevCampaignContent && !isGeneratingCampaign) {
@@ -426,7 +416,7 @@ const Campaign = ({
                                 <Tooltip title="Adicionar nova persona">
                                     <IconButton
                                         color="primary"
-                                        onClick={() => navigate('/personas', { state: { createNew: true, from: location.pathname } })}
+                                        onClick={onRequestNewPersona}
                                         disabled={campaignContent !== null}
                                     >
                                         <AddIcon />
@@ -480,7 +470,7 @@ const Campaign = ({
                                         <Tooltip title="Adicionar novo autor">
                                             <IconButton
                                                 color="primary"
-                                                onClick={() => navigate('/autores', { state: { createNew: true, from: location.pathname } })}
+                                                onClick={onRequestNewAutor}
                                                 disabled={campaignContent !== null}
                                             >
                                                 <AddIcon />

--- a/src/pages/AutoresPage.jsx
+++ b/src/pages/AutoresPage.jsx
@@ -15,7 +15,7 @@ import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
 import { getGeminiApiKey } from '../utils/geminiCredentials';
 import geminiAPI from '../utils/geminiAPI';
 
-const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected, onUpdate }) => {
+const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected, onUpdate, startInCreateMode, onAutorCreated, onCreationCancelled }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
@@ -53,11 +53,10 @@ const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected, o
   }, [selectedAutor, onNoAutorSelected]);
 
   useEffect(() => {
-    if (location.state?.createNew) {
+    if (startInCreateMode) {
       handleNewAutor();
-      navigate(location.pathname, { state: {}, replace: true });
     }
-  }, [location.state]);
+  }, [startInCreateMode]);
 
   const fetchAutores = async () => {
       setAutoresLoading(true);
@@ -106,8 +105,8 @@ const AutoresPage = ({ autorDrawerOpen, setAutorDrawerOpen, onNoAutorSelected, o
 
         toast.success("Autor salvo com sucesso!");
 
-        if (isNewAutor && location.state?.from) {
-            navigate(location.state.from, { state: { newAutorId: saved.id }, replace: true });
+        if (isNewAutor && onAutorCreated) {
+            onAutorCreated(saved);
             return true;
         }
 
@@ -287,8 +286,12 @@ Retorne apenas um único objeto JSON.`;
                   isMobile ? (
                     <AutorWizard
                       key={selectedAutor.id || 'new'}
-                      open={Boolean(selectedAutor)}
-                      onClose={() => handleNavigation(() => setSelectedAutor(null))}
+                      onClose={() => handleNavigation(() => {
+                        if (startInCreateMode && onCreationCancelled) {
+                          onCreationCancelled();
+                        }
+                        setSelectedAutor(null);
+                      })}
                       onSave={handleSaveAutor}
                       onReset={handleNewAutor}
                       autorData={autorFormData}
@@ -302,7 +305,12 @@ Retorne apenas um único objeto JSON.`;
                       <AutorWizard
                         key={selectedAutor.id || 'new'}
                         open={Boolean(selectedAutor)}
-                        onClose={() => handleNavigation(() => setSelectedAutor(null))}
+                        onClose={() => handleNavigation(() => {
+                          if (startInCreateMode && onCreationCancelled) {
+                            onCreationCancelled();
+                          }
+                          setSelectedAutor(null);
+                        })}
                         onSave={handleSaveAutor}
                         onReset={handleNewAutor}
                         autorData={autorFormData}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -186,6 +186,8 @@ function HomePage() {
 
   const [selectedPersonaForCampaign, setSelectedPersonaForCampaign] = useState('');
   const [selectedAutorForCampaign, setSelectedAutorForCampaign] = useState('');
+  const [startAutoresInCreate, setStartAutoresInCreate] = useState(false);
+  const [startPersonasInCreate, setStartPersonasInCreate] = useState(false);
 
   // State for unsaved changes guard
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
@@ -229,6 +231,41 @@ function HomePage() {
         // }
         setNavigationTarget(null);
     };
+
+  const handleRequestNewAutor = () => {
+    setStartAutoresInCreate(true);
+    setCurrentView('autores');
+  };
+
+  const handleRequestNewPersona = () => {
+    setStartPersonasInCreate(true);
+    setCurrentView('personas');
+  };
+
+  const handleCreationDone = (view) => {
+    if (view === 'autores') {
+      setStartAutoresInCreate(false);
+    } else if (view === 'personas') {
+      setStartPersonasInCreate(false);
+    }
+    setCurrentView('campaigns');
+  };
+
+  const handleAutorCreated = (newAutor) => {
+    if (newAutor && newAutor.id) {
+        setSelectedAutorForCampaign(newAutor.id);
+    }
+    setStartAutoresInCreate(false);
+    setCurrentView('campaigns');
+  };
+
+  const handlePersonaCreated = (newPersona) => {
+    if (newPersona && newPersona.id) {
+        setSelectedPersonaForCampaign(newPersona.id);
+    }
+    setStartPersonasInCreate(false);
+    setCurrentView('campaigns');
+  };
 
 
   const applyAppState = (state) => {
@@ -1521,6 +1558,8 @@ function HomePage() {
                       selectedPersonaForCampaign={selectedPersonaForCampaign}
                       setSelectedPersonaForCampaign={setSelectedPersonaForCampaign}
                       palettes={palettes}
+                      onRequestNewAutor={handleRequestNewAutor}
+                      onRequestNewPersona={handleRequestNewPersona}
                     />
                   </Container>
                 )}
@@ -1685,8 +1724,8 @@ function HomePage() {
                 </Box>
               </>
             )}
-            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} onUpdate={fetchPersonasForCampaign} />}
-            {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} onUpdate={fetchAutoresForCampaign} />}
+            {currentView === 'personas' && <PersonasPage personaDrawerOpen={personaDrawerOpen} setPersonaDrawerOpen={setPersonaDrawerOpen} onNoPersonaSelected={() => setPersonaDrawerOpen(true)} onUpdate={fetchPersonasForCampaign} startInCreateMode={startPersonasInCreate} onPersonaCreated={handlePersonaCreated} onCreationCancelled={() => handleCreationDone('personas')} />}
+            {currentView === 'autores' && <AutoresPage autorDrawerOpen={autorDrawerOpen} setAutorDrawerOpen={setAutorDrawerOpen} onNoAutorSelected={() => setAutorDrawerOpen(true)} onUpdate={fetchAutoresForCampaign} startInCreateMode={startAutoresInCreate} onAutorCreated={handleAutorCreated} onCreationCancelled={() => handleCreationDone('autores')} />}
             {currentView === 'palettes' && <PalettesPage paletteDrawerOpen={paletteDrawerOpen} setPaletteDrawerOpen={setPaletteDrawerOpen} onNoPaletteSelected={() => setPaletteDrawerOpen(true)} />}
         </Box>
       </Box>

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -23,7 +23,7 @@ import geminiAPI from '../utils/geminiAPI';
  * where the `PersonaWizard` is displayed. The component is self-contained and handles
  * all its state and API interactions.
  */
-const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected, onUpdate }) => {
+const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSelected, onUpdate, startInCreateMode, onPersonaCreated, onCreationCancelled }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
@@ -66,13 +66,10 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
   }, [selectedPersona, onNoPersonaSelected]);
 
   useEffect(() => {
-    // If the user was routed from another page with the intent to create a new persona
-    if (location.state?.createNew) {
+    if (startInCreateMode) {
       handleNewPersona();
-      // Clean the state to prevent this from re-triggering on refresh
-      navigate(location.pathname, { state: {}, replace: true });
     }
-  }, [location.state]);
+  }, [startInCreateMode]);
 
   /**
    * Fetches the list of personas from the API and updates the state.
@@ -135,8 +132,8 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
 
         toast.success("Persona salva com sucesso!");
 
-        if (isNewPersona && location.state?.from) {
-            navigate(location.state.from, { state: { newPersonaId: saved.id }, replace: true });
+        if (isNewPersona && onPersonaCreated) {
+            onPersonaCreated(saved);
             return true;
         }
 
@@ -318,8 +315,12 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                   isMobile ? (
                     <PersonaWizard
                       key={selectedPersona.id || 'new'}
-                      open={Boolean(selectedPersona)}
-                      onClose={() => handleNavigation(() => setSelectedPersona(null))}
+                      onClose={() => handleNavigation(() => {
+                        if (startInCreateMode && onCreationCancelled) {
+                          onCreationCancelled();
+                        }
+                        setSelectedPersona(null);
+                      })}
                       onSave={handleSavePersona}
                       onReset={handleNewPersona}
                       personaData={personaFormData}
@@ -333,7 +334,12 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                       <PersonaWizard
                         key={selectedPersona.id || 'new'}
                         open={Boolean(selectedPersona)}
-                        onClose={() => handleNavigation(() => setSelectedPersona(null))}
+                        onClose={() => handleNavigation(() => {
+                            if (startInCreateMode && onCreationCancelled) {
+                                onCreationCancelled();
+                            }
+                            setSelectedPersona(null);
+                        })}
                         onSave={handleSavePersona}
                         onReset={handleNewPersona}
                         personaData={personaFormData}


### PR DESCRIPTION
This commit refactors the feature for adding new authors and personas from the campaign page to work with the application's state-based navigation, rather than URL routing.

The key changes are:

- **`HomePage.jsx`:**
  - Now manages the creation flow with new state variables (`startAutoresInCreate`, `startPersonasInCreate`) and handler functions (`handleRequestNewAutor`, `handleRequestNewPersona`, `handleAutorCreated`, `handlePersonaCreated`, `handleCreationDone`).
  - It passes these handlers down to the child components to orchestrate the view switching and state updates.

- **`Campaign.jsx`:**
  - The '+' buttons no longer use `useNavigate`. Instead, they call the `onRequestNew...` props passed down from `HomePage` to trigger the view change.
  - The `useNavigate` and `useLocation` hooks have been removed as they are no longer needed.

- **`AutoresPage.jsx` & `PersonasPage.jsx`:**
  - These components now accept `startInCreateMode`, `on...Created`, and `onCreationCancelled` props.
  - A `useEffect` hook triggers the creation wizard when `startInCreateMode` is true.
  - The save handlers now call the `on...Created` callback to pass the new data up to `HomePage` and switch the view back to the campaign.
  - The wizard's `onClose` handler now calls `onCreationCancelled` to return to the campaign view if the creation process is aborted.

This resolves the 404 errors and implements the feature in a way that is consistent with the existing application architecture.