### PR TITLE
Fix: Escape special characters in scheduled LinkedIn posts

### DIFF
--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -1,5 +1,5 @@
 import { query } from '../db.js';
-import { markdownToLinkedinText } from '../utils.js';
+import { markdownToLinkedinText, escapeLinkedinText } from '../utils.js';
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -100,7 +100,7 @@ export async function publishPost(fetch, post, accessToken) {
     const videoUrn = post.post_content?.video;
     const payload = {
         author: authorUrn,
-        content: postText,
+        content: escapeLinkedinText(postText),
         images: imageUrns,
         video: videoUrn,
         title: post.post_content?.titulo || 'Video Post'

--- a/api/utils.js
+++ b/api/utils.js
@@ -10,3 +10,11 @@ export const markdownToLinkedinText = (markdown) => {
     text = text.trim().replace(/\n{3,}/g, '\n\n');
     return text;
 };
+
+export const escapeLinkedinText = (text) => {
+    if (!text) return '';
+    // Escapa caracteres especiais que o LinkedIn pode interpretar como formatação.
+    // A lista de caracteres é baseada em documentação e testes da comunidade.
+    // A barra invertida '\' precisa ser escapada na regex e na string de substituição.
+    return text.replace(/([|{}@[\]()<>#*_~\\])/g, '\\$1');
+};


### PR DESCRIPTION
This commit fixes a bug where scheduled LinkedIn posts were being truncated if they contained special characters, such as parentheses.

The issue was caused by the scheduler not escaping special characters before sending the post content to the LinkedIn API.

This has been fixed by introducing a new `escapeLinkedinText` utility function that escapes a range of special characters known to be problematic on LinkedIn. This function is now called within the `publishPost` helper in the cron job (`api/cron/linkedin.js`) to ensure all post content is properly escaped before being sent to the API. This single, backend change ensures that both newly scheduled posts and already-scheduled posts with problematic characters will be handled correctly.