### PR TITLE
Fix: Prevent element position reset in Page Editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -143,20 +143,20 @@ const FieldPositioner = ({
         }
       }));
     } else {
-      const imageIndex = pageTemplate.images.findIndex(img => img.id === id);
-      if (imageIndex > -1) {
-        setPageTemplate(prev => {
+      setPageTemplate(prev => {
+        const imageIndex = prev.images.findIndex(img => img.id === id);
+        if (imageIndex > -1) {
           const newImages = [...prev.images];
           newImages[imageIndex] = { ...newImages[imageIndex], ...newPosition };
           return { ...prev, images: newImages };
-        });
-      } else {
-        setBrandElements(prev => prev.map(el =>
-          el.id === id ? { ...el, ...newPosition } : el
-        ));
-      }
+        }
+        return prev;
+      });
+      setBrandElements(prev => prev.map(el =>
+        el.id === id ? { ...el, ...newPosition } : el
+      ));
     }
-  }, [fieldPositions, pageTemplate, brandElements, selectedField, setPageTemplate, setFieldPositions, setBrandElements]);
+  }, [selectedField, setPageTemplate, setFieldPositions, setBrandElements]);
 
   const handleSizeChange = useCallback((id, newSize) => {
     if (id === '__cropbox__') {
@@ -177,20 +177,20 @@ const FieldPositioner = ({
         }
       }));
     } else {
-      const imageIndex = pageTemplate.images.findIndex(img => img.id === id);
-      if (imageIndex > -1) {
-        setPageTemplate(prev => {
+      setPageTemplate(prev => {
+        const imageIndex = prev.images.findIndex(img => img.id === id);
+        if (imageIndex > -1) {
           const newImages = [...prev.images];
           newImages[imageIndex] = { ...newImages[imageIndex], ...newSize };
           return { ...prev, images: newImages };
-        });
-      } else {
-        setBrandElements(prev => prev.map(el =>
-          el.id === id ? { ...el, ...newSize } : el
-        ));
-      }
+        }
+        return prev;
+      });
+      setBrandElements(prev => prev.map(el =>
+        el.id === id ? { ...el, ...newSize } : el
+      ));
     }
-  }, [fieldPositions, pageTemplate, brandElements, selectedField, setPageTemplate, setFieldPositions, setBrandElements]);
+  }, [selectedField, setPageTemplate, setFieldPositions, setBrandElements]);
 
   const centerAllFields = () => {
     const newPositions = { ...fieldPositions };


### PR DESCRIPTION
This commit resolves a state management issue in the `FieldPositioner` component where moving one type of element (e.g., an image) would cause a previously moved element of another type (e.g., a text field) to revert to its original position.

The root cause was that the `useCallback` hooks for `handlePositionChange` and `handleSizeChange` included multiple state variables (`fieldPositions`, `pageTemplate`, `brandElements`) in their dependency arrays. This led to stale closures, where updating one piece of state would cause the callback to be recreated with an old version of the other states, effectively overwriting recent changes.

The fix involves two key changes:
1.  Removing `fieldPositions`, `pageTemplate`, and `brandElements` from the `useCallback` dependency arrays.
2.  Refactoring the state update logic to exclusively use the functional update form of the state setters (e.g., `setPageTemplate(prevState => ...)`).

This ensures that all state modifications are atomic and based on the most recent state, preventing race conditions and data loss.