### PR TITLE
fix(dashboard): Correct user ownership logic in API queries

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -39,7 +39,7 @@ const handler = async (req, res) => {
             JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                c.user_id = $1
+                ls.user_id = $1
                 AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 

--- a/api/analytics/daterange.js
+++ b/api/analytics/daterange.js
@@ -20,7 +20,7 @@ const handler = async (req, res) => {
             JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                c.user_id = $1;
+                ls.user_id = $1;
         `;
 
         const { rows } = await query(dateRangeQuery, [userId]);

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -24,7 +24,7 @@ const handler = async (req, res) => {
             JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                c.user_id = $1
+                ls.user_id = $1
                 AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -43,7 +43,7 @@ const handler = async (req, res) => {
             JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                c.user_id = $1
+                ls.user_id = $1
                 AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -42,7 +42,7 @@ const handler = async (req, res) => {
             JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                c.user_id = $1
+                ls.user_id = $1
                 AND lpa.snapshot_date BETWEEN $2 AND $3
         `;
 


### PR DESCRIPTION
This commit fixes a critical bug where the analytics dashboard would show no data (all zeros) for a user, even when data was present in the database.

The root cause was an incorrect join condition in the backend API queries. The queries were filtering by `c.user_id` (the user ID of the campaign creator) instead of `ls.user_id` (the user ID of the person who scheduled the post). This meant that if a user was viewing analytics for posts they created under a campaign created by another user, the query would return no results.

This fix standardizes the user ownership logic across all five analytics endpoints (`overview`, `timeline`, `campaigns/compare`, `posts/top`, and `daterange`). The `WHERE` clause in each query has been changed to correctly filter by `ls.user_id = $1`.

This ensures that the dashboard accurately displays all relevant analytics data for the authenticated user's own posts, resolving the 'no data' issue and making the feature reliable.