### PR TITLE
Adds a new "Run Analytics" button to the Admin Dashboard.

### DIFF
--- a/api/schedule/run-analytics.js
+++ b/api/schedule/run-analytics.js
@@ -1,20 +1,23 @@
 import { withAuth, isAdmin } from '../middleware/auth.js';
-import { handleRunScheduler } from '../cron/linkedin.js';
+import { handleRunAnalyticsCollector } from '../cron/linkedin-analytics.js';
 
-const schedulerRunnerHandler = async (request, response) => {
+const analyticsRunnerHandler = async (request, response) => {
     // Ensure the user is an admin
     if (!isAdmin(request)) {
         return response.status(403).json({ error: 'Forbidden: You do not have permission to perform this action.' });
     }
 
-    return handleRunScheduler(request, response);
+    // We can call the analytics collector directly.
+    // The request object might need to be slightly adapted if the collector expects a specific format,
+    // but for now, we assume it can be called directly.
+    return handleRunAnalyticsCollector(request, response);
 };
 
 // Main handler for the endpoint
 const mainHandler = async (request, response) => {
     if (request.method === 'POST') {
         // Wrap the handler with withAuth to ensure the user is authenticated
-        return withAuth(schedulerRunnerHandler)(request, response);
+        return withAuth(analyticsRunnerHandler)(request, response);
     }
 
     response.setHeader('Allow', ['POST']);

--- a/src/pages/AdminDashboardPage.jsx
+++ b/src/pages/AdminDashboardPage.jsx
@@ -17,6 +17,7 @@ const AdminDashboardPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isSchedulerRunning, setIsSchedulerRunning] = useState(false);
+  const [isAnalyticsRunning, setIsAnalyticsRunning] = useState(false);
   const { user: adminUser, logout } = useUserAuth();
   const navigate = useNavigate();
 
@@ -78,6 +79,24 @@ const AdminDashboardPage = () => {
     }
   };
 
+  const handleRunAnalytics = async () => {
+    setIsAnalyticsRunning(true);
+    toast.info('Analytics run initiated...');
+    try {
+      const res = await fetch('/api/schedule/run-analytics', { method: 'POST' });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || 'Analytics run completed successfully.');
+      } else {
+        throw new Error(data.error || 'Failed to run analytics');
+      }
+    } catch (err) {
+      toast.error(`Analytics run failed: ${err.message}`);
+    } finally {
+      setIsAnalyticsRunning(false);
+    }
+  };
+
   const handleLogout = async () => {
     await logout();
     navigate('/login');
@@ -126,6 +145,16 @@ const AdminDashboardPage = () => {
               startIcon={isSchedulerRunning ? <CircularProgress size={20} color="inherit" /> : <PlayCircleOutlineIcon />}
             >
               {isSchedulerRunning ? 'Running...' : 'Run Scheduler'}
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              sx={{ mr: 2 }}
+              onClick={handleRunAnalytics}
+              disabled={isAnalyticsRunning}
+              startIcon={isAnalyticsRunning ? <CircularProgress size={20} color="inherit" /> : <PlayCircleOutlineIcon />}
+            >
+              {isAnalyticsRunning ? 'Running...' : 'Run Analytics'}
             </Button>
             <Button variant="outlined" onClick={handleLogout}>Logout</Button>
           </Box>


### PR DESCRIPTION
This button allows administrators to manually trigger the consolidation of post statistics.

Creates a new API endpoint `/api/schedule/run-analytics` to handle this action.

Ensures both the new and existing scheduler trigger endpoints are protected and require admin privileges.