### PR TITLE
Feat: Allow resubmission of published posts

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -1144,7 +1144,7 @@ const Publisher = ({
                                                 </IconButton>
                                             </Tooltip>
                                             <Tooltip title={row.status === 'failed' ? 'Retry' : 'Edit Schedule'}>
-                                                <IconButton onClick={() => handleOpenEditModal(row)} size="small" disabled={row.status === 'published'}>
+                                                <IconButton onClick={() => handleOpenEditModal(row)} size="small">
                                                     {row.status === 'failed' ? <Replay /> : <Edit />}
                                                 </IconButton>
                                             </Tooltip>


### PR DESCRIPTION
This change allows users to resubmit posts that have already been published, not just failed ones. This is achieved by removing the 'disabled' attribute from the edit button for published posts in the Publisher component.