### PR TITLE
fix(dashboard): Handle empty campaign filter and format dates

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -29,7 +29,7 @@ const handler = async (req, res) => {
             return res.status(400).json({ error: 'Invalid metric specified.' });
         }
 
-        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
+        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
         const baseQuery = `
             FROM

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -14,7 +14,7 @@ const handler = async (req, res) => {
             return res.status(400).json({ error: 'Os parâmetros startDate e endDate são obrigatórios.' });
         }
 
-        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
+        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
         const baseQuery = `
             FROM

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -33,7 +33,7 @@ const handler = async (req, res) => {
             return res.status(400).json({ error: 'Invalid limit specified. Must be between 1 and 100.' });
         }
 
-        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
+        const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
         const baseQuery = `
             FROM

--- a/src/components/AnalyticsDashboard.jsx
+++ b/src/components/AnalyticsDashboard.jsx
@@ -18,6 +18,7 @@ import {
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { ptBR } from 'date-fns/locale';
 import { getCampaigns } from '../utils/campaignState';
 import fetchWithAuth from '../utils/fetchWithAuth';
 import { subDays } from 'date-fns';
@@ -146,7 +147,7 @@ const AnalyticsDashboard = ({ currentCampaign }) => {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ptBR}>
       <Box>
         <Typography variant="h6" gutterBottom>Dashboard de Analytics</Typography>
 


### PR DESCRIPTION
This commit addresses two issues in the LinkedIn Analytics Dashboard:
1.  **Empty Campaign Filter Bug**: When no campaigns were selected in the filter, the backend would receive an empty `campaignIds` parameter. This was being processed incorrectly, leading to an invalid SQL query that returned no results (all zeros). The backend API endpoints (`overview`, `campaigns/compare`, `posts/top`) have been updated to safely handle an empty or invalid `campaignIds` parameter, ensuring that the query returns data for all of the user's campaigns in this scenario.

2.  **Date Format Standardization**: The date pickers in the dashboard were not using the Brazilian date format (`dd/MM/yyyy`). The `AnalyticsDashboard.jsx` component has been updated to use the `ptBR` locale from `date-fns`, ensuring a consistent and intuitive user experience for date selection.

These changes make the dashboard more robust, reliable, and user-friendly.