### PR TITLE
Fix: Resolve 403 error and correct build issue.

### DIFF
--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -195,7 +195,6 @@ export const CampaignProvider = ({ children }) => {
     // Asset Management
     addPendingAsset,
     addPendingAssetMap,
-    addPendingAssetMap,
     removePendingAsset,
     processAssetQueue,
 
@@ -219,6 +218,7 @@ export const CampaignProvider = ({ children }) => {
     customPalette,
     imageColorPalette,
     addPendingAsset,
+    addPendingAssetMap,
     removePendingAsset,
     processAssetQueue,
   ]);


### PR DESCRIPTION
This commit fixes a critical bug where assets could not be loaded from Vercel Blob Storage, resulting in a 403 Forbidden error. It also corrects a build error caused by a duplicate key in CampaignContext.

Asset Proxy Fix:
The root cause of the 403 error was an incorrect security validation in the `/api/asset-proxy.js` file. The validation (`urlObject.host === 'blob.vercel-storage.com'`) was too strict and did not account for the unique subdomains in Vercel's public blob URLs. The fix changes the validation logic to use `urlObject.hostname.endsWith('.blob.vercel-storage.com')`.

Build Error Fix:
A duplicate key "addPendingAssetMap" was present in the `useMemo` hook's return object in `src/context/CampaignContext.jsx`. This has been removed, and the function has been added to the dependency array.

This commit also includes the original asset management refinements, such as the asset queue to prevent race conditions and improved memory management for Blob URLs.