### PR TITLE
Hotfix: Add missing useEffect import in SetupModal

### DIFF
--- a/src/components/SetupModal.jsx
+++ b/src/components/SetupModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useIsMobile } from '../hooks/use-mobile.js';
 import {
   Dialog,


### PR DESCRIPTION
This commit fixes a regression caused by a missing `useEffect` import in the `SetupModal` component. This was causing a runtime error and preventing the application from rendering correctly.