### PR TITLE
fix(RecordRow): Sanitize HTML to render images correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "dompurify": "^3.2.7",
         "file-saver": "^2.0.5",
         "gapi-script": "^1.2.0",
         "google-auth-library": "^10.2.1",
@@ -3659,6 +3660,13 @@
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -5546,6 +5554,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
+    "dompurify": "^3.2.7",
     "file-saver": "^2.0.5",
     "gapi-script": "^1.2.0",
     "google-auth-library": "^10.2.1",

--- a/src/features/RecordManager/components/RecordRow/RecordRow.jsx
+++ b/src/features/RecordManager/components/RecordRow/RecordRow.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DOMPurify from 'dompurify';
 import styles from './RecordRow.module.css';
 
 /**
@@ -39,9 +40,12 @@ const RecordRow = ({ registro, colunas, onEditar, onExcluir, darkMode = false })
             </td>
             {colunas.map(colunaNome => (
                 <td key={`${registro.id}-${colunaNome}`} data-label={colunaNome} className={styles.dataCell}>
-                    <span className={styles.cellContent}>
-                        {registro[colunaNome] !== undefined && registro[colunaNome] !== null ? String(registro[colunaNome]) : ''}
-                    </span>
+                    <div
+                        className={styles.cellContent}
+                        dangerouslySetInnerHTML={{
+                            __html: DOMPurify.sanitize(registro[colunaNome] !== undefined && registro[colunaNome] !== null ? registro[colunaNome] : '')
+                        }}
+                    />
                 </td>
             ))}
         </tr>


### PR DESCRIPTION
The page editor was displaying broken images because HTML content, including `<img>` tags, was being rendered as a plain string instead of being parsed as HTML.

This was happening in the `RecordRow` component, which explicitly converted cell content to a string.

This commit fixes the issue by using `dangerouslySetInnerHTML` to render the content as HTML. To prevent XSS vulnerabilities, the content is first sanitized using the `dompurify` library. This ensures that images are displayed correctly while maintaining application security.