### PR TITLE
feat: Remove LinkedIn persona generation feature

### DIFF
--- a/src/components/PersonaWizard.jsx
+++ b/src/components/PersonaWizard.jsx
@@ -31,10 +31,8 @@ const steps = ['Início Rápido com IA', 'Revisão Básica', 'Responsabilidades'
  * @param {object} props.personaData - The object containing all the data for the persona being edited.
  * @param {function} props.onPersonaDataChange - Callback to update the personaData object in the parent component.
  * @param {number} [props.initialStep=0] - The step the wizard should start on.
- * @param {function} props.onGenerateFromLinkedIn - Callback to trigger AI description generation from LinkedIn.
- * @param {boolean} props.isGeneratingFromLinkedIn - Flag indicating if the LinkedIn generation is in progress.
  */
-export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, personaData, onPersonaDataChange, initialStep = 0, onGenerateFromLinkedIn, isGeneratingFromLinkedIn }) => {
+export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGeneratingPersona, personaData, onPersonaDataChange, initialStep = 0 }) => {
   const [activeStep, setActiveStep] = useState(initialStep);
   const isMobile = useIsMobile();
 
@@ -86,15 +84,6 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     }
   };
 
-  const handleGenerateFromLinkedInClick = () => {
-    const linkedInUrl = window.prompt("Por favor, insira a URL do perfil do LinkedIn:");
-    if (linkedInUrl) {
-        onGenerateFromLinkedIn(linkedInUrl, (generatedDescription) => {
-            onPersonaDataChange(prev => ({ ...prev, description: generatedDescription }));
-        });
-    }
-  };
-
 
   const InfoTooltip = ({ title, url }) => (<Tooltip title={<Typography variant="body2" sx={{ p: 1 }}>{title} {url && <MuiLink href={url} target="_blank" rel="noopener noreferrer" sx={{ color: 'cyan', display: 'block', mt: 1 }}>Saiba mais</MuiLink>}</Typography>}><IconButton><InfoOutlinedIcon sx={{ color: 'text.secondary', fontSize: '1rem' }} /></IconButton></Tooltip>);
 
@@ -102,14 +91,9 @@ export const PersonaWizardContent = ({ onSave, onClose, onGenerate, isGenerating
     switch (step) {
       case 0: return (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <TextField name="description" label="Descrição da Persona" multiline rows={6} fullWidth value={personaData.description || ''} onChange={handleChange} placeholder="Ex: 'CTO de uma startup...'" disabled={isGeneratingPersona || isGeneratingFromLinkedIn} />
-            <Tooltip title="Gerar descrição com IA a partir de um perfil do LinkedIn">
-                <IconButton onClick={handleGenerateFromLinkedInClick} disabled={isGeneratingPersona || isGeneratingFromLinkedIn} color="primary">
-                    {isGeneratingFromLinkedIn ? <CircularProgress size={24} /> : <LinkedInIcon />}
-                </IconButton>
-            </Tooltip>
+            <TextField name="description" label="Descrição da Persona" multiline rows={6} fullWidth value={personaData.description || ''} onChange={handleChange} placeholder="Ex: 'CTO de uma startup...'" disabled={isGeneratingPersona} />
             <Tooltip title="Gerar persona com IA">
-                <IconButton onClick={handleGenerateClick} disabled={isGeneratingPersona || isGeneratingFromLinkedIn || !personaData.description?.trim()} color="primary">
+                <IconButton onClick={handleGenerateClick} disabled={isGeneratingPersona || !personaData.description?.trim()} color="primary">
                     {isGeneratingPersona ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
                 </IconButton>
             </Tooltip>

--- a/src/pages/PersonasPage.jsx
+++ b/src/pages/PersonasPage.jsx
@@ -32,7 +32,6 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
   const [personasLoading, setPersonasLoading] = useState(true);
   const [personasError, setPersonasError] = useState(null);
   const [isGeneratingPersona, setIsGeneratingPersona] = useState(false);
-  const [isGeneratingFromLinkedIn, setIsGeneratingFromLinkedIn] = useState(false);
   const [initialWizardStep, setInitialWizardStep] = useState(0);
 
   // State for unsaved changes guard
@@ -174,29 +173,6 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
             toast.error('Ocorreu um erro ao processar a resposta da IA. Verifique o console para detalhes.');
         } finally {
             setIsGeneratingPersona(false);
-        }
-    };
-
-    const handleGenerateDescriptionFromLinkedIn = async (linkedInUrl, callback) => {
-        if (!geminiAPI.isInitialized) {
-            const apiKey = getGeminiApiKey();
-            if (!apiKey) {
-                toast.error('Chave de API do Gemini não configurada.');
-                return;
-            }
-            geminiAPI.initialize(apiKey);
-        }
-        setIsGeneratingFromLinkedIn(true);
-        const prompt = `Com base no seguinte perfil do LinkedIn: ${linkedInUrl}, elabore o resumo da descrição de sua persona no contexto da elaboração uma campanha de marketing destinada a pessoas com esse tipo de perfil. A descrição deve ser detalhada, em primeira pessoa, e capturar a essência profissional, as responsabilidades e os desafios do indivíduo, como se ele mesmo estivesse se descrevendo. Você deve priorizar sua ocupação atual`;
-        try {
-            const response = await geminiAPI.generateContent(prompt);
-            if (callback) callback(response);
-            toast.success('Descrição gerada com sucesso!');
-        } catch (error) {
-            console.error("Error generating description from LinkedIn:", error);
-            toast.error('Ocorreu um erro ao gerar a descrição a partir do LinkedIn. Verifique o console para detalhes.');
-        } finally {
-            setIsGeneratingFromLinkedIn(false);
         }
     };
 
@@ -349,8 +325,6 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                       onPersonaDataChange={setPersonaFormData}
                       onGenerate={handleGeneratePersonaWithAI}
                       isGeneratingPersona={isGeneratingPersona}
-                      onGenerateFromLinkedIn={handleGenerateDescriptionFromLinkedIn}
-                      isGeneratingFromLinkedIn={isGeneratingFromLinkedIn}
                       initialStep={initialWizardStep}
                     />
                   ) : (
@@ -370,8 +344,6 @@ const PersonasPage = ({ personaDrawerOpen, setPersonaDrawerOpen, onNoPersonaSele
                         onPersonaDataChange={setPersonaFormData}
                         onGenerate={handleGeneratePersonaWithAI}
                         isGeneratingPersona={isGeneratingPersona}
-                        onGenerateFromLinkedIn={handleGenerateDescriptionFromLinkedIn}
-                        isGeneratingFromLinkedIn={isGeneratingFromLinkedIn}
                         initialStep={initialWizardStep}
                       />
                     </Paper>


### PR DESCRIPTION
Removes the functionality that allows generating a persona description from a LinkedIn profile.

This change includes:
- Removal of the 'Gerar descrição com IA a partir de um perfil do LinkedIn' button from the PersonaWizard component.
- Deletion of the `handleGenerateDescriptionFromLinkedIn` function and its related state and props from the PersonasPage and PersonaWizard components.