### PR TITLE
Fix color swatches and element positioning in page editor

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -468,6 +468,27 @@ const FieldPositioner = ({
             </Box>
         </Box>
 
+            {colorPalette && colorPalette.length > 0 && (
+              <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>
+                {colorPalette.map((color, index) => (
+                  <Box
+                    key={index}
+                    sx={{
+                      width: 30,
+                      height: 30,
+                      borderRadius: '50%',
+                      backgroundColor: color,
+                      cursor: 'pointer',
+                      border: '2px solid #fff',
+                      boxShadow: '0 0 5px rgba(0,0,0,0.2)',
+                      touchAction: 'manipulation',
+                      '&:active': { transform: 'scale(0.95)' }
+                    }}
+                    onClick={() => handleColorCircleClick(color)}
+                  />
+                ))}
+              </Box>
+            )}
     </Box>
   );
 };


### PR DESCRIPTION
This commit addresses two issues in the page editor:

1.  **Missing Color Swatches:** The campaign and image color palettes were not visible in the formatting panels for text and background editing. This has been fixed by creating a reusable `ColorSwatches` component and integrating it into the `TextFormatting` and `BackgroundColorEditor` components.

2.  **Element Positioning Reset:** When an element was deselected by clicking on the canvas, its position and style would be reset. This was caused by a state re-initialization issue in `PageEditor.jsx`. The `useEffect` hook that sets the initial state has been modified to only run once when the editor is opened, preserving user changes.

This version re-adds the image color palette displayed below the page preview, which was incorrectly removed in a previous version.