### PR TITLE
fix: Add data refetching after creating author/persona

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -252,6 +252,7 @@ function HomePage() {
   };
 
   const handleAutorCreated = (newAutor) => {
+    fetchAutoresForCampaign();
     if (newAutor && newAutor.id) {
         setSelectedAutorForCampaign(newAutor.id);
     }
@@ -260,6 +261,7 @@ function HomePage() {
   };
 
   const handlePersonaCreated = (newPersona) => {
+    fetchPersonasForCampaign();
     if (newPersona && newPersona.id) {
         setSelectedPersonaForCampaign(newPersona.id);
     }


### PR DESCRIPTION
This commit fixes a data synchronization bug where the list of authors or personas was not being updated on the campaign page after a new one was created.

- **`HomePage.jsx`:**
  - The `handleAutorCreated` and `handlePersonaCreated` functions now call `fetchAutoresForCampaign()` and `fetchPersonasForCampaign()` respectively. This ensures that the lists of authors and personas are refreshed with the latest data before returning to the campaign view.

This change ensures that when a user creates a new author or persona, it correctly appears in the selection dropdown upon returning to the campaign page.