### PR TITLE
fix(proxy, image): Authenticate Vercel blob requests and ensure proxy…

### DIFF
--- a/api/image-proxy.js
+++ b/api/image-proxy.js
@@ -18,7 +18,11 @@ export default async function handler(req) {
   }
 
   try {
-    const imageResponse = await fetch(imageUrl);
+    const imageResponse = await fetch(imageUrl, {
+      headers: {
+        Authorization: `Bearer ${process.env.BLOB_READ_WRITE_TOKEN}`,
+      },
+    });
 
     if (!imageResponse.ok) {
       return new Response('Failed to fetch the image from the external source.', { status: imageResponse.status });


### PR DESCRIPTION
… usage

This commit fixes a bug where thumbnails and other canvas-based images would appear as broken images. The issue occurred when an image from Vercel's blob storage was used in a template and then subsequently loaded in a different part of the application.

The root cause was two-fold:
1.  A Cross-Origin Resource Sharing (CORS) error was preventing the browser's canvas from loading images from the `...blob.vercel-storage.com` domain.
2.  The Vercel Blob Storage requires an `Authorization` token for access, which was causing a 403 Forbidden error when fetched from the server-side proxy.

This commit addresses both issues comprehensively:

1.  **Updates `api/image-proxy.js`**: The server-side proxy is modified to include the `Authorization: Bearer ${process.env.BLOB_READ_WRITE_TOKEN}` header in its `fetch` request. This allows the proxy to correctly authenticate with and retrieve files from Vercel's private blob storage.

2.  **Updates `src/utils/imageComposer.js`**: The `loadImage` function is modified to route any Vercel Blob Storage URLs through the `/api/image-proxy`. This ensures that images used directly in canvas composition are fetched correctly.

3.  **Updates `src/utils/campaignState.js`**: The `deserializeCampaignData` function is modified to also use the `/api/image-proxy` when downloading assets from Vercel. This ensures that when a saved campaign is loaded, its assets are correctly fetched, converted to local `blob:` URLs, and made available to the rest of the application without CORS issues.

These changes ensure that images from Vercel's blob storage are always loaded correctly and securely, whether during initial generation or when loading a saved campaign.