### PR TITLE
Refactor: Use Debounce for Pending Asset Management

### DIFF
--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -1,4 +1,14 @@
-import React, { createContext, useContext, useState, useMemo, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, useState, useMemo, useCallback, useEffect, useRef } from 'react';
+
+// A simple debounce utility
+function debounce(func, wait) {
+  let timeout;
+  return function(...args) {
+    const context = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(context, args), wait);
+  };
+}
 
 const defaultPageTemplate = {
     backgroundColor: '#FFFFFF',
@@ -38,87 +48,67 @@ export const CampaignProvider = ({ children }) => {
    * using `URL.revokeObjectURL()` when the asset is no longer needed to prevent memory leaks.
    */
   const [pendingAssets, setPendingAssets] = useState({});
-    /**
-   * @type {[Object<string, Blob>, Function]}
-   * @description A temporary queue for assets that are created while a save operation
-   * (`saveCampaign` or `updateCampaign`) is in progress. This prevents race conditions
-   * where a new asset might be added to `pendingAssets` after serialization has already
-   * begun, causing the asset to be missed in the upload process. Once the save is complete,
-   * assets from this queue are merged into the main `pendingAssets` state.
-   */
-  const [assetQueue, setAssetQueue] = useState({});
   const [colors, setColors] = useState([]);
   const [paletteId, setPaletteId] = useState(null);
   const [customPalette, setCustomPalette] = useState(null);
   const [imageColorPalette, setImageColorPalette] = useState([]);
 
-    /**
-   * @description Processes the asset queue, moving any queued assets into the main
-   * `pendingAssets` state. This should be called after a save/update operation
-   * is successfully completed.
-   */
-  const processAssetQueue = useCallback(() => {
-    if (Object.keys(assetQueue).length > 0) {
-      console.log('[CampaignContext] Processing asset queue...', assetQueue);
-      setPendingAssets(prev => ({ ...prev, ...assetQueue }));
-      setAssetQueue({}); // Clear the queue
+  // Asset queue for debounced updates
+  const assetQueue = useRef({});
+
+  // Debounced function to flush the asset queue into the main state
+  const flushAssetQueue = useCallback(() => {
+    if (Object.keys(assetQueue.current).length > 0) {
+      console.log('[CampaignContext] Debounced update. Flushing asset queue...', assetQueue.current);
+      setPendingAssets(prev => ({ ...prev, ...assetQueue.current }));
+      assetQueue.current = {}; // Clear the queue after flushing
     }
-  }, [assetQueue]);
+  }, []);
+
+  // Create a memoized debounced version of the flush function
+  const debouncedFlush = useMemo(() => debounce(flushAssetQueue, 300), [flushAssetQueue]);
+
 
   // Centralized asset handlers
     /**
-   * @description Creates a `blob:` URL for a given Blob and adds it to the asset management system.
-   * If a save operation is in progress (`isSaving` is true), the asset is added to a temporary
-   * queue (`assetQueue`) to prevent race conditions. Otherwise, it's added directly to the
-   * main `pendingAssets` state.
+   * @description Creates a `blob:` URL for a given Blob and adds it to a queue for batch processing.
+   * The queue is flushed automatically after a short delay to prevent race conditions and improve performance.
+   * This function no longer requires an `isSaving` flag.
    *
    * ---
    * **Blob Lifecycle:**
-   * 1. **Creation:** A `blob:` URL is created using `URL.createObjectURL(blob)`. This URL is a
-   *    temporary, local reference to the Blob data held in memory.
-   * 2. **Management:** The URL and Blob are stored in the `pendingAssets` map. The URL can now be
-   *    used in `src` attributes of `<img>`, `<video>`, etc.
-   * 3. **Serialization:** During a campaign save, `serializeCampaignData` finds all `blob:` URLs in the
-   *    campaign state, retrieves their corresponding Blobs from `pendingAssets`, uploads them to
-   *    permanent storage, and replaces the `blob:` URLs with the new permanent URLs.
-   * 4. **Revocation:** The `blob:` URL **must** be revoked using `URL.revokeObjectURL(url)` to free up
-   *    memory. This is handled automatically by `removePendingAsset` or by the component's unmount effect.
+   * 1. **Creation:** A `blob:` URL is created using `URL.createObjectURL(blob)`.
+   * 2. **Queueing:** The URL and Blob are added to a temporary queue (`assetQueue`).
+   * 3. **Batch Update:** A debounced function (`debouncedFlush`) merges the queue into the main
+   *    `pendingAssets` state after a 300ms delay.
+   * 4. **Serialization:** During a campaign save, `serializeCampaignData` uses the stable `pendingAssets` state.
+   * 5. **Revocation:** The `blob:` URL **must** be revoked using `URL.revokeObjectURL(url)`. This is handled
+   *    by `removePendingAsset` or the component's unmount effect.
    * ---
    *
    * @param {Blob} blob The Blob object to add.
-   * @param {boolean} [isSaving=false] A flag indicating if a campaign save is in progress.
    * @returns {string|null} The generated `blob:` URL, or null if the input was invalid.
    */
-  const addPendingAsset = useCallback((blob, isSaving = false) => {
+  const addPendingAsset = useCallback((blob) => {
     if (!(blob instanceof Blob)) {
       console.error("[addPendingAsset] Invalid argument. Expected a Blob.", blob);
       return null;
     }
     const blobUrl = URL.createObjectURL(blob);
-
-    if (isSaving) {
-      console.log('[addPendingAsset] App is saving. Queuing asset:', blobUrl);
-      setAssetQueue(prev => ({ ...prev, [blobUrl]: blob }));
-    } else {
-      setPendingAssets(prev => ({ ...prev, [blobUrl]: blob }));
-    }
+    assetQueue.current[blobUrl] = blob;
+    debouncedFlush();
     return blobUrl;
-  }, []);
+  }, [debouncedFlush]);
 
     /**
-   * @description Adds a map of pre-existing `blob:` URLs and their Blobs to the asset management system.
+   * @description Adds a map of pre-existing `blob:` URLs and their Blobs to the asset queue.
    * This is a batch version of `addPendingAsset` for efficiency.
    * @param {Object<string, Blob>} assetMap A map of `blob:` URLs to Blob objects.
-   * @param {boolean} [isSaving=false] A flag indicating if a campaign save is in progress.
    */
-  const addPendingAssetMap = useCallback((assetMap, isSaving = false) => {
-    if (isSaving) {
-      console.log('[addPendingAssetMap] App is saving. Queuing asset map:', assetMap);
-      setAssetQueue(prev => ({ ...prev, ...assetMap }));
-    } else {
-      setPendingAssets(prev => ({ ...prev, ...assetMap }));
-    }
-  }, []);
+  const addPendingAssetMap = useCallback((assetMap) => {
+    assetQueue.current = { ...assetQueue.current, ...assetMap };
+    debouncedFlush();
+  }, [debouncedFlush]);
 
     /**
    * @description Removes a pending asset from the state and revokes its associated `blob:` URL
@@ -130,6 +120,11 @@ export const CampaignProvider = ({ children }) => {
       console.error("[removePendingAsset] Invalid argument. Expected a blob URL string.", blobUrl);
       return;
     }
+    // Also remove from the queue in case it hasn't been flushed yet
+    if (assetQueue.current[blobUrl]) {
+        delete assetQueue.current[blobUrl];
+    }
+
     setPendingAssets(prev => {
       const newAssets = { ...prev };
       if (newAssets[blobUrl]) {
@@ -148,9 +143,15 @@ export const CampaignProvider = ({ children }) => {
    */
   useEffect(() => {
     return () => {
+      // Clean up assets in the main state
       Object.keys(pendingAssets).forEach(url => {
         console.log(`[CampaignContext] Revoking blob URL on unmount: ${url}`);
         URL.revokeObjectURL(url);
+      });
+      // Clean up any assets still in the queue
+      Object.keys(assetQueue.current).forEach(url => {
+          console.log(`[CampaignContext] Revoking queued blob URL on unmount: ${url}`);
+          URL.revokeObjectURL(url);
       });
     };
   }, [pendingAssets]);
@@ -196,7 +197,6 @@ export const CampaignProvider = ({ children }) => {
     addPendingAsset,
     addPendingAssetMap,
     removePendingAsset,
-    processAssetQueue,
 
     // Constants
     defaultPageTemplate,
@@ -220,7 +220,6 @@ export const CampaignProvider = ({ children }) => {
     addPendingAsset,
     addPendingAssetMap,
     removePendingAsset,
-    processAssetQueue,
   ]);
 
   return (

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -113,7 +113,6 @@ function HomePage() {
     pendingAssets, setPendingAssets,
     addPendingAsset,
     addPendingAssetMap,
-    processAssetQueue,
     removePendingAsset,
     defaultPageTemplate,
     paletteId, setPaletteId,
@@ -501,9 +500,6 @@ function HomePage() {
          console.warn("[HomePage] Save operation did not return a re-hydrated state to synchronize.");
          setPendingAssets({}); // Clear pending assets as a fallback
       }
-
-      // 4. Process any assets that were queued during the save operation
-      processAssetQueue();
 
       console.log("[HomePage] Save/Update operation completed successfully.");
     } catch (err) {
@@ -995,13 +991,13 @@ function HomePage() {
     const file = event.target.files[0];
     if (!file) return;
 
-    const tempUrl = addPendingAsset(file, isSaving);
+    const tempUrl = addPendingAsset(file);
     if (tempUrl) {
       addNewImageToCanvas(tempUrl);
     } else {
       toast.error("Não foi possível criar uma URL local para a imagem carregada.");
     }
-  }, [addNewImageToCanvas, addPendingAsset, isSaving]);
+  }, [addNewImageToCanvas, addPendingAsset]);
 
   const handleImageSelected = async (file) => {
     if (!file) return;
@@ -1034,7 +1030,7 @@ function HomePage() {
 
       canvas.toBlob((blob) => {
         if (blob) {
-          const resizedTempUrl = addPendingAsset(blob, isSaving);
+          const resizedTempUrl = addPendingAsset(blob);
           if (resizedTempUrl) {
             addNewImageToCanvas(resizedTempUrl);
           } else {
@@ -1225,7 +1221,7 @@ function HomePage() {
         throw new Error("Failed to convert generated image data to a Blob.");
       }
 
-      const tempUrl = addPendingAsset(blob, isSaving);
+      const tempUrl = addPendingAsset(blob);
       if (!tempUrl) {
         throw new Error("Failed to create a managed URL for the generated image.");
       }
@@ -1247,7 +1243,7 @@ function HomePage() {
     } finally {
       setIsGeneratingImage(false);
     }
-  }, [aspectRatio, addNewImageToCanvas, addPendingAsset, autorList, selectedAutorForCampaign, isSaving]);
+  }, [aspectRatio, addNewImageToCanvas, addPendingAsset, autorList, selectedAutorForCampaign]);
   const handleGenerateSummary = async (targetLength, content = campaignContent) => { if (!content?.conteudo) { alert("Por favor, gere o conteúdo principal primeiro."); return; } const setLoading = targetLength === 1800 ? setIsGeneratingSummaryMedio : setIsGeneratingSummaryPequeno; setLoading(true); if (!geminiAPI.isInitialized) { const apiKey = getGeminiApiKey(); if (!apiKey) { alert('Por favor, configure sua chave de API Gemini primeiro.'); setLoading(false); return; } geminiAPI.initialize(apiKey); } try { const summaryPrompt = `Resuma o seguinte texto para ter no máximo ${targetLength} caracteres, mantendo a essência e o tom: "${stripHtml(content.conteudo)}"`; const summary = await geminiAPI.generateContent(summaryPrompt); const fieldName = targetLength === 1800 ? 'conteudoMedio' : 'conteudoPequeno'; setCampaignContent(prev => ({ ...prev, [fieldName]: summary })); } catch (error) { alert(`Ocorreu um erro ao gerar o resumo. Verifique o console.`); } finally { setLoading(false); } };
   const handleGenerateFormattedContent = async (content = campaignContent) => { if (!content?.conteudo) { toast.error("Por favor, gere o conteúdo principal primeiro."); return; } setIsGeneratingConteudoFormatado(true); try { const finalContent = await generateFormattedContent({ content }); setCampaignContent(prev => ({ ...prev, conteudoFormatado: finalContent })); } catch (error) { toast.error(`Ocorreu um erro ao gerar o conteúdo formatado: ${error.message}`); } finally { setIsGeneratingConteudoFormatado(false); } };
   const handleGenerateFollowupPosts = async (content = campaignContent) => {
@@ -1425,7 +1421,7 @@ function HomePage() {
       });
 
       const { blob } = finalPageData;
-      const tempUrl = addPendingAsset(blob, isSaving);
+      const tempUrl = addPendingAsset(blob);
       if (!tempUrl) {
         throw new Error("Failed to create managed URL for final page image.");
       }
@@ -1682,10 +1678,10 @@ function HomePage() {
                           newAssetMap[asset.thumbnailUrl] = asset.thumbnailBlob;
                         }
                       });
-                      addPendingAssetMap(newAssetMap, isSaving);
+                      addPendingAssetMap(newAssetMap);
                     }}
                     onUpdateVideos={setGeneratedVideos}
-                    onNewAsset={(blob) => addPendingAsset(blob, isSaving)}
+                    onNewAsset={(blob) => addPendingAsset(blob)}
                   />
                 )}
                 {activeStep === 7 && (


### PR DESCRIPTION
This commit refactors the asset management logic in `CampaignContext.jsx` to use a debounced queue for handling pending assets. This approach mitigates race conditions that could occur when assets were added during a campaign save operation.

Key changes:
- Replaced the manual `isSaving` flag and `assetQueue` state with a `useRef` to hold a temporary asset queue.
- Implemented a debounced function that flushes the asset queue to the `pendingAssets` state, ensuring atomic updates.
- Removed the `isSaving` parameter from `addPendingAsset` and `addPendingAssetMap`, simplifying the API.
- Updated all call sites in `HomePage.jsx` to remove the `isSaving` argument.
- Removed the now-obsolete `processAssetQueue` function.

This change makes the asset management system more robust, less error-prone, and easier to maintain.