### PR TITLE
fix(analytics): Corrige filtro de user_id e padroniza consultas

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -34,13 +34,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [];
+        const queryParams = [parseInt(userId, 10), formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
-        // if (campaignIdArray.length > 0) {
-        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-        //     queryParams.push(campaignIdArray);
-        // }
+        if (campaignIdArray.length > 0) {
+            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+            queryParams.push(campaignIdArray);
+        }
 
         const metricAggregation = ALLOWED_METRICS[metric];
 
@@ -54,9 +54,9 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                -- WHERE
-                    -- ls.user_id = $1
-                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 c.id AS campaign_id,

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -19,13 +19,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [];
+        const queryParams = [parseInt(userId, 10), formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
-        // if (campaignIdArray.length > 0) {
-        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-        //     queryParams.push(campaignIdArray);
-        // }
+        if (campaignIdArray.length > 0) {
+            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+            queryParams.push(campaignIdArray);
+        }
 
         const finalQuery = `
             WITH latest_analytics AS (
@@ -37,9 +37,9 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                -- WHERE
-                    -- ls.user_id = $1
-                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 COALESCE(SUM(la.impression_count), 0) AS total_impressions,

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -38,13 +38,13 @@ const handler = async (req, res) => {
         const formattedStartDate = new Date(startDate).toISOString().split('T')[0];
         const formattedEndDate = new Date(endDate).toISOString().split('T')[0];
 
-        const queryParams = [];
+        const queryParams = [parseInt(userId, 10), formattedStartDate, formattedEndDate];
 
         let campaignFilter = '';
-        // if (campaignIdArray.length > 0) {
-        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-        //     queryParams.push(campaignIdArray);
-        // }
+        if (campaignIdArray.length > 0) {
+            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+            queryParams.push(campaignIdArray);
+        }
 
         const metricAggregation = ALLOWED_METRICS[metric];
 
@@ -55,8 +55,8 @@ const handler = async (req, res) => {
                     ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
                 FROM
                     linkedin_post_analytics lpa
-                -- WHERE
-                    -- lpa.snapshot_date BETWEEN $2 AND $3
+                WHERE
+                    lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 ls.id AS post_id,
@@ -71,9 +71,8 @@ const handler = async (req, res) => {
             LEFT JOIN
                 campaigns c ON ls.campaign_id = c.id
             WHERE
-                -- ls.user_id = $1
-                -- AND
-                la.rn = 1
+                ls.user_id = $1
+                AND la.rn = 1
                 ${campaignFilter}
             GROUP BY
                 ls.id, c.name, ls.post_content, ls.linkedin_post_url

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -33,13 +33,17 @@ const handler = async (req, res) => {
         const endDate = endDateStr ? new Date(endDateStr) : new Date();
         const startDate = startDateStr ? new Date(startDateStr) : new Date(new Date().setDate(endDate.getDate() - 30));
 
-        const queryParams = [];
+        const queryParams = [
+            parseInt(userId, 10),
+            startDate.toISOString().split('T')[0],
+            endDate.toISOString().split('T')[0]
+        ];
 
         let campaignFilter = '';
-        // if (campaignIdArray.length > 0) {
-        //     campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
-        //     queryParams.push(campaignIdArray);
-        // }
+        if (campaignIdArray.length > 0) {
+            campaignFilter = `AND c.id = ANY($${queryParams.length + 1}::int[])`;
+            queryParams.push(campaignIdArray);
+        }
 
         const finalQuery = `
             WITH latest_analytics AS (
@@ -51,9 +55,9 @@ const handler = async (req, res) => {
                     linkedin_post_analytics lpa
                 JOIN
                     linkedin_schedules ls ON lpa.publication_id = ls.id
-                -- WHERE
-                    -- ls.user_id = $1
-                    -- AND lpa.snapshot_date BETWEEN $2 AND $3
+                WHERE
+                    ls.user_id = $1
+                    AND lpa.snapshot_date BETWEEN $2 AND $3
             )
             SELECT
                 la.snapshot_date AS date,


### PR DESCRIPTION
Esta é a solução definitiva para o problema de dados ausentes no painel de análise. A causa raiz foi identificada como um problema de tipo de dado na filtragem por `user_id`.

- **Correção do `user_id`**: O `userId` agora é explicitamente convertido para um inteiro usando `parseInt(userId, 10)` antes de ser passado para a consulta SQL. Isso resolve a falha na cláusula `WHERE` que impedia o retorno dos dados.

Além disso, esta solução consolida as melhorias identificadas durante o processo de depuração:

- **Agregação Correta**: Mantém o uso de uma CTE com `ROW_NUMBER()` para garantir que apenas o registro de análise mais recente de cada publicação seja utilizado.
- **Junção Segura**: Mantém o uso de `LEFT JOIN` na tabela `campaigns` para evitar a perda de dados de publicações associadas a campanhas excluídas.
- **Padronização de Datas**: Mantém a formatação consistente de datas para o padrão `YYYY-MM-DD`.

Essas alterações, aplicadas a todos os endpoints de análise, garantem que o painel funcione de forma robusta, precisa e confiável.