### PR TITLE
feat(analytics): Add daily LinkedIn post statistics collection

### DIFF
--- a/api/cron/linkedin-analytics.js
+++ b/api/cron/linkedin-analytics.js
@@ -1,0 +1,198 @@
+import { query } from '../db.js';
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+const PROXY_API_BASE_URL = process.env.VITE_API_BASE_URL || 'http://localhost:5173';
+
+// Fetches stats for a given set of posts, handling token refresh internally.
+async function fetchStatsWithRefresh(fetch, userId, accessToken, postsByAuthor) {
+    const internalApiHeaders = {
+        'Content-Type': 'application/json',
+        'x-internal-secret': process.env.INTERNAL_API_SECRET,
+    };
+
+    let currentAccessToken = accessToken;
+
+    const callProxy = (action, payload) => {
+        return fetch(`${PROXY_API_BASE_URL}/api/linkedin-proxy`, {
+            method: 'POST',
+            headers: internalApiHeaders,
+            body: JSON.stringify({
+                action,
+                accessToken: currentAccessToken,
+                payload,
+            }),
+        });
+    };
+
+    const processAuthor = async (authorUrn, posts) => {
+        if (authorUrn.includes(':organization:')) {
+            const urns = posts.map(p => p.urn);
+            return callProxy('getShareStatistics', { authorUrn, shareUrns: urns });
+        } else {
+            // For personal posts, we must call them one by one.
+            const results = [];
+            for (const post of posts) {
+                const res = await callProxy('getMemberPostStatistics', { ugcPostUrn: post.urn });
+                results.push(res);
+            }
+            return results;
+        }
+    };
+
+    let allResults = [];
+
+    for (const [authorUrn, posts] of Object.entries(postsByAuthor)) {
+        let responseOrResponses = await processAuthor(authorUrn, posts);
+
+        const isSingleResponse = !Array.isArray(responseOrResponses);
+        const responses = isSingleResponse ? [responseOrResponses] : responseOrResponses;
+
+        // Check for 401 in any of the responses
+        const needsRefresh = responses.some(res => res.status === 401);
+
+        if (needsRefresh) {
+            console.log(`Token expired for user ${userId}. Refreshing...`);
+            const refreshResponse = await fetch(`${PROXY_API_BASE_URL}/api/linkedin-proxy`, {
+                method: 'POST',
+                headers: internalApiHeaders,
+                body: JSON.stringify({ action: 'refreshTokenInternal', userId }),
+            });
+
+            if (!refreshResponse.ok) {
+                throw new Error(`Failed to refresh token for user ${userId}.`);
+            }
+
+            const { accessToken: newAccessToken } = await refreshResponse.json();
+            currentAccessToken = newAccessToken;
+            console.log(`Token refreshed for user ${userId}. Retrying stat collection...`);
+            await delay(2000);
+
+            // Retry the API call with the new token
+            responseOrResponses = await processAuthor(authorUrn, posts);
+        }
+
+        allResults.push(responseOrResponses);
+    }
+
+    return allResults.flat();
+}
+
+
+// The main scheduler logic for collecting analytics
+export async function handleRunAnalyticsCollector(request, response) {
+    const fetch = (await import('node-fetch')).default;
+    console.log('Analytics collector run initiated...');
+    let processedCount = 0;
+    let failedCount = 0;
+
+    try {
+        const threeMonthsAgo = new Date();
+        threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+
+        const { rows: posts } = await query(
+            `SELECT ls.id, ls.urn, ls.user_id, ls.post_content->>'authorUrn' as author_urn, u.linkedin_access_token
+             FROM linkedin_schedules ls
+             JOIN users u ON ls.user_id = u.id
+             WHERE ls.status = 'published' AND ls.scheduled_at >= $1`,
+            [threeMonthsAgo]
+        );
+
+        if (posts.length === 0) {
+            return response.status(200).json({ message: 'No published posts in the last 3 months to analyze.' });
+        }
+
+        const postsByUser = posts.reduce((acc, post) => {
+            if (!acc[post.user_id]) {
+                acc[post.user_id] = { accessToken: post.linkedin_access_token, posts: [] };
+            }
+            acc[post.user_id].posts.push({ id: post.id, urn: post.urn, author_urn: post.author_urn });
+            return acc;
+        }, {});
+
+        const snapshotDate = new Date().toISOString().split('T')[0];
+
+        for (const [userId, userData] of Object.entries(postsByUser)) {
+            try {
+                const postsByAuthor = userData.posts.reduce((acc, post) => {
+                    if (post.author_urn && post.urn) {
+                        if (!acc[post.author_urn]) acc[post.author_urn] = [];
+                        acc[post.author_urn].push({ id: post.id, urn: post.urn });
+                    }
+                    return acc;
+                }, {});
+
+                const statResponses = await fetchStatsWithRefresh(fetch, userId, userData.accessToken, postsByAuthor);
+
+                for (const res of statResponses) {
+                    if (!res.ok) {
+                        const errorData = await res.json().catch(() => ({}));
+                        console.error(`Failed to fetch stats for a batch. Status: ${res.status}, Body: ${JSON.stringify(errorData)}`);
+                        continue;
+                    }
+
+                    const data = await res.json();
+                    if (!data.elements) continue;
+
+                    for (const stat of data.elements) {
+                        const urn = stat.share || stat.ugcPost || stat.post || data.urn;
+                        const statsData = stat.totalShareStatistics || stat; // Adapt for different response structures
+
+                        const post = userData.posts.find(p => p.urn === urn);
+                        if (!post) continue;
+
+                        const {
+                            impressionCount = 0,
+                            likeCount = 0,
+                            commentCount = 0,
+                            shareCount = 0,
+                            clickCount = 0,
+                            engagement = 0
+                        } = statsData;
+
+                        await query(
+                            `INSERT INTO linkedin_post_analytics
+                             (publication_id, snapshot_date, impression_count, click_count, like_count, comment_count, share_count, engagement)
+                             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                             ON CONFLICT (publication_id, snapshot_date) DO UPDATE SET
+                                impression_count = EXCLUDED.impression_count,
+                                click_count = EXCLUDED.click_count,
+                                like_count = EXCLUDED.like_count,
+                                comment_count = EXCLUDED.comment_count,
+                                share_count = EXCLUDED.share_count,
+                                engagement = EXCLUDED.engagement,
+                                updated_at = NOW()`,
+                            [post.id, snapshotDate, impressionCount, clickCount, likeCount, commentCount, shareCount, engagement]
+                        );
+                        processedCount++;
+                    }
+                }
+            } catch (error) {
+                failedCount++;
+                console.error(`Failed to process analytics for user ${userId}. Error: ${error.message}`);
+            }
+        }
+
+        const summary = `Analytics collector finished. Processed: ${processedCount}, Failed Batches: ${failedCount}.`;
+        console.log(summary);
+        return response.status(200).json({ message: summary });
+
+    } catch (error) {
+        console.error('Critical error in analytics collector run:', error);
+        return response.status(500).json({ error: 'Internal Server Error during analytics collector run' });
+    }
+}
+
+// Main handler for the cron job endpoint
+export default async function handler(request, response) {
+    if (request.method !== 'GET') {
+        return response.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const authHeader = request.headers.authorization;
+    if (!authHeader || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+        console.warn('Unauthorized cron request for analytics. Mismatched or missing secret.');
+        return response.status(401).json({ error: 'Unauthorized' });
+    }
+
+    return handleRunAnalyticsCollector(request, response);
+}

--- a/db/migrations/add_linkedin_post_analytics_table.sql
+++ b/db/migrations/add_linkedin_post_analytics_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS linkedin_post_analytics (
+    id SERIAL PRIMARY KEY,
+    publication_id INTEGER NOT NULL,
+    snapshot_date DATE NOT NULL,
+    impression_count INTEGER DEFAULT 0,
+    click_count INTEGER DEFAULT 0,
+    like_count INTEGER DEFAULT 0,
+    comment_count INTEGER DEFAULT 0,
+    share_count INTEGER DEFAULT 0,
+    engagement REAL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (publication_id) REFERENCES linkedin_schedules(id) ON DELETE CASCADE,
+    UNIQUE (publication_id, snapshot_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_linkedin_post_analytics_publication_date
+ON linkedin_post_analytics (publication_id, snapshot_date);

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/linkedin",
       "schedule": "0 8-23 * * *"
+    },
+    {
+      "path": "/api/cron/linkedin-analytics",
+      "schedule": "0 2 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
This commit introduces a new daily cron job to collect performance analytics for LinkedIn posts.

- Creates a new `linkedin_post_analytics` table to store daily snapshots of post statistics (impressions, clicks, likes, etc.). A database migration file is included.
- Adds a new cron job at `api/cron/linkedin-analytics.js` that runs daily.
- The job fetches all posts published in the last 3 months.
- It efficiently groups posts by user to handle token refreshes and then by author to batch API calls.
- It calls the appropriate LinkedIn statistics endpoints and stores the results in the new table using an UPSERT operation for idempotency.
- Updates `vercel.json` to schedule the new job to run at 02:00 UTC daily.