### PR TITLE
debug: Remove todos os filtros para teste final

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -34,7 +34,7 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId];
+        const queryParams = [];
 
         let campaignFilter = '';
         // if (campaignIdArray.length > 0) {
@@ -54,8 +54,8 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                WHERE
-                    ls.user_id = $1
+                -- WHERE
+                    -- ls.user_id = $1
                     -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -19,7 +19,7 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId];
+        const queryParams = [];
 
         let campaignFilter = '';
         // if (campaignIdArray.length > 0) {
@@ -37,8 +37,8 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                WHERE
-                    ls.user_id = $1
+                -- WHERE
+                    -- ls.user_id = $1
                     -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -38,7 +38,7 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [userId];
+        const queryParams = [];
 
         let campaignFilter = '';
         // if (campaignIdArray.length > 0) {
@@ -71,8 +71,9 @@ const handler = async (req, res) => {
             LEFT JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                ls.user_id = $1
-                AND la.rn = 1
+                -- ls.user_id = $1
+                -- AND
+                la.rn = 1
                 ${campaignFilter}
             GROUP BY
                 ls.id, c.name, ls.post_content, ls.linkedin_post_url

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -33,9 +33,7 @@ const handler = async (req, res) => {
         const endDate = endDateStr ? new Date(endDateStr) : new Date();
         const startDate = startDateStr ? new Date(startDateStr) : new Date(new Date().setDate(endDate.getDate() - 30));
 
-        const queryParams = [
-            userId
-        ];
+        const queryParams = [];
 
         let campaignFilter = '';
         // if (campaignIdArray.length > 0) {
@@ -53,8 +51,8 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                WHERE
-                    ls.user_id = $1
+                -- WHERE
+                    -- ls.user_id = $1
                     -- AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT


### PR DESCRIPTION
Esta alteração remove temporariamente todos os filtros, incluindo data, campanha e, crucialmente, `user_id`, de todos os quatro endpoints da API de análise:
- `/api/analytics/overview`
- `/api/analytics/timeline`
- `/api/analytics/posts/top`
- `/api/analytics/campaigns/compare`

O objetivo é executar um teste final para depurar o problema de "escassez de dados". Ao remover todas as condições `WHERE`, a consulta buscará todos os dados existentes no banco de dados. Se os dados aparecerem, isso confirmará que a lógica de junção e agregação está correta e que o problema está especificamente na forma como o `user_id` está sendo filtrado ou passado para a consulta.