### PR TITLE
fix(dashboard): Standardize date filtering across all analytics APIs

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -18,26 +18,18 @@ const handler = async (req, res) => {
     }
 
     try {
-        const { period = '30d', campaignIds, metric = 'total_impressions' } = req.query;
+        const { startDate, endDate, campaignIds, metric = 'total_impressions' } = req.query;
         const userId = req.user.id;
+
+        if (!startDate || !endDate) {
+            return res.status(400).json({ error: 'Os parâmetros startDate e endDate são obrigatórios.' });
+        }
 
         if (!Object.keys(ALLOWED_METRICS).includes(metric)) {
             return res.status(400).json({ error: 'Invalid metric specified.' });
         }
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
-
-        const startDate = new Date();
-        const periodMatch = period.match(/(\d+)([d|m|y])/);
-        if (periodMatch) {
-            const amount = parseInt(periodMatch[1]);
-            const unit = periodMatch[2];
-            if (unit === 'd') startDate.setDate(startDate.getDate() - amount);
-            else if (unit === 'm') startDate.setMonth(startDate.getMonth() - amount);
-            else if (unit === 'y') startDate.setFullYear(startDate.getFullYear() - amount);
-        } else {
-            startDate.setDate(startDate.getDate() - 30);
-        }
 
         const baseQuery = `
             FROM
@@ -48,10 +40,10 @@ const handler = async (req, res) => {
                 campaigns c ON ls.campaign_id = c.id
             WHERE
                 c.user_id = $1
-                AND lpa.snapshot_date >= $2
+                AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 
-        const queryParams = [userId, startDate.toISOString().split('T')[0]];
+        const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -7,28 +7,14 @@ const handler = async (req, res) => {
     }
 
     try {
-        const { period = '30d', campaignIds } = req.query;
+        const { startDate, endDate, campaignIds } = req.query;
         const userId = req.user.id;
 
-        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
-
-        // Calculate start date based on period
-        const startDate = new Date();
-        const periodMatch = period.match(/(\d+)([d|m|y])/);
-        if (periodMatch) {
-            const amount = parseInt(periodMatch[1]);
-            const unit = periodMatch[2];
-            if (unit === 'd') {
-                startDate.setDate(startDate.getDate() - amount);
-            } else if (unit === 'm') {
-                startDate.setMonth(startDate.getMonth() - amount);
-            } else if (unit === 'y') {
-                startDate.setFullYear(startDate.getFullYear() - amount);
-            }
-        } else {
-            // Default to 30 days if period format is invalid
-            startDate.setDate(startDate.getDate() - 30);
+        if (!startDate || !endDate) {
+            return res.status(400).json({ error: 'Os parâmetros startDate e endDate são obrigatórios.' });
         }
+
+        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
 
         const baseQuery = `
             FROM
@@ -39,10 +25,10 @@ const handler = async (req, res) => {
                 campaigns c ON ls.campaign_id = c.id
             WHERE
                 c.user_id = $1
-                AND lpa.snapshot_date >= $2
+                AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 
-        const queryParams = [userId, startDate.toISOString().split('T')[0]];
+        const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -17,8 +17,12 @@ const handler = async (req, res) => {
     }
 
     try {
-        const { period = '30d', campaignIds, metric = 'engagement', limit = 10 } = req.query;
+        const { startDate, endDate, campaignIds, metric = 'engagement', limit = 10 } = req.query;
         const userId = req.user.id;
+
+        if (!startDate || !endDate) {
+            return res.status(400).json({ error: 'Os parâmetros startDate e endDate são obrigatórios.' });
+        }
 
         if (!Object.keys(ALLOWED_METRICS).includes(metric)) {
             return res.status(400).json({ error: 'Invalid metric specified.' });
@@ -31,18 +35,6 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
 
-        const startDate = new Date();
-        const periodMatch = period.match(/(\d+)([d|m|y])/);
-        if (periodMatch) {
-            const amount = parseInt(periodMatch[1]);
-            const unit = periodMatch[2];
-            if (unit === 'd') startDate.setDate(startDate.getDate() - amount);
-            else if (unit === 'm') startDate.setMonth(startDate.getMonth() - amount);
-            else if (unit === 'y') startDate.setFullYear(startDate.getFullYear() - amount);
-        } else {
-            startDate.setDate(startDate.getDate() - 30);
-        }
-
         const baseQuery = `
             FROM
                 linkedin_post_analytics lpa
@@ -52,10 +44,10 @@ const handler = async (req, res) => {
                 campaigns c ON ls.campaign_id = c.id
             WHERE
                 c.user_id = $1
-                AND lpa.snapshot_date >= $2
+                AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 
-        const queryParams = [userId, startDate.toISOString().split('T')[0]];
+        const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {

--- a/src/components/AnalyticsDashboard.jsx
+++ b/src/components/AnalyticsDashboard.jsx
@@ -96,16 +96,12 @@ const AnalyticsDashboard = ({ currentCampaign }) => {
     const startDate = dateRange.startDate.toISOString().split('T')[0];
     const endDate = dateRange.endDate.toISOString().split('T')[0];
 
-    // Use a period string for overview, e.g., 30d
-    const periodInDays = Math.ceil((dateRange.endDate - dateRange.startDate) / (1000 * 60 * 60 * 24));
-    const period = `${periodInDays}d`;
-
     try {
       const endpoints = {
-        overview: `/api/analytics/overview?period=${period}&campaignIds=${campaignIds}`,
+        overview: `/api/analytics/overview?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}`,
         timeline: `/api/analytics/timeline?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=impression_count`,
-        campaignCompare: `/api/analytics/campaigns/compare?period=${period}&campaignIds=${campaignIds}&metric=total_impressions`,
-        topPosts: `/api/analytics/posts/top?period=${period}&campaignIds=${campaignIds}&metric=engagement&limit=10`,
+        campaignCompare: `/api/analytics/campaigns/compare?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=total_impressions`,
+        topPosts: `/api/analytics/posts/top?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=engagement&limit=10`,
       };
 
       const requests = Object.entries(endpoints).map(([key, url]) =>


### PR DESCRIPTION
This commit fixes a critical bug where the analytics dashboard would display no data, even when data was present for the selected date range.

The root cause was an inconsistency in how the backend APIs handled date filtering. While the frontend sent a specific `startDate` and `endDate`, several key API endpoints (`overview`, `campaigns/compare`, `posts/top`) ignored these parameters and incorrectly calculated a relative period (e.g., 'last 30 days') from the current date. This caused a mismatch, leading to empty results.

This fix standardizes the behavior across the entire analytics backend:
- All analytics API endpoints (`overview`, `campaigns/compare`, `posts/top`) have been updated to accept and use the explicit `startDate` and `endDate` parameters provided by the client.
- The frontend (`AnalyticsDashboard.jsx`) has been updated to consistently send `startDate` and `endDate` to all endpoints.

This ensures that the data displayed in every part of the dashboard accurately reflects the date range selected by the user, resolving the 'no data' issue and making the feature reliable.