### PR TITLE
Fix: Add missing IconButton import in FormattingPanel

### DIFF
--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
   ToggleButton,
   ToggleButtonGroup,
+  IconButton,
 } from '@mui/material';
 import {
   ExpandMore,


### PR DESCRIPTION
The `FormattingPanel` component was using the `IconButton` component from `@mui/material` without importing it. This caused a `ReferenceError: IconButton is not defined` when the component was rendered, for example, when loading a campaign.

This change adds the missing import to resolve the error.