### PR TITLE
This commit addresses two critical runtime errors.

### DIFF
--- a/api/cron/linkedin-analytics.js
+++ b/api/cron/linkedin-analytics.js
@@ -90,10 +90,10 @@ export async function handleRunAnalyticsCollector(request, response) {
         threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
 
         const { rows: posts } = await query(
-            `SELECT ls.id, ls.urn, ls.user_id, ls.post_content->>'authorUrn' as author_urn, u.linkedin_access_token
+            `SELECT ls.id, ls.linkedin_post_id AS urn, ls.user_id, ls.post_content->>'authorUrn' as author_urn, u.linkedin_access_token
              FROM linkedin_schedules ls
              JOIN users u ON ls.user_id = u.id
-             WHERE ls.status = 'published' AND ls.scheduled_at >= $1`,
+             WHERE ls.status = 'published' AND ls.scheduled_at >= $1 AND ls.linkedin_post_id IS NOT NULL`,
             [threeMonthsAgo]
         );
 


### PR DESCRIPTION
First, it fixes a `TypeError` by replacing the incorrect usage of a non-existent `isAdmin` function with the correct `withAdminAuth` higher-order function. This is applied to both the scheduler and analytics trigger API routes, ensuring they are properly protected.

Second, it resolves a database error (`column ls.urn does not exist`) by correcting the column name in the analytics collector query. The query now uses `ls.linkedin_post_id` instead of the non-existent `ls.urn`, and includes a check to ensure the ID is not null.

These changes ensure the manual trigger for analytics consolidation is fully functional and secure.