### PR TITLE
feat: Add AI-powered persona description generation from LinkedIn

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -4,7 +4,7 @@ import { useSwipeable } from 'react-swipeable';
 import {
   Dialog, DialogTitle, DialogContent, Button, LinearProgress, Box, TextField, Typography, Grid, FormControl, InputLabel, Select, MenuItem, Chip, Checkbox, ListItemText, Accordion, AccordionSummary, AccordionDetails, FormGroup, FormControlLabel, CircularProgress, Tooltip, IconButton, Link as MuiLink,
 } from '@mui/material';
-import { ExpandMore as ExpandMoreIcon, InfoOutlined as InfoOutlinedIcon, Replay as ReplayIcon, ArrowBack, ArrowForward, AutoAwesome as AutoAwesomeIcon } from '@mui/icons-material';
+import { ExpandMore as ExpandMoreIcon, InfoOutlined as InfoOutlinedIcon, Replay as ReplayIcon, ArrowBack, ArrowForward, AutoAwesome as AutoAwesomeIcon, LinkedIn as LinkedInIcon } from '@mui/icons-material';
 import TextEditor from './TextEditor';
 
 // Constants
@@ -31,8 +31,10 @@ const steps = ['Início Rápido com IA', 'Revisão Básica', 'Responsabilidades'
  * @param {object} props.personaData - The object containing all the data for the persona being edited.
  * @param {function} props.onPersonaDataChange - Callback to update the personaData object in the parent component.
  * @param {number} [props.initialStep=0] - The step the wizard should start on.
+ * @param {function} props.onGenerateFromLinkedIn - Callback to trigger AI description generation from LinkedIn.
+ * @param {boolean} props.isGeneratingFromLinkedIn - Flag indicating if the LinkedIn generation is in progress.
  */
-export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, personaData, onPersonaDataChange, initialStep = 0 }) => {
+export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, personaData, onPersonaDataChange, initialStep = 0, onGenerateFromLinkedIn, isGeneratingFromLinkedIn }) => {
   const [activeStep, setActiveStep] = useState(initialStep);
   const isMobile = useIsMobile();
 
@@ -84,6 +86,15 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     }
   };
 
+  const handleGenerateFromLinkedInClick = () => {
+    const linkedInUrl = window.prompt("Por favor, insira a URL do perfil do LinkedIn:");
+    if (linkedInUrl) {
+        onGenerateFromLinkedIn(linkedInUrl, (generatedDescription) => {
+            onPersonaDataChange(prev => ({ ...prev, description: generatedDescription }));
+        });
+    }
+  };
+
 
   const InfoTooltip = ({ title, url }) => (<Tooltip title={<Typography variant="body2" sx={{ p: 1 }}>{title} {url && <MuiLink href={url} target="_blank" rel="noopener noreferrer" sx={{ color: 'cyan', display: 'block', mt: 1 }}>Saiba mais</MuiLink>}</Typography>}><IconButton><InfoOutlinedIcon sx={{ color: 'text.secondary', fontSize: '1rem' }} /></IconButton></Tooltip>);
 
@@ -91,9 +102,14 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     switch (step) {
       case 0: return (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <TextField name="description" label="Descrição da Persona" multiline rows={6} fullWidth value={personaData.description || ''} onChange={handleChange} placeholder="Ex: 'CTO de uma startup...'" disabled={isGeneratingPersona} />
+            <TextField name="description" label="Descrição da Persona" multiline rows={6} fullWidth value={personaData.description || ''} onChange={handleChange} placeholder="Ex: 'CTO de uma startup...'" disabled={isGeneratingPersona || isGeneratingFromLinkedIn} />
+            <Tooltip title="Gerar descrição com IA a partir de um perfil do LinkedIn">
+                <IconButton onClick={handleGenerateFromLinkedInClick} disabled={isGeneratingPersona || isGeneratingFromLinkedIn} color="primary">
+                    {isGeneratingFromLinkedIn ? <CircularProgress size={24} /> : <LinkedInIcon />}
+                </IconButton>
+            </Tooltip>
             <Tooltip title="Gerar persona com IA">
-                <IconButton onClick={handleGenerateClick} disabled={isGeneratingPersona || !personaData.description?.trim()} color="primary">
+                <IconButton onClick={handleGenerateClick} disabled={isGeneratingPersona || isGeneratingFromLinkedIn || !personaData.description?.trim()} color="primary">
                     {isGeneratingPersona ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
                 </IconButton>
             </Tooltip>

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -35,6 +35,7 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
   const [personasLoading, setPersonasLoading] = useState(true);
   const [personasError, setPersonasError] = useState(null);
   const [isGeneratingPersona, setIsGeneratingPersona] = useState(false);
+  const [isGeneratingFromLinkedIn, setIsGeneratingFromLinkedIn] = useState(false);
   const [initialWizardStep, setInitialWizardStep] = useState(0);
 
   // State for unsaved changes guard
@@ -176,6 +177,29 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
             toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console para detalhes.');
         } finally {
             setIsGeneratingPersona(false);
+        }
+    };
+
+    const handleGenerateDescriptionFromLinkedIn = async (linkedInUrl, callback) => {
+        if (!geminiAPI.isInitialized) {
+            const apiKey = getGeminiApiKey();
+            if (!apiKey) {
+                toast.error('Chave de API do Gemini não configurada.');
+                return;
+            }
+            geminiAPI.initialize(apiKey);
+        }
+        setIsGeneratingFromLinkedIn(true);
+        const prompt = `Com base no seguinte perfil do LinkedIn: ${linkedInUrl}, elabore o conteúdo para o campo de descrição de uma persona de marketing. A descrição deve ser detalhada, em primeira pessoa, e capturar a essência profissional, as responsabilidades e os desafios do indivíduo, como se ele mesmo estivesse se descrevendo.`;
+        try {
+            const response = await geminiAPI.generateContent(prompt);
+            if (callback) callback(response);
+            toast.success('Descrição gerada com sucesso!');
+        } catch (error) {
+            console.error("Error generating description from LinkedIn:", error);
+            toast.error('Ocorreu um erro ao gerar a descrição a partir do LinkedIn. Verifique o console para detalhes.');
+        } finally {
+            setIsGeneratingFromLinkedIn(false);
         }
     };
 
@@ -328,6 +352,8 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                       onPersonaDataChange={setPersonaFormData}
                       onGenerate={handleGeneratePersonaWithAI}
                       isGeneratingPersona={isGeneratingPersona}
+                      onGenerateFromLinkedIn={handleGenerateDescriptionFromLinkedIn}
+                      isGeneratingFromLinkedIn={isGeneratingFromLinkedIn}
                       initialStep={initialWizardStep}
                     />
                   ) : (
@@ -347,6 +373,8 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                         onPersonaDataChange={setPersonaFormData}
                         onGenerate={handleGeneratePersonaWithAI}
                         isGeneratingPersona={isGeneratingPersona}
+                        onGenerateFromLinkedIn={handleGenerateDescriptionFromLinkedIn}
+                        isGeneratingFromLinkedIn={isGeneratingFromLinkedIn}
                         initialStep={initialWizardStep}
                       />
                     </Paper>


### PR DESCRIPTION
This commit introduces a new feature that allows users to generate a persona's description using a LinkedIn profile URL.

Key changes:

-   A new button with a LinkedIn icon has been added to the first step of the Persona Wizard.
-   When clicked, the user is prompted to enter a LinkedIn profile URL.
-   A new function, `handleGenerateDescriptionFromLinkedIn`, has been added to `PersonasPage.jsx`. This function calls the Gemini API with a specialized prompt to create a detailed, first-person description based on the provided LinkedIn profile.
-   The `PersonaWizard.jsx` component has been updated to handle the new button's logic, including showing a loading state and updating the description field with the AI-generated content upon success.