### PR TITLE
Fix color swatches and element positioning in page editor

### DIFF
--- a/src/components/BackgroundColorEditor.jsx
+++ b/src/components/BackgroundColorEditor.jsx
@@ -12,13 +12,15 @@ import {
   Tooltip,
 } from '@mui/material';
 import { Add, Delete, Gradient } from '@mui/icons-material';
+import ColorSwatches from './common/ColorSwatches';
 
-const BackgroundColorEditor = ({ pageTemplate, onUpdate }) => {
+
+const BackgroundColorEditor = ({ pageTemplate, onUpdate, colorPalette, imagePalette }) => {
   if (!pageTemplate) return null;
 
-  // Determine the initial mode. If the pageTemplate has a gradient, default to gradient mode.
   const initialMode = pageTemplate.gradient ? 'gradient' : 'solid';
   const [colorMode, setColorMode] = React.useState(initialMode);
+  const [selectedGradientColorIndex, setSelectedGradientColorIndex] = React.useState(0);
 
   const handleUpdate = (property, value) => {
     onUpdate({ ...pageTemplate, [property]: value });
@@ -39,16 +41,24 @@ const BackgroundColorEditor = ({ pageTemplate, onUpdate }) => {
   };
 
   const addColor = () => {
-    const newColors = [
-      ...(pageTemplate.gradient?.colors || []),
-      '#ffffff',
-    ];
+    const newColors = [...(pageTemplate.gradient?.colors || []), '#ffffff'];
     handleGradientUpdate('colors', newColors);
   };
 
   const removeColor = (index) => {
     const newColors = (pageTemplate.gradient?.colors || []).filter((_, i) => i !== index);
+    if (selectedGradientColorIndex >= newColors.length) {
+      setSelectedGradientColorIndex(newColors.length - 1);
+    }
     handleGradientUpdate('colors', newColors);
+  };
+
+  const handleSolidColorSelect = (color) => {
+    handleUpdate('backgroundColor', color);
+  };
+
+  const handleGradientColorSelect = (color) => {
+    handleColorUpdate(selectedGradientColorIndex, color);
   };
 
   return (
@@ -62,40 +72,27 @@ const BackgroundColorEditor = ({ pageTemplate, onUpdate }) => {
           if (newMode) {
             setColorMode(newMode);
             const newPageTemplate = { ...pageTemplate };
-
             if (newMode === 'solid') {
               newPageTemplate.gradient = null;
-              if (!newPageTemplate.backgroundColor) {
-                newPageTemplate.backgroundColor = '#FFFFFF';
-              }
-            } else { // newMode === 'gradient'
+              if (!newPageTemplate.backgroundColor) newPageTemplate.backgroundColor = '#FFFFFF';
+            } else {
               newPageTemplate.backgroundColor = null;
-              if (!newPageTemplate.gradient) {
-                newPageTemplate.gradient = { type: 'linear', angle: 90, colors: ['#ffffff', '#000000'] };
-              }
+              if (!newPageTemplate.gradient) newPageTemplate.gradient = { type: 'linear', angle: 90, colors: ['#ffffff', '#000000'] };
             }
             onUpdate(newPageTemplate);
           }
         }}
         aria-label="color mode"
       >
-        <ToggleButton value="solid" aria-label="solid color background">
-          Cor Sólida
-        </ToggleButton>
-        <ToggleButton value="gradient" aria-label="gradient background">
-          Gradiente
-        </ToggleButton>
+        <ToggleButton value="solid" aria-label="solid color">Cor Sólida</ToggleButton>
+        <ToggleButton value="gradient" aria-label="gradient">Gradiente</ToggleButton>
       </ToggleButtonGroup>
 
       {colorMode === 'solid' && (
         <Box sx={{ mt: 2 }}>
-          <Typography gutterBottom>Cor de Fundo</Typography>
-          <TextField
-            type="color"
-            value={pageTemplate.backgroundColor || '#ffffff'}
-            onChange={(e) => handleUpdate('backgroundColor', e.target.value)}
-            fullWidth
-          />
+          <TextField type="color" value={pageTemplate.backgroundColor || '#ffffff'} onChange={(e) => handleUpdate('backgroundColor', e.target.value)} fullWidth />
+          <ColorSwatches title="Paleta da Campanha" palette={colorPalette} onColorSelect={handleSolidColorSelect} />
+          <ColorSwatches title="Paleta da Imagem" palette={imagePalette} onColorSelect={handleSolidColorSelect} />
         </Box>
       )}
 
@@ -103,64 +100,33 @@ const BackgroundColorEditor = ({ pageTemplate, onUpdate }) => {
         <Box sx={{ mt: 2 }}>
           <Grid container spacing={2}>
             <Grid item xs={12}>
-                <ToggleButtonGroup
-                    value={pageTemplate.gradient?.type || 'linear'}
-                    exclusive
-                    fullWidth
-                    size="small"
-                    onChange={(e, newType) => {
-                        if (newType) handleGradientUpdate('type', newType);
-                    }}
-                >
-                    <Tooltip title="Gradiente Linear">
-                        <ToggleButton value="linear"><Gradient /></ToggleButton>
-                    </Tooltip>
-                    <Tooltip title="Gradiente Radial">
-                        <ToggleButton value="radial"><Gradient /></ToggleButton>
-                    </Tooltip>
-                </ToggleButtonGroup>
+              <ToggleButtonGroup value={pageTemplate.gradient?.type || 'linear'} exclusive fullWidth size="small" onChange={(e, v) => v && handleGradientUpdate('type', v)}>
+                <Tooltip title="Gradiente Linear"><ToggleButton value="linear"><Gradient /></ToggleButton></Tooltip>
+                <Tooltip title="Gradiente Radial"><ToggleButton value="radial"><Gradient /></ToggleButton></Tooltip>
+              </ToggleButtonGroup>
             </Grid>
 
             {pageTemplate.gradient?.type === 'linear' && (
               <Grid item xs={12}>
-                <Typography gutterBottom>Ângulo do Gradiente: {pageTemplate.gradient?.angle || 0}°</Typography>
-                <Slider
-                  value={pageTemplate.gradient?.angle || 0}
-                  onChange={(e, value) => handleGradientUpdate('angle', value)}
-                  min={0}
-                  max={360}
-                  step={1}
-                  valueLabelDisplay="auto"
-                />
+                <Typography gutterBottom>Ângulo: {pageTemplate.gradient?.angle || 0}°</Typography>
+                <Slider value={pageTemplate.gradient?.angle || 0} onChange={(e, v) => handleGradientUpdate('angle', v)} min={0} max={360} />
               </Grid>
             )}
 
             <Grid item xs={12}>
               <Typography gutterBottom>Cores do Gradiente</Typography>
               {(pageTemplate.gradient?.colors || []).map((color, index) => (
-                <Grid container spacing={1} key={index} alignItems="center" sx={{ mb: 1 }}>
-                  <Grid item xs={4}>
-                    <TextField
-                      type="color"
-                      value={color}
-                      onChange={(e) => handleColorUpdate(index, e.target.value)}
-                      fullWidth
-                      size="small"
-                    />
-                  </Grid>
-                   <Grid item xs={6}>
-                     <Typography noWrap>{color}</Typography>
-                   </Grid>
-                  <Grid item xs={2}>
-                    <IconButton onClick={() => removeColor(index)} size="small" disabled={(pageTemplate.gradient?.colors?.length || 0) <= 2}>
-                      <Delete />
-                    </IconButton>
-                  </Grid>
+                <Grid container spacing={1} key={index} alignItems="center" sx={{ mb: 1, p: 0.5, borderRadius: 1, border: selectedGradientColorIndex === index ? '2px solid #90caf9' : '2px solid transparent' }}>
+                  <Grid item xs={4}><TextField type="color" value={color} onChange={(e) => handleColorUpdate(index, e.target.value)} onFocus={() => setSelectedGradientColorIndex(index)} fullWidth size="small" /></Grid>
+                  <Grid item xs={6}><Typography noWrap>{color}</Typography></Grid>
+                  <Grid item xs={2}><IconButton onClick={() => removeColor(index)} size="small" disabled={(pageTemplate.gradient?.colors?.length || 0) <= 2}><Delete /></IconButton></Grid>
                 </Grid>
               ))}
-              <Button startIcon={<Add />} onClick={addColor} size="small" variant="outlined" fullWidth>
-                Adicionar Cor
-              </Button>
+              <Button startIcon={<Add />} onClick={addColor} size="small" variant="outlined" fullWidth>Adicionar Cor</Button>
+            </Grid>
+            <Grid item xs={12}>
+              <ColorSwatches title="Paleta da Campanha" palette={colorPalette} onColorSelect={handleGradientColorSelect} />
+              <ColorSwatches title="Paleta da Imagem" palette={imagePalette} onColorSelect={handleGradientColorSelect} />
             </Grid>
           </Grid>
         </Box>

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -468,27 +468,6 @@ const FieldPositioner = ({
             </Box>
         </Box>
 
-            {colorPalette && colorPalette.length > 0 && (
-              <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>
-                {colorPalette.map((color, index) => (
-                  <Box
-                    key={index}
-                    sx={{
-                      width: 30,
-                      height: 30,
-                      borderRadius: '50%',
-                      backgroundColor: color,
-                      cursor: 'pointer',
-                      border: '2px solid #fff',
-                      boxShadow: '0 0 5px rgba(0,0,0,0.2)',
-                      touchAction: 'manipulation',
-                      '&:active': { transform: 'scale(0.95)' }
-                    }}
-                    onClick={() => handleColorCircleClick(color)}
-                  />
-                ))}
-              </Box>
-            )}
     </Box>
   );
 };

--- a/src/components/FormattingDrawer.jsx
+++ b/src/components/FormattingDrawer.jsx
@@ -6,6 +6,8 @@ import FormattingPanel from './FormattingPanel';
 const FormattingDrawer = ({
   open,
   onClose,
+  colorPalette,
+  imagePalette,
   selectedField,
   setSelectedField, // <-- Add this
   fieldStyles,
@@ -38,6 +40,8 @@ const FormattingDrawer = ({
           </IconButton>
         </Box>
         <FormattingPanel
+          colorPalette={colorPalette}
+          imagePalette={imagePalette}
           selectedField={selectedField}
           setSelectedField={setSelectedField} // <-- Pass it down
           fieldStyles={fieldStyles}

--- a/src/components/FormattingPanel.jsx
+++ b/src/components/FormattingPanel.jsx
@@ -320,6 +320,8 @@ const FormattingPanel = ({
                 setPageTemplate={setPageTemplate}
                 expandedPanel={expandedPanel}
                 handleAccordionChange={handleAccordionChange}
+                colorPalette={colorPalette}
+                imagePalette={imagePalette}
               />
             )}
           </>

--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -158,7 +158,8 @@ const PageEditor = ({
   }, []);
 
   useEffect(() => {
-    if (open && pageData) {
+    // Only initialize state if the dialog is opening and the state is not already populated
+    if (open && pageData && !editedPositions) {
       const {
         effectiveFieldPositions,
         effectiveFieldStyles,
@@ -183,7 +184,7 @@ const PageEditor = ({
       setEditedRecord(null);
       setSelectedFieldInternal(null);
     }
-  }, [open, pageData, pageDataFromHook, csvHeaders]);
+  }, [open, pageData, pageDataFromHook, csvHeaders, editedPositions]);
 
   if (!open || !pageData || !editedPageTemplate) {
     // Render nothing or a loader until the state is initialized by the effect
@@ -239,7 +240,7 @@ const PageEditor = ({
               fieldStyles={editedStyles}
               setFieldStyles={setEditedStyles}
               csvData={editorCsvData}
-              colorPalette={imageSwatches}
+              imagePalette={imageSwatches}
               selectedField={selectedFieldInternal}
               setSelectedField={handleInternalFieldSelection}
               onCsvDataUpdate={handleFieldPositionerCsvDataUpdate}
@@ -255,7 +256,7 @@ const PageEditor = ({
             <Grid item xs={12} md={4}>
               <FormattingPanel
                 colorPalette={colorPalette}
-                imagePalette={imagePalette}
+                imagePalette={imageSwatches}
                 selectedField={selectedFieldInternal}
                 setSelectedField={setSelectedFieldInternal}
                 fieldStyles={editedStyles}
@@ -286,6 +287,8 @@ const PageEditor = ({
           <FormattingDrawer
             open={isDrawerOpen}
             onClose={() => setIsDrawerOpen(false)}
+            colorPalette={colorPalette}
+            imagePalette={imageSwatches}
             selectedField={selectedFieldInternal}
             setSelectedField={setSelectedFieldInternal}
             fieldStyles={editedStyles}

--- a/src/components/common/ColorSwatches.jsx
+++ b/src/components/common/ColorSwatches.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box, Typography, Tooltip } from '@mui/material';
+
+const Swatch = ({ color, onClick }) => (
+  <Tooltip title={color.name || color.hex || color} placement="top">
+    <Box
+      sx={{
+        width: 24,
+        height: 24,
+        borderRadius: '50%',
+        backgroundColor: color.hex || color,
+        border: '1px solid #ddd',
+        cursor: 'pointer',
+        '&:hover': {
+          transform: 'scale(1.1)',
+          boxShadow: '0px 0px 5px rgba(0,0,0,0.3)',
+        },
+        transition: 'transform 0.1s ease-in-out, box-shadow 0.1s ease-in-out',
+      }}
+      onClick={() => onClick(color.hex || color)}
+    />
+  </Tooltip>
+);
+
+const ColorSwatches = ({ title, palette, onColorSelect }) => {
+  if (!palette || palette.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ my: 2 }}>
+      <Typography variant="caption" display="block" gutterBottom>
+        {title}
+      </Typography>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'flex-start', mt: 1 }}>
+        {palette.map((color, index) => (
+          <Swatch key={index} color={color} onClick={onColorSelect} />
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+export default ColorSwatches;

--- a/src/components/formatting/BackgroundFormatting.jsx
+++ b/src/components/formatting/BackgroundFormatting.jsx
@@ -18,11 +18,20 @@ const BackgroundFormatting = ({
   setPageTemplate,
   expandedPanel,
   handleAccordionChange,
+  colorPalette,
+  imagePalette,
 }) => {
   return (
     <Accordion expanded={expandedPanel === 'backgroundColor'} onChange={handleAccordionChange('backgroundColor')}>
       <AccordionSummary expandIcon={<ExpandMore />}><Typography><Gradient sx={{ mr: 1, verticalAlign: 'middle' }} />Fundo da Página</Typography></AccordionSummary>
-      <AccordionDetails><BackgroundColorEditor pageTemplate={pageTemplate} onUpdate={setPageTemplate} /></AccordionDetails>
+      <AccordionDetails>
+        <BackgroundColorEditor
+          pageTemplate={pageTemplate}
+          onUpdate={setPageTemplate}
+          colorPalette={colorPalette}
+          imagePalette={imagePalette}
+        />
+      </AccordionDetails>
     </Accordion>
   );
 };

--- a/src/components/formatting/TextFormatting.jsx
+++ b/src/components/formatting/TextFormatting.jsx
@@ -14,8 +14,8 @@ import {
   AccordionSummary,
   AccordionDetails,
   TextField,
-  Tooltip,
 } from '@mui/material';
+import ColorSwatches from '../common/ColorSwatches';
 import {
   ExpandMore,
   FormatSize,
@@ -75,28 +75,20 @@ const TextFormatting = ({
             <Grid item xs={8}><FormControl fullWidth size="small"><InputLabel>Fonte</InputLabel><Select value={currentElement.style.fontFamily || 'Arial'} label="Fonte" onChange={(e) => updateFieldStyle('fontFamily', e.target.value)} MenuProps={{ sx: { zIndex: 1500 } }}>{fonts.map(font => (<MenuItem key={font} value={font} style={{ fontFamily: font }}>{font}</MenuItem>))}</Select></FormControl></Grid>
             <Grid item xs={4}><TextField label="Cor" type="color" value={rgbStringToHex(currentElement.style.color || '#000000')} onChange={(e) => updateFieldStyle('color', e.target.value)} fullWidth size="small" /></Grid>
 
-            {colorPalette && colorPalette.length > 0 && (
-              <Grid item xs={12}>
-                <Typography variant="caption">Paleta da Campanha</Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mt: 1 }}>
-                  {colorPalette.map((color, index) => (
-                    <Tooltip title={color.name || color.hex} key={index}>
-                      <Box
-                        sx={{
-                          width: 24,
-                          height: 24,
-                          borderRadius: '50%',
-                          backgroundColor: color.hex,
-                          border: '1px solid #ddd',
-                          cursor: 'pointer',
-                        }}
-                        onClick={() => updateFieldStyle('color', color.hex)}
-                      />
-                    </Tooltip>
-                  ))}
-                </Box>
-              </Grid>
-            )}
+            <Grid item xs={12}>
+                <ColorSwatches
+                    title="Cores da Campanha"
+                    palette={colorPalette}
+                    onColorSelect={(color) => updateFieldStyle('color', color)}
+                />
+            </Grid>
+            <Grid item xs={12}>
+                <ColorSwatches
+                    title="Cores da Imagem"
+                    palette={imagePalette}
+                    onColorSelect={(color) => updateFieldStyle('color', color)}
+                />
+            </Grid>
 
 
             <Grid item xs={12}><ToggleButtonGroup size="small" fullWidth><ToggleButton value="bold" selected={currentElement.style.fontWeight === 'bold'} onClick={() => updateFieldStyle('fontWeight', currentElement.style.fontWeight === 'bold' ? 'normal' : 'bold')}><FormatBold /></ToggleButton><ToggleButton value="italic" selected={currentElement.style.fontStyle === 'italic'} onClick={() => updateFieldStyle('fontStyle', currentElement.style.fontStyle === 'italic' ? 'normal' : 'italic')}><FormatItalic /></ToggleButton><ToggleButton value="underline" selected={currentElement.style.textDecoration === 'underline'} onClick={() => updateFieldStyle('textDecoration', currentElement.style.textDecoration === 'underline' ? 'none' : 'underline')}><FormatUnderlined /></ToggleButton></ToggleButtonGroup></Grid>

--- a/test/test.csv
+++ b/test/test.csv
@@ -1,0 +1,2 @@
+headline
+"This is a test headline"


### PR DESCRIPTION
This commit addresses two issues in the page editor:

1.  **Missing Color Swatches:** The campaign and image color palettes were not visible in the formatting panels for text and background editing. This has been fixed by creating a reusable `ColorSwatches` component and integrating it into the `TextFormatting` and `BackgroundColorEditor` components.

2.  **Element Positioning Reset:** When an element was deselected by clicking on the canvas, its position and style would be reset. This was caused by a state re-initialization issue in `PageEditor.jsx`. The `useEffect` hook that sets the initial state has been modified to only run once when the editor is opened, preserving user changes.

Additionally, the redundant color palette display has been removed from the main canvas (`FieldPositioner.jsx`) to avoid UI clutter.