### PR TITLE
fix(analytics): Corrige lógica de agregação do endpoint da timeline

### DIFF
--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -46,33 +46,23 @@ const handler = async (req, res) => {
         }
 
         const finalQuery = `
-            WITH latest_analytics AS (
-                SELECT
-                    lpa.*,
-                    ls.campaign_id,
-                    ROW_NUMBER() OVER(PARTITION BY lpa.publication_id ORDER BY lpa.snapshot_date DESC) as rn
-                FROM
-                    linkedin_post_analytics lpa
-                JOIN
-                    linkedin_schedules ls ON lpa.publication_id = ls.id
-                WHERE
-                    ls.user_id = $1
-                    AND lpa.snapshot_date BETWEEN $2 AND $3
-            )
             SELECT
-                la.snapshot_date AS date,
-                SUM(la.${metric}) as value
+                lpa.snapshot_date AS date,
+                SUM(lpa.${metric}) as value
             FROM
-                latest_analytics la
+                linkedin_post_analytics lpa
+            JOIN
+                linkedin_schedules ls ON lpa.publication_id = ls.id
             LEFT JOIN
-                campaigns c ON la.campaign_id = c.id
+                campaigns c ON ls.campaign_id = c.id
             WHERE
-                la.rn = 1
+                ls.user_id = $1
+                AND lpa.snapshot_date BETWEEN $2 AND $3
                 ${campaignFilter}
             GROUP BY
-                la.snapshot_date
+                lpa.snapshot_date
             ORDER BY
-                la.snapshot_date ASC;
+                lpa.snapshot_date ASC;
         `;
 
         const { rows } = await query(finalQuery, queryParams);


### PR DESCRIPTION
Esta alteração corrige o erro 'Failed to fetch timeline' ao restaurar a lógica de agregação diária correta para o endpoint `/api/analytics/timeline.js`.

- **Lógica da Timeline:** A consulta foi reescrita para remover a CTE que selecionava apenas o registro mais recente de cada post. Em vez disso, ela agora agrupa os resultados por `snapshot_date` para somar corretamente as métricas de todas as publicações em cada dia, mostrando a evolução diária como esperado.

- **Consistência Mantida:** As outras correções essenciais, como o `LEFT JOIN` na tabela de campanhas e o tratamento adequado de datas e do `user_id` (convertido para inteiro), foram mantidas.

- **Outros Endpoints:** Os endpoints de `overview`, `posts/top` e `campaigns/compare` permanecem com a lógica de CTE, pois seu objetivo é mostrar o status mais recente das publicações, e não a evolução diária.

Esta correção finaliza o ajuste do painel de análise, garantindo que todos os componentes exibam dados precisos e corretos de acordo com seus requisitos específicos.