### PR TITLE
fix(image-loading): Use proxy for Vercel URLs in canvas operations

### DIFF
--- a/src/utils/campaignState.js
+++ b/src/utils/campaignState.js
@@ -172,7 +172,12 @@ export const deserializeCampaignData = async (loadedState) => {
   const permanentToTempUrlMap = new Map();
 
   for (const downloadUrl of uniqueUrlsToDownload.keys()) {
-    const promise = fetch(downloadUrl)
+    // Use the proxy for Vercel URLs to avoid CORS issues
+    const fetchUrl = isVercelUrl(downloadUrl)
+      ? `/api/image-proxy?url=${encodeURIComponent(downloadUrl)}`
+      : downloadUrl;
+
+    const promise = fetch(fetchUrl)
       .then(response => {
         if (!response.ok) {
           throw new Error(`HTTP error ${response.status} fetching ${downloadUrl}`);


### PR DESCRIPTION
This commit fixes a bug where thumbnails and other canvas-based images would appear broken. The issue occurred when an image from Vercel's blob storage was used in a template and then subsequently loaded in a different part of the application.

The root cause was a cross-origin (CORS) error. The browser's security policy prevents a canvas from being tainted by images loaded from a different domain (e.g., `...blob.vercel-storage.com`) without the proper CORS headers. When this happens, operations like `toDataURL()` fail, leading to broken images.

This was happening in two key places:
1.  `imageComposer.js`: During the initial generation of page thumbnails.
2.  `campaignState.js`: During the deserialization of a saved campaign, where permanent Vercel URLs are fetched and converted back to local blobs.

The solution is to consistently use the existing server-side API endpoint at `/api/image-proxy` to handle these requests. This makes the request appear to come from the same origin, resolving the CORS issue.

This commit applies the fix to both `imageComposer.js` and `campaignState.js` to ensure that images from Vercel's blob storage are always loaded correctly, whether during initial generation or when loading a saved campaign.