### PR TITLE
fix(analytics): Alinha autenticação com padrão JWT usando 'sub'

### DIFF
--- a/api/analytics/campaigns/compare.js
+++ b/api/analytics/campaigns/compare.js
@@ -19,7 +19,7 @@ const handler = async (req, res) => {
 
     try {
         const { startDate, endDate, campaignIds, metric = 'total_impressions' } = req.query;
-        const userId = req.user?.id;
+        const userId = req.user?.sub;
 
         if (!userId || isNaN(parseInt(userId, 10))) {
             return res.status(401).json({ error: 'Usuário não autenticado ou inválido.' });

--- a/api/analytics/overview.js
+++ b/api/analytics/overview.js
@@ -8,7 +8,7 @@ const handler = async (req, res) => {
 
     try {
         const { startDate, endDate, campaignIds } = req.query;
-        const userId = req.user?.id;
+        const userId = req.user?.sub;
 
         if (!userId || isNaN(parseInt(userId, 10))) {
             return res.status(401).json({ error: 'Usuário não autenticado ou inválido.' });

--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -18,7 +18,7 @@ const handler = async (req, res) => {
 
     try {
         const { startDate, endDate, campaignIds, metric = 'engagement', limit = 10 } = req.query;
-        const userId = req.user?.id;
+        const userId = req.user?.sub;
 
         if (!userId || isNaN(parseInt(userId, 10))) {
             return res.status(401).json({ error: 'Usuário não autenticado ou inválido.' });

--- a/api/analytics/timeline.js
+++ b/api/analytics/timeline.js
@@ -22,7 +22,7 @@ const handler = async (req, res) => {
             campaignIds,
             metric = 'impression_count'
         } = req.query;
-        const userId = req.user?.id;
+        const userId = req.user?.sub;
 
         if (!userId || isNaN(parseInt(userId, 10))) {
             return res.status(401).json({ error: 'Usuário não autenticado ou inválido.' });

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -64,7 +64,6 @@ export default async function handler(req, res) {
 
     // User is authenticated, create JWT
     const tokenPayload = {
-      id: user.id, // Explicitly include 'id' for our middleware
       sub: user.id, // 'sub' is the standard claim for subject (user ID)
       uuid: user.uuid,
       name: user.name,


### PR DESCRIPTION
Esta é a correção definitiva para a falha de autenticação que causava o erro 401 Unauthorized nos endpoints de análise. A causa raiz era uma inconsistência entre o payload do token JWT e a forma como os endpoints liam o ID do usuário.

- **Padrão JWT (`sub`):** Todos os quatro endpoints de análise (`overview`, `timeline`, `posts/top`, `campaigns/compare`) foram atualizados para obter o ID do usuário a partir de `req.user.sub`, que é o campo padrão ("subject") para o identificador do usuário em JWTs.

- **Payload do Token Restaurado:** O endpoint `api/auth/login.js` foi revertido ao seu estado original, sem o campo `id` redundante no payload, mantendo o token mais limpo e seguro.

- **Melhorias Consolidadas:** Esta solução mantém todas as outras melhorias de robustez identificadas anteriormente, incluindo o uso de `DISTINCT ON`, `LEFT JOIN`, padronização de datas e a cláusula de guarda para `userId`.

Para que a correção tenha efeito, o usuário precisará fazer logout e login novamente para gerar um novo token que será interpretado corretamente.