### PR TITLE
fix: Handle null values in analytics overview API

### DIFF
--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -59,12 +59,7 @@ const handler = async (req, res) => {
                 COALESCE(SUM(lpa.share_count), 0) AS total_shares,
                 COALESCE(SUM(lpa.like_count + lpa.comment_count + lpa.share_count), 0) as total_engagement_actions,
                 COALESCE(AVG(lpa.engagement), 0) AS avg_engagement_rate,
-                CASE
-                    WHEN SUM(lpa.impression_count) > 0 THEN
-                        COALESCE(SUM(lpa.click_count) * 100.0 / SUM(lpa.impression_count), 0)
-                    ELSE
-                        0
-                END AS avg_ctr
+                COALESCE(SUM(lpa.click_count) * 100.0 / NULLIF(SUM(lpa.impression_count), 0), 0) AS avg_ctr
             ${baseQuery}
             ${campaignFilter}
         `;


### PR DESCRIPTION
This commit fixes a bug in the LinkedIn Analytics Dashboard that caused a `c.toFixed is not a function` error in the frontend.

The error occurred when the `/api/analytics/overview` endpoint returned a `null` value for the `avg_ctr` (Average Click-Through Rate) metric, specifically when there were no impressions for the selected period or campaigns. The frontend code did not anticipate a null value and failed when trying to call `.toFixed()` on it.

The fix replaces the `CASE` statement in the SQL query with a more robust `COALESCE(..., NULLIF(..., 0), 0)` structure. This ensures that the division by zero is safely handled and that the API always returns `0` for `avg_ctr` if there are no impressions, preventing null values in the response.