### PR TITLE
feat: Implement interactive grid layout for campaign list

### DIFF
--- a/api/campaigns/index.js
+++ b/api/campaigns/index.js
@@ -23,15 +23,15 @@ const handler = async (req, res) => {
         [userId]
       );
 
-      const campaignsWithPreview = rows.map(campaign => {
-        const firstPageUrl = campaign.campaign_data?.generatedPagesData?.[0]?.url || null;
+      const campaignsWithPages = rows.map(campaign => {
+        const pageUrls = campaign.campaign_data?.generatedPagesData?.map(page => page.url).filter(Boolean) || [];
         // We don't want to send the full, potentially large, campaign_data object
         // in the list view. So we extract what we need and return the rest.
         const { campaign_data, ...rest } = campaign;
-        return { ...rest, firstPageUrl };
+        return { ...rest, pageUrls };
       });
 
-      return res.status(200).json(campaignsWithPreview);
+      return res.status(200).json(campaignsWithPages);
     } catch (error) {
       console.error(`[GET /api/campaigns] Error for user ${userId}:`, error);
       return res.status(500).json({ error: 'Internal Server Error' });

--- a/src/components/CampaignCard.jsx
+++ b/src/components/CampaignCard.jsx
@@ -1,0 +1,117 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  CardActions,
+  Typography,
+  IconButton,
+  Box,
+} from '@mui/material';
+import { Delete as DeleteIcon, Edit as EditIcon, Image as ImageIcon } from '@mui/icons-material';
+
+const CampaignCard = ({ campaign, onLoadCampaign, onEditCampaign, onDeleteCampaign }) => {
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const intervalRef = useRef(null);
+
+  const hasImages = campaign.pageUrls && campaign.pageUrls.length > 0;
+
+  const startCarousel = () => {
+    if (hasImages && campaign.pageUrls.length > 1) {
+      intervalRef.current = setInterval(() => {
+        setCurrentImageIndex(prevIndex => (prevIndex + 1) % campaign.pageUrls.length);
+      }, 800); // Change image every 800ms
+    }
+  };
+
+  const stopCarousel = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setCurrentImageIndex(0); // Reset to the first image
+  };
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  const displayedImageUrl = hasImages ? campaign.pageUrls[currentImageIndex] : null;
+
+  return (
+    <Card
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+      onMouseEnter={startCarousel}
+      onMouseLeave={stopCarousel}
+      raised={!!intervalRef.current}
+    >
+      <Box sx={{ cursor: 'pointer', position: 'relative' }} onClick={() => onLoadCampaign(campaign.id)}>
+        {displayedImageUrl ? (
+          <CardMedia
+            component="img"
+            sx={{ height: 194, objectFit: 'cover' }}
+            image={displayedImageUrl}
+            alt={`Preview of ${campaign.name}`}
+          />
+        ) : (
+          <Box
+            sx={{
+              height: 194,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              backgroundColor: 'grey.200',
+            }}>
+            <ImageIcon color="disabled" sx={{ fontSize: 40 }} />
+          </Box>
+        )}
+        {hasImages && campaign.pageUrls.length > 1 && (
+           <Box sx={{
+                position: 'absolute',
+                bottom: 8,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                display: 'flex',
+                gap: '4px',
+            }}>
+                {campaign.pageUrls.map((_, index) => (
+                    <Box
+                        key={index}
+                        sx={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: '50%',
+                            backgroundColor: currentImageIndex === index ? 'primary.main' : 'rgba(255, 255, 255, 0.7)',
+                            transition: 'background-color 0.3s',
+                        }}
+                    />
+                ))}
+            </Box>
+        )}
+      </Box>
+      <CardContent sx={{ flexGrow: 1 }}>
+        <Typography gutterBottom variant="h6" component="h2" noWrap title={campaign.name}>
+          {campaign.name}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Atualizada em: {new Date(campaign.updated_at).toLocaleString()}
+        </Typography>
+      </CardContent>
+      <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>
+        <IconButton aria-label="edit" onClick={() => onEditCampaign(campaign)}>
+          <EditIcon />
+        </IconButton>
+        <IconButton aria-label="delete" onClick={() => onDeleteCampaign(campaign.id, campaign.name)}>
+          <DeleteIcon />
+        </IconButton>
+      </CardActions>
+    </Card>
+  );
+};
+
+export default CampaignCard;

--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -18,11 +18,13 @@ import {
   CardActions,
   Fab,
   CardMedia,
+  Grid,
 } from '@mui/material';
 import { Delete as DeleteIcon, Edit as EditIcon, Add as AddIcon, Image as ImageIcon } from '@mui/icons-material';
 import { useIsMobile } from '../hooks/use-mobile';
 import { getCampaigns, deleteCampaign } from '../utils/campaignState';
 import { toast } from 'sonner';
+import CampaignCard from './CampaignCard';
 
 const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorList, personaList }) => {
   const [campaigns, setCampaigns] = useState([]);
@@ -106,50 +108,18 @@ const MyCampaignsStep = ({ onLoadCampaign, onEditCampaign, onCreateNew, autorLis
                 Nenhuma campanha salva encontrada. Crie uma nova para começar.
               </Typography>
             ) : (
-              (campaigns || []).map((campaign) => (
-                <Card key={campaign.id} sx={{ mb: 2, display: 'flex', flexDirection: { xs: 'column', sm: 'row' } }}>
-                  {campaign.firstPageUrl ? (
-                    <CardMedia
-                      component="img"
-                      sx={{ width: { xs: '100%', sm: 151 }, height: { xs: 151, sm: 'auto' }, objectFit: 'cover' }}
-                      image={campaign.firstPageUrl}
-                      alt={`Preview of ${campaign.name}`}
+              <Grid container spacing={4}>
+                {(campaigns || []).map((campaign) => (
+                  <Grid item key={campaign.id} xs={12} sm={6} md={4}>
+                    <CampaignCard
+                      campaign={campaign}
+                      onLoadCampaign={onLoadCampaign}
+                      onEditCampaign={onEditCampaign}
+                      onDeleteCampaign={handleDelete}
                     />
-                  ) : (
-                    <Box sx={{
-                      width: { xs: '100%', sm: 151 },
-                      height: { xs: 151, sm: 'auto' },
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      backgroundColor: 'grey.200',
-                      minHeight: 151,
-                    }}>
-                      <ImageIcon color="disabled" sx={{ fontSize: 40 }} />
-                    </Box>
-                  )}
-                  <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
-                    <ListItemButton onClick={() => onLoadCampaign(campaign.id)} sx={{ p: 0, flexGrow: 1 }}>
-                      <CardContent>
-                        <Typography variant="h6" component="div">
-                          {campaign.name}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          Atualizada em: {new Date(campaign.updated_at).toLocaleString()}
-                        </Typography>
-                      </CardContent>
-                    </ListItemButton>
-                    <CardActions sx={{ justifyContent: 'flex-end', alignSelf: 'flex-end', p: 1 }}>
-                      <IconButton aria-label="edit" onClick={() => onEditCampaign(campaign)}>
-                        <EditIcon />
-                      </IconButton>
-                      <IconButton aria-label="delete" onClick={() => handleDelete(campaign.id, campaign.name)}>
-                        <DeleteIcon />
-                      </IconButton>
-                    </CardActions>
-                  </Box>
-                </Card>
-              ))
+                  </Grid>
+                ))}
+              </Grid>
             )}
           </Box>
         )}


### PR DESCRIPTION
This commit transforms the campaign list from a static list into a dynamic, interactive grid with a media-style presentation, as requested by the user.

- **API Enhancement:**
  - The `GET /api/campaigns` endpoint has been updated to return an array of all generated page URLs (`pageUrls`) for each campaign, instead of just the first one. This provides the necessary data for the image carousel.

- **Frontend Redesign:**
  - A new `CampaignCard.jsx` component has been created to encapsulate the display logic for each campaign.
  - On mouse hover, the `CampaignCard` now initiates an image carousel, cycling through all available page images for that campaign. This provides a rich, interactive preview.
  - The main `MyCampaignsStep.jsx` view has been refactored to use Material-UI's `<Grid>` component, creating a responsive grid layout that adapts to different screen sizes.
  - The old list-based layout has been completely replaced by the new grid of `CampaignCard` components.