### PR TITLE
fix(dashboard): Ensure Top Posts reflects selected metric

### DIFF
--- a/api/analytics/posts/top.js
+++ b/api/analytics/posts/top.js
@@ -4,11 +4,11 @@ import { withAuth } from '../../middleware/auth.js';
 // We are aggregating over the snapshots, so we use SUM for counts/rates
 const ALLOWED_METRICS = {
     engagement: 'AVG(lpa.engagement)',
-    impressions: 'SUM(lpa.impression_count)',
-    clicks: 'SUM(lpa.click_count)',
-    likes: 'SUM(lpa.like_count)',
-    comments: 'SUM(lpa.comment_count)',
-    shares: 'SUM(lpa.share_count)'
+    impression_count: 'SUM(lpa.impression_count)',
+    click_count: 'SUM(lpa.click_count)',
+    like_count: 'SUM(lpa.like_count)',
+    comment_count: 'SUM(lpa.comment_count)',
+    share_count: 'SUM(lpa.share_count)'
 };
 
 const handler = async (req, res) => {


### PR DESCRIPTION
The API call for the 'Top Posts' analytics tab was not using the metric selected by the user. Additionally, the backend endpoint for this tab was expecting metric names inconsistent with other analytics endpoints.

This commit addresses the issue by:
1.  Updating the frontend component (`AnalyticsDashboard.jsx`) to correctly pass the `selectedMetric` to the `topPosts` API endpoint.
2.  Harmonizing the metric keys in the backend (`api/analytics/posts/top.js`) to align with the `snake_case` convention used by the frontend and other APIs (e.g., `impression_count`).

These changes ensure the 'Top Posts' component now dynamically updates to reflect the user's chosen metric.