### PR TITLE
fix(analytics): Padroniza tratamento de datas e melhora consultas

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -31,7 +31,10 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const queryParams = [userId, startDate, endDate];
+        const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
+        const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
+
+        const queryParams = [userId, formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -16,7 +16,10 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const queryParams = [userId, startDate, endDate];
+        const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
+        const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
+
+        const queryParams = [userId, formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -35,7 +35,10 @@ const handler = async (req, res) => {
 
         const campaignIdArray = campaignIds ? campaignIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id)) : [];
 
-        const queryParams = [userId, startDate, endDate];
+        const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
+        const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
+
+        const queryParams = [userId, formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
         if (campaignIdArray.length > 0) {


### PR DESCRIPTION
Esta alteração corrige a causa raiz da ausência de dados no painel de análise, que era a manipulação inconsistente de datas entre o JavaScript e o SQL.

- **Padronização de Datas:** As datas `startDate` e `endDate` agora são convertidas para o formato `YYYY-MM-DD` em todos os endpoints de análise (`overview`, `posts/top`, `campaigns/compare`) antes de serem enviadas ao banco de dados. Isso garante que a cláusula `BETWEEN` do SQL funcione corretamente, resolvendo o problema de "escassez" de dados.

Além disso, duas melhorias de robustez foram mantidas das iterações anteriores:

- **Agregação Correta:** Utiliza uma CTE com `ROW_NUMBER()` para selecionar apenas o registro de análise mais recente de cada publicação, evitando a inflação de métricas.
- **Junção Segura:** Usa `LEFT JOIN` na tabela `campaigns` para garantir que os dados das publicações não sejam perdidos se a campanha associada for excluída.