### PR TITLE
debug: Remove filtros de data e campanha para teste

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -34,13 +34,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId, formattedStartDate, formattedEndDate];
+        const queryParams = [userId];
 
         let campaignFilter = '';
-        if (campaignIdArray.length > 0) {
-            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-            queryParams.push(campaignIdArray);
-        }
+        // if (campaignIdArray.length > 0) {
+        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+        //     queryParams.push(campaignIdArray);
+        // }
 
         const metricAggregation = ALLOWED_METRICS[metric];
 
@@ -56,7 +56,7 @@ const handler = async (req, res) => {
                     linkedin_schedules ls ON lpa.publication_id = ls.id
                 WHERE
                     ls.user_id = $1
-                    AND lpa.snapshot_date BETWEEN $2 AND $3
+                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 c.id AS campaign_id,

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -19,13 +19,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId, formattedStartDate, formattedEndDate];
+        const queryParams = [userId];
 
         let campaignFilter = '';
-        if (campaignIdArray.length > 0) {
-            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-            queryParams.push(campaignIdArray);
-        }
+        // if (campaignIdArray.length > 0) {
+        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+        //     queryParams.push(campaignIdArray);
+        // }
 
         const finalQuery = `
             WITH latest_analytics AS (
@@ -39,7 +39,7 @@ const handler = async (req, res) => {
                     linkedin_schedules ls ON lpa.publication_id = ls.id
                 WHERE
                     ls.user_id = $1
-                    AND lpa.snapshot_date BETWEEN $2 AND $3
+                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 COALESCE(SUM(la.impression_count), 0) AS total_impressions,

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -38,13 +38,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId, formattedStartDate, formattedEndDate];
+        const queryParams = [userId];
 
         let campaignFilter = '';
-        if (campaignIdArray.length > 0) {
-            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-            queryParams.push(campaignIdArray);
-        }
+        // if (campaignIdArray.length > 0) {
+        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+        //     queryParams.push(campaignIdArray);
+        // }
 
         const metricAggregation = ALLOWED_METRICS[metric];
 
@@ -55,8 +55,8 @@ const handler = async (req, res) => {
                     ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
                 FROM
                     linkedin_post_analytics lpa
-                WHERE
-                    lpa.snapshot_date BETWEEN $2 AND $3
+                -- WHERE
+                    -- lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 ls.id AS post_id,

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -34,16 +34,14 @@ const handler = async (req, res) => {
         const startDate = startDateStr ? new Date(startDateStr) : new Date(new Date().setDate(endDate.getDate() - 30));
 
         const queryParams = [
-            userId,
-            startDate.toISOString().split('T')[0],
-            endDate.toISOString().split('T')[0]
+            userId
         ];
 
         let campaignFilter = '';
-        if (campaignIdArray.length > 0) {
-            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-            queryParams.push(campaignIdArray);
-        }
+        // if (campaignIdArray.length > 0) {
+        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+        //     queryParams.push(campaignIdArray);
+        // }
 
         const finalQuery = `
             WITH latest_analytics AS (
@@ -57,7 +55,7 @@ const handler = async (req, res) => {
                     linkedin_schedules ls ON lpa.publication_id = ls.id
                 WHERE
                     ls.user_id = $1
-                    AND lpa.snapshot_date BETWEEN $2 AND $3
+                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 la.snapshot_date AS date,


### PR DESCRIPTION
Esta alteração remove temporariamente todos os filtros de data (`snapshot_date`) e campanha (`campaign_id`) dos quatro endpoints da API de análise:
- `/api/analytics/overview`
- `/api/analytics/timeline`
- `/api/analytics/posts/top`
- `/api/analytics/campaigns/compare`

O objetivo é depurar o problema de "escassez de dados", permitindo que o usuário teste a consulta base sem nenhuma restrição de filtro, para verificar se os dados são retornados corretamente nessas condições. As linhas de código foram comentadas para facilitar a restauração posterior.