### PR TITLE
feat: Unify campaign hashtags in follow-up posts

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1269,7 +1269,12 @@ function HomePage() {
         persona: finalPersona,
         autor: finalAutor,
       });
-      const newPosts = await generateFollowupPosts({ content, plan, persona: finalPersona, autor: finalAutor });
+      const newPosts = await generateFollowupPosts({
+        content,
+        plan,
+        persona: finalPersona,
+        autor: finalAutor,
+      });
       setFollowupPosts(prevPosts => [...prevPosts, ...newPosts]);
     } catch (error) {
       toast.error(`Ocorreu um erro ao gerar os posts de follow-up: ${error.message}`);

--- a/src/utils/generationHandlers.js
+++ b/src/utils/generationHandlers.js
@@ -384,6 +384,10 @@ export const generateFollowupPosts = async ({ content, plan, persona = null, aut
           throw new Error(`O conteúdo gerado tem ${conteudo_post.length} caracteres, mas o mínimo é ${MIN_CONTENT_LENGTH}.`);
         }
 
+        const campaignHashtags = content.hashtags || [];
+        const suggestedHashtags = postPlan.hashtags_sugeridas || [];
+        const combinedHashtags = [...new Set([...campaignHashtags, ...suggestedHashtags])];
+
         generatedPosts.push({
           post_numero: postPlan.post_numero,
           tipo_gancho: postPlan.tipo_gancho,
@@ -391,7 +395,7 @@ export const generateFollowupPosts = async ({ content, plan, persona = null, aut
           titulo: titulo_post,
           conteudo: conteudo_post,
           cta: postPlan.cta_sugerido,
-          hashtags_sugeridas: postPlan.hashtags_sugeridas || [],
+          hashtags_sugeridas: combinedHashtags,
         });
 
         console.log(`Post de follow-up #${postPlan.post_numero} gerado com sucesso na tentativa ${attempt}.`);


### PR DESCRIPTION
This change ensures that the hashtags defined at the campaign level are automatically included in all generated follow-up posts.

The `generateFollowupPosts` function in `src/utils/generationHandlers.js` has been modified to merge the campaign's hashtags with the AI-suggested hashtags for each follow-up post. This guarantees consistency and reinforces the campaign's branding across all related content.