### PR TITLE
fix(analytics): Corrige agregação da métrica de engajamento

### DIFF
--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -3,7 +3,7 @@ import { withAuth } from '../../middleware/auth.js';
 
 // We are aggregating over the snapshots, so we use SUM for counts/rates
 const ALLOWED_METRICS = {
-    engagement: 'SUM(lpa.engagement)',
+    engagement: 'AVG(lpa.engagement)',
     impressions: 'SUM(lpa.impression_count)',
     clicks: 'SUM(lpa.click_count)',
     likes: 'SUM(lpa.like_count)',


### PR DESCRIPTION
Esta é a correção final para os problemas do painel de análise, focada na lógica de agregação da métrica de engajamento.

- **Agregação Corrigida:** A métrica 'engagement' no endpoint `api/analytics/posts/top.js` foi alterada de `SUM(lpa.engagement)` para `AVG(lpa.engagement)`. Somar uma taxa percentual é incorreto; a média é a agregação correta para representar a taxa de engajamento dos posts.

Esta alteração complementa as correções anteriores (uso de `DISTINCT ON`, `LEFT JOIN`, padronização de datas e `user_id`), garantindo que todos os cálculos e lógicas do painel de análise estejam corretos, robustos e eficientes.