### PR TITLE
fix(analytics): Corrige consultas para evitar perda de dados e agrega…

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -31,18 +31,6 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const baseQuery = `
-            FROM
-                linkedin_post_analytics lpa
-            JOIN
-                linkedin_schedules ls ON lpa.publication_id = ls.id
-            JOIN
-                campaigns c ON ls.campaign_id = c.id
-            WHERE
-                ls.user_id = $1
-                AND lpa.snapshot_date BETWEEN $2 AND $3
-        `;
-
         const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
@@ -54,12 +42,30 @@ const handler = async (req, res) => {
         const metricAggregation = ALLOWED_METRICS[metric];
 
         const finalQuery = `
+            WITH latest_analytics AS (
+                SELECT
+                    lpa.*,
+                    ls.campaign_id,
+                    ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
+                FROM
+                    linkedin_post_analytics lpa
+                JOIN
+                    linkedin_schedules ls ON lpa.publication_id = ls.id
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
+            )
             SELECT
                 c.id AS campaign_id,
                 c.name AS campaign_name,
-                COALESCE(${metricAggregation}, 0) AS value
-            ${baseQuery}
-            ${campaignFilter}
+                COALESCE(${metricAggregation.replace(/lpa\./g, 'la.')}, 0) AS value
+            FROM
+                latest_analytics la
+            LEFT JOIN
+                campaigns c ON la.campaign_id = c.id
+            WHERE
+                la.rn = 1
+                ${campaignFilter}
             GROUP BY
                 c.id, c.name
             ORDER BY

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -16,18 +16,6 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const baseQuery = `
-            FROM
-                linkedin_post_analytics lpa
-            JOIN
-                linkedin_schedules ls ON lpa.publication_id = ls.id
-            JOIN
-                campaigns c ON ls.campaign_id = c.id
-            WHERE
-                ls.user_id = $1
-                AND lpa.snapshot_date BETWEEN $2 AND $3
-        `;
-
         const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
@@ -37,17 +25,35 @@ const handler = async (req, res) => {
         }
 
         const finalQuery = `
+            WITH latest_analytics AS (
+                SELECT
+                    lpa.*,
+                    ls.campaign_id,
+                    ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
+                FROM
+                    linkedin_post_analytics lpa
+                JOIN
+                    linkedin_schedules ls ON lpa.publication_id = ls.id
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
+            )
             SELECT
-                COALESCE(SUM(lpa.impression_count), 0) AS total_impressions,
-                COALESCE(SUM(lpa.click_count), 0) AS total_clicks,
-                COALESCE(SUM(lpa.like_count), 0) AS total_likes,
-                COALESCE(SUM(lpa.comment_count), 0) AS total_comments,
-                COALESCE(SUM(lpa.share_count), 0) AS total_shares,
-                COALESCE(SUM(lpa.like_count + lpa.comment_count + lpa.share_count), 0) as total_engagement_actions,
-                COALESCE(AVG(lpa.engagement), 0) AS avg_engagement_rate,
-                COALESCE(SUM(lpa.click_count) * 100.0 / NULLIF(SUM(lpa.impression_count), 0), 0) AS avg_ctr
-            ${baseQuery}
-            ${campaignFilter}
+                COALESCE(SUM(la.impression_count), 0) AS total_impressions,
+                COALESCE(SUM(la.click_count), 0) AS total_clicks,
+                COALESCE(SUM(la.like_count), 0) AS total_likes,
+                COALESCE(SUM(la.comment_count), 0) AS total_comments,
+                COALESCE(SUM(la.share_count), 0) AS total_shares,
+                COALESCE(SUM(la.like_count + la.comment_count + la.share_count), 0) as total_engagement_actions,
+                COALESCE(AVG(la.engagement), 0) AS avg_engagement_rate,
+                COALESCE(SUM(la.click_count) * 100.0 / NULLIF(SUM(la.impression_count), 0), 0) AS avg_ctr
+            FROM
+                latest_analytics la
+            LEFT JOIN
+                campaigns c ON la.campaign_id = c.id
+            WHERE
+                la.rn = 1
+                ${campaignFilter}
         `;
 
         const { rows } = await query(finalQuery, queryParams);

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -35,18 +35,6 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const baseQuery = `
-            FROM
-                linkedin_post_analytics lpa
-            JOIN
-                linkedin_schedules ls ON lpa.publication_id = ls.id
-            JOIN
-                campaigns c ON ls.campaign_id = c.id
-            WHERE
-                ls.user_id = $1
-                AND lpa.snapshot_date BETWEEN $2 AND $3
-        `;
-
         const queryParams = [userId, startDate, endDate];
 
         let campaignFilter = '';
@@ -58,14 +46,31 @@ const handler = async (req, res) => {
         const metricAggregation = ALLOWED_METRICS[metric];
 
         const finalQuery = `
+            WITH latest_analytics AS (
+                SELECT
+                    lpa.*,
+                    ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
+                FROM
+                    linkedin_post_analytics lpa
+                WHERE
+                    lpa.snapshot_date BETWEEN $2 AND $3
+            )
             SELECT
                 ls.id AS post_id,
                 COALESCE(ls.post_content->>'titulo', 'Publicação sem título') AS post_title,
                 c.name AS campaign_name,
                 ls.linkedin_post_url,
-                COALESCE(${metricAggregation}, 0) AS value
-            ${baseQuery}
-            ${campaignFilter}
+                COALESCE(${metricAggregation.replace(/lpa\./g, 'la.')}, 0) AS value
+            FROM
+                linkedin_schedules ls
+            JOIN
+                latest_analytics la ON ls.id = la.publication_id
+            LEFT JOIN
+                campaigns c ON ls.campaign_id = c.id
+            WHERE
+                ls.user_id = $1
+                AND la.rn = 1
+                ${campaignFilter}
             GROUP BY
                 ls.id, c.name, ls.post_content, ls.linkedin_post_url
             ORDER BY

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -30,21 +30,8 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)) : [];
 
-        // Default to last 30 days if dates are not provided
         const endDate = endDateStr ? new Date(endDateStr) : new Date();
         const startDate = startDateStr ? new Date(startDateStr) : new Date(new Date().setDate(endDate.getDate() - 30));
-
-        const baseQuery = `
-            FROM
-                linkedin_post_analytics lpa
-            JOIN
-                linkedin_schedules ls ON lpa.publication_id = ls.id
-            JOIN
-                campaigns c ON ls.campaign_id = c.id
-            WHERE
-                ls.user_id = $1
-                AND lpa.snapshot_date BETWEEN $2 AND $3
-        `;
 
         const queryParams = [
             userId,
@@ -58,17 +45,34 @@ const handler = async (req, res) => {
             queryParams.push(campaignIdArray);
         }
 
-        // The metric is sanitized by checking against ALLOWED_METRICS
         const finalQuery = `
+            WITH latest_analytics AS (
+                SELECT
+                    lpa.*,
+                    ls.campaign_id,
+                    ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
+                FROM
+                    linkedin_post_analytics lpa
+                JOIN
+                    linkedin_schedules ls ON lpa.publication_id = ls.id
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
+            )
             SELECT
-                lpa.snapshot_date AS date,
-                SUM(lpa.${metric}) as value
-            ${baseQuery}
-            ${campaignFilter}
+                la.snapshot_date AS date,
+                SUM(la.${metric}) as value
+            FROM
+                latest_analytics la
+            LEFT JOIN
+                campaigns c ON la.campaign_id = c.id
+            WHERE
+                la.rn = 1
+                ${campaignFilter}
             GROUP BY
-                lpa.snapshot_date
+                la.snapshot_date
             ORDER BY
-                lpa.snapshot_date ASC;
+                la.snapshot_date ASC;
         `;
 
         const { rows } = await query(finalQuery, queryParams);


### PR DESCRIPTION
…ção incorreta

Esta alteração aborda dois problemas críticos nos endpoints da API de análise:

1.  **Dados Ausentes (Escassez):** As consultas usavam `INNER JOIN` entre as publicações e as campanhas. Isso fazia com que os dados de publicações ligadas a campanhas excluídas fossem completamente ignorados, resultando em zero dados no painel. A correção foi alterar para `LEFT JOIN`, garantindo que todas as publicações sejam incluídas.

2.  **Agregação Incorreta (Inflação):** As consultas somavam todos os registros históricos de análise para cada publicação, em vez de usar apenas o mais recente. Isso foi corrigido com uma CTE (`WITH latest_analytics AS ...`) que usa `ROW_NUMBER()` para selecionar apenas o último registro de cada publicação (`rn = 1`).

Essas duas correções, aplicadas a todos os endpoints de análise (`overview`, `timeline`, `posts/top`, `campaigns/compare`), garantem que o painel exiba dados precisos e completos.