### PR TITLE
This commit provides the definitive fix for the scheduled analytics j…

### DIFF
--- a/api/cron/linkedin-analytics.js
+++ b/api/cron/linkedin-analytics.js
@@ -7,7 +7,7 @@ const PROXY_API_BASE_URL = process.env.VITE_API_BASE_URL || 'http://localhost:51
 async function fetchStatsWithRefresh(fetch, userId, initialAccessToken, postsByAuthor) {
     const internalApiHeaders = {
         'Content-Type': 'application/json',
-        'x-internal-secret': process.env.INTERNAL_API_SECRET,
+        'X-Internal-Secret': process.env.INTERNAL_API_SECRET,
     };
 
     // This function now takes the token explicitly to avoid closure issues.

--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -532,7 +532,9 @@ const SCHEDULER_ACTIONS = new Set([
   'initializeVideoUpload',
   'uploadVideo',
   'finalizeVideoUpload',
-  'checkVideoStatus'
+  'checkVideoStatus',
+  'getShareStatistics',
+  'getMemberPostStatistics'
 ]);
 
 // This handler is for requests that are authenticated via a shared secret.


### PR DESCRIPTION
…ob, which was failing with 401 Unauthorized errors.

The root cause was that the analytics-related actions (`getShareStatistics`, `getMemberPostStatistics`) were not being treated as internal, scheduler-safe actions. This resulted in the internal authentication secret not being correctly applied during the batch process.

This commit resolves the issue by:
1.  Adding `getShareStatistics` and `getMemberPostStatistics` to the `SCHEDULER_ACTIONS` Set in `api/linkedin-proxy.js`.
2.  Correcting the casing of the `X-Internal-Secret` header in `api/cron/linkedin-analytics.js` to match the proxy's expectation.

These changes ensure that the analytics job is properly authenticated when run via the scheduler, resolving the 401 errors.