### PR TITLE
fix(ui): Corrige exibição de detalhes para agendamentos com imagens

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -1170,11 +1170,21 @@ const Publisher = ({
             {viewingSchedule ? (
                 <Box>
                     <Typography variant="h6" gutterBottom>{viewingSchedule.post_content.titulo}</Typography>
-                    <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', my: 2 }}>{viewingSchedule.post_content.conteudo}</Typography>
-                    <Typography variant="body2" color="text.secondary"><strong>CTA:</strong> {viewingSchedule.post_content.cta}</Typography>
-                    <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                        <strong>Hashtags:</strong> {(viewingSchedule.post_content.hashtags || []).join(' ')}
-                    </Typography>
+
+                    {viewingSchedule.post_content.fullText ? (
+                        <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', my: 2 }}>
+                            {viewingSchedule.post_content.fullText}
+                        </Typography>
+                    ) : (
+                        <>
+                            <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', my: 2 }}>{viewingSchedule.post_content.conteudo}</Typography>
+                            <Typography variant="body2" color="text.secondary"><strong>CTA:</strong> {viewingSchedule.post_content.cta}</Typography>
+                            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                                <strong>Hashtags:</strong> {(viewingSchedule.post_content.hashtags || []).join(' ')}
+                            </Typography>
+                        </>
+                    )}
+
                     <Divider sx={{ my: 2 }} />
                     <Typography variant="body2"><strong>Scheduled for:</strong> {formatInTimeZone(new Date(viewingSchedule.scheduled_at), getTimezone() || 'UTC', 'dd/MM/yyyy HH:mm:ss zzz', { locale: ptBR })}</Typography>
                     <Typography variant="body2"><strong>Status:</strong> {viewingSchedule.status}</Typography>


### PR DESCRIPTION
A caixa de diálogo de detalhes do agendamento agora verifica a estrutura do objeto `post_content`. Se o campo `fullText` existir (típico de posts com múltiplas imagens), seu conteúdo será exibido. Caso contrário, ele recorre à exibição dos campos `conteudo`, `cta` e `hashtags`.

Isso resolve o bug em que os detalhes de um agendamento com várias imagens eram exibidos de forma incompleta, mostrando apenas o título e os rótulos, sem alterar a estrutura de dados subjacente ou a lógica de publicação.