### PR TITLE
fix(dashboard): Ensure Top Posts reflects selected metric

### DIFF
--- a/src/components/AnalyticsDashboard.jsx
+++ b/src/components/AnalyticsDashboard.jsx
@@ -122,7 +122,7 @@ const AnalyticsDashboard = ({ currentCampaign }) => {
         overview: `/api/analytics/overview?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}`,
         timeline: `/api/analytics/timeline?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=${selectedMetric}`,
         campaignCompare: `/api/analytics/campaigns/compare?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=${campaignCompareMetric}`,
-        topPosts: `/api/analytics/posts/top?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=engagement&limit=10`,
+        topPosts: `/api/analytics/posts/top?startDate=${startDate}&endDate=${endDate}&campaignIds=${campaignIds}&metric=${selectedMetric}&limit=10`,
       };
 
       const requests = Object.entries(endpoints).map(([key, url]) =>


### PR DESCRIPTION
The API call for the 'Top Posts' analytics tab was hardcoding the 'metric' parameter to 'engagement', causing it to ignore the user's selection from the dropdown menu.

This commit updates the API call to use the 'selectedMetric' state variable, ensuring that the 'Top Posts' component dynamically updates to reflect the metric chosen by the user, consistent with the behavior of other dashboard components.