### PR TITLE
Fix: Prevent double escaping of LinkedIn posts

### DIFF
--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -1,5 +1,5 @@
 import { query } from '../db.js';
-import { markdownToLinkedinText, escapeLinkedinText } from '../utils.js';
+import { markdownToLinkedinText } from '../utils.js';
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -100,7 +100,7 @@ export async function publishPost(fetch, post, accessToken) {
     const videoUrn = post.post_content?.video;
     const payload = {
         author: authorUrn,
-        content: escapeLinkedinText(postText),
+        content: postText,
         images: imageUrns,
         video: videoUrn,
         title: post.post_content?.titulo || 'Video Post'

--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -69,6 +69,14 @@ function stripEmojis(text) {
     return text.replace(/([\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF])/g, '');
 }
 
+function escapeLinkedinText(text) {
+    if (!text) return '';
+    // Escape special characters that LinkedIn might interpret as formatting.
+    // The list of characters is based on community documentation and testing.
+    // The backslash '\' needs to be escaped in the regex and in the replacement string.
+    return text.replace(/([|{}@[\]()<>#*_~\\])/g, '\\$1');
+}
+
 async function handleGenericPost(fetch, request, response, url) {
     const { accessToken, payload } = request.body;
     if (!accessToken || !payload) return response.status(400).json({ error: 'Missing accessToken or payload.' });
@@ -221,7 +229,7 @@ async function handleCreatePost(fetch, request, response) {
         // Base structure for the new Posts API
         const postData = {
             author: authorUrn,
-            commentary: content,
+            commentary: escapeLinkedinText(content),
             visibility: "PUBLIC",
             distribution: {
                 feedDistribution: "MAIN_FEED",

--- a/api/utils.js
+++ b/api/utils.js
@@ -11,10 +11,3 @@ export const markdownToLinkedinText = (markdown) => {
     return text;
 };
 
-export const escapeLinkedinText = (text) => {
-    if (!text) return '';
-    // Escapa caracteres especiais que o LinkedIn pode interpretar como formatação.
-    // A lista de caracteres é baseada em documentação e testes da comunidade.
-    // A barra invertida '\' precisa ser escapada na regex e na string de substituição.
-    return text.replace(/([|{}@[\]()<>#*_~\\])/g, '\\$1');
-};

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -77,12 +77,6 @@ export const markdownToLinkedinText = (markdown) => {
     // First, strip any HTML tags that might be present
     let text = stripHtml(markdown);
 
-    // Escape reserved characters for LinkedIn as per user request
-    // The characters to escape are: | { } @ [ ] ( ) < > # \ * _ ~
-    // The backslash is escaped in the regex itself.
-    const reservedCharsRegex = /([|{}@[\]()<>#\\*_~])/g;
-    text = text.replace(reservedCharsRegex, '\\$1');
-
     // Collapse multiple newlines to just two for cleaner formatting
     text = text.trim().replace(/\n{3,}/g, '\n\n');
 


### PR DESCRIPTION
Refactors the LinkedIn publishing flow to prevent double-escaping of text in scheduled posts.

The escaping logic has been centralized within the `api/linkedin-proxy.js` which is the final gateway for all posts (interactive and scheduled) before they are sent to LinkedIn.

This ensures that escaping is applied exactly once, at the correct time, resolving the issue where scheduled posts were being escaped by the frontend and then again by the backend cron job.

Changes include:
- Moved escaping logic to `api/linkedin-proxy.js`.
- Removed escaping from the frontend's `markdownToLinkedinText` utility.
- Removed escaping from the `api/cron/linkedin.js` job.