### PR TITLE
This commit fixes a runtime error caused by an incorrect import.

### DIFF
--- a/api/schedule/run-analytics.js
+++ b/api/schedule/run-analytics.js
@@ -1,23 +1,16 @@
-import { withAuth, isAdmin } from '../middleware/auth.js';
+import { withAdminAuth } from '../middleware/auth.js';
 import { handleRunAnalyticsCollector } from '../cron/linkedin-analytics.js';
 
+// The withAdminAuth middleware now handles the authentication and admin role check.
 const analyticsRunnerHandler = async (request, response) => {
-    // Ensure the user is an admin
-    if (!isAdmin(request)) {
-        return response.status(403).json({ error: 'Forbidden: You do not have permission to perform this action.' });
-    }
-
-    // We can call the analytics collector directly.
-    // The request object might need to be slightly adapted if the collector expects a specific format,
-    // but for now, we assume it can be called directly.
     return handleRunAnalyticsCollector(request, response);
 };
 
 // Main handler for the endpoint
 const mainHandler = async (request, response) => {
     if (request.method === 'POST') {
-        // Wrap the handler with withAuth to ensure the user is authenticated
-        return withAuth(analyticsRunnerHandler)(request, response);
+        // Wrap the handler with withAdminAuth.
+        return withAdminAuth(analyticsRunnerHandler)(request, response);
     }
 
     response.setHeader('Allow', ['POST']);

--- a/api/schedule/run.js
+++ b/api/schedule/run.js
@@ -1,20 +1,16 @@
-import { withAuth, isAdmin } from '../middleware/auth.js';
+import { withAdminAuth } from '../middleware/auth.js';
 import { handleRunScheduler } from '../cron/linkedin.js';
 
+// The withAdminAuth middleware now handles the authentication and admin role check.
 const schedulerRunnerHandler = async (request, response) => {
-    // Ensure the user is an admin
-    if (!isAdmin(request)) {
-        return response.status(403).json({ error: 'Forbidden: You do not have permission to perform this action.' });
-    }
-
     return handleRunScheduler(request, response);
 };
 
 // Main handler for the endpoint
 const mainHandler = async (request, response) => {
     if (request.method === 'POST') {
-        // Wrap the handler with withAuth to ensure the user is authenticated
-        return withAuth(schedulerRunnerHandler)(request, response);
+        // Wrap the handler with withAdminAuth.
+        return withAdminAuth(schedulerRunnerHandler)(request, response);
     }
 
     response.setHeader('Allow', ['POST']);


### PR DESCRIPTION
The `isAdmin` function does not exist; the correct way to protect admin routes is by using the `withAdminAuth` higher-order function.

This commit updates both the `run.js` and `run-analytics.js` API routes to use the `withAdminAuth` middleware, ensuring they are correctly protected and functional.