### PR TITLE
fix(dashboard): Add frontend guards for null metric values

### DIFF
--- a/src/components/dashboard/Overview.jsx
+++ b/src/components/dashboard/Overview.jsx
@@ -48,13 +48,13 @@ const Overview = ({ data, loading }) => {
   } = data || {};
 
   const stats = [
-    { title: "Total de Impressões", value: total_impressions.toLocaleString('pt-BR'), icon: <Visibility fontSize="large" />, loading },
-    { title: "Total de Cliques", value: total_clicks.toLocaleString('pt-BR'), icon: <AdsClick fontSize="large" />, loading },
-    { title: "Total de Likes", value: total_likes.toLocaleString('pt-BR'), icon: <ThumbUp fontSize="large" />, loading },
-    { title: "Total de Comentários", value: total_comments.toLocaleString('pt-BR'), icon: <Comment fontSize="large" />, loading },
-    { title: "Total de Compartilhamentos", value: total_shares.toLocaleString('pt-BR'), icon: <Share fontSize="large" />, loading },
-    { title: "Taxa Média de Engajamento", value: `${(avg_engagement_rate * 100).toFixed(2)}%`, icon: <TrendingUp fontSize="large" />, loading },
-    { title: "CTR Médio", value: `${avg_ctr.toFixed(2)}%`, icon: <Percent fontSize="large" />, loading },
+    { title: "Total de Impressões", value: (total_impressions || 0).toLocaleString('pt-BR'), icon: <Visibility fontSize="large" />, loading },
+    { title: "Total de Cliques", value: (total_clicks || 0).toLocaleString('pt-BR'), icon: <AdsClick fontSize="large" />, loading },
+    { title: "Total de Likes", value: (total_likes || 0).toLocaleString('pt-BR'), icon: <ThumbUp fontSize="large" />, loading },
+    { title: "Total de Comentários", value: (total_comments || 0).toLocaleString('pt-BR'), icon: <Comment fontSize="large" />, loading },
+    { title: "Total de Compartilhamentos", value: (total_shares || 0).toLocaleString('pt-BR'), icon: <Share fontSize="large" />, loading },
+    { title: "Taxa Média de Engajamento", value: `${((avg_engagement_rate || 0) * 100).toFixed(2)}%`, icon: <TrendingUp fontSize="large" />, loading },
+    { title: "CTR Médio", value: `${(avg_ctr || 0).toFixed(2)}%`, icon: <Percent fontSize="large" />, loading },
   ];
 
   return (


### PR DESCRIPTION
This commit provides a definitive fix for the `c.toFixed is not a function` error that occurred in the LinkedIn Analytics Dashboard.

The root cause was that API responses could contain `null` for certain metrics when no data was available for a given filter. The previous fix attempted to solve this on the backend but was not comprehensive enough.

This commit strengthens the frontend component `src/components/dashboard/Overview.jsx` by adding defensive guards. It now ensures that every metric value is checked for nullish values and defaults to `0` before any formatting function (like `.toLocaleString()` or `.toFixed()`) is called.

This client-side approach makes the dashboard more resilient and prevents crashes, regardless of whether the API returns a number or `null`.