### PR TITLE
fix: Ensure consistent asset hydration across the app

### DIFF
--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -237,7 +237,17 @@ const Publisher = ({
 
   const handleViewDetails = async (scheduleId) => {
     try {
-      const scheduleDetails = await getSchedule(scheduleId);
+      let scheduleDetails = await getSchedule(scheduleId);
+
+      // Hydrate campaign_data if it exists
+      if (scheduleDetails.campaign_data) {
+        const { finalState, newlyCreatedAssets } = await deserializeCampaignData(scheduleDetails.campaign_data);
+        scheduleDetails.campaign_data = finalState;
+        if (Object.keys(newlyCreatedAssets).length > 0) {
+          setPendingAssets(prev => ({ ...prev, ...newlyCreatedAssets }));
+        }
+      }
+
       const parsedSchedule = {
         ...scheduleDetails,
         post_content: typeof scheduleDetails.post_content === 'string' ? JSON.parse(scheduleDetails.post_content) : scheduleDetails.post_content,


### PR DESCRIPTION
This commit resolves multiple bugs stemming from improper handling of asset URLs, ensuring a consistent and stable user experience.

1.  **Fix Broken Images in Page Editor**:
    - The `handleEditCampaign` function in `HomePage.jsx` was previously loading campaign data without hydrating it. This passed stale, permanent Vercel URLs to the page editor, causing images to appear broken.
    - The function has been refactored to use the `handleLoadCampaign` utility, which correctly deserializes the campaign data and populates the context with valid, playable `blob:` URLs before navigating to the editor.
    - The `handleSaveCampaign` function was also improved to correctly process the re-hydrated state returned from the backend, preventing state corruption after saving.

2.  **Fix Broken Images in Publisher**:
    - A proactive check revealed a similar issue in the `Publisher.jsx` component, where scheduled posts with associated campaign data would display broken images.
    - The `fetchSchedules` function now hydrates the `campaign_data` for each schedule using `deserializeCampaignData`, converting permanent URLs to local `blob:` URLs and ensuring images render correctly.

3.  **Proactively Fix Latent Bug in Publisher Details**:
    - The `handleViewDetails` function in `Publisher.jsx` was fetching schedule data without hydrating it.
    - This has been fixed to also call `deserializeCampaignData`, preventing a future bug where images would be broken in the schedule details view.