### PR TITLE
feat: Implement automatic deletion of Vercel Blob assets on campaign …

### DIFF
--- a/api/campaigns/[id].js
+++ b/api/campaigns/[id].js
@@ -1,5 +1,7 @@
+import { del } from '@vercel/blob';
 import { withAuth } from '../middleware/auth.js';
 import { query } from '../db.js';
+import { extractAssetUrls } from '../../src/utils/campaignUtils.js';
 
 const parseBody = async (req) => {
   let body = '';
@@ -14,7 +16,7 @@ const parseBody = async (req) => {
 };
 
 const handler = async (req, res) => {
-  const userId = req.user.sub;
+  const userId = req.user.id; // Correctly use the user's integer ID
   const { id } = req.query;
 
   if (req.method === 'GET') {
@@ -57,16 +59,38 @@ const handler = async (req, res) => {
     }
   } else if (req.method === 'DELETE') {
     try {
-      const { rowCount } = await query(
-        'DELETE FROM campaigns WHERE id = $1 AND user_id = $2',
-        [id, userId]
-      );
-      if (rowCount === 0) {
+      // Step 1: Fetch the campaign to get its data
+      const { rows } = await query('SELECT campaign_data FROM campaigns WHERE id = $1 AND user_id = $2', [id, userId]);
+
+      if (rows.length === 0) {
         return res.status(404).json({ error: 'Campaign not found or access denied.' });
       }
-      return res.status(200).json({ message: 'Campaign deleted successfully.' });
+
+      const campaignData = rows[0].campaign_data;
+      const assetUrls = extractAssetUrls(campaignData);
+
+      // Step 2: Delete associated assets from Vercel Blob Storage
+      if (assetUrls.length > 0) {
+        console.log(`[DELETE /api/campaigns/${id}] Deleting ${assetUrls.length} assets from blob storage...`);
+        await del(assetUrls);
+        console.log(`[DELETE /api/campaigns/${id}] Successfully deleted assets.`);
+      }
+
+      // Step 3: Delete the campaign from the database
+      const { rowCount } = await query('DELETE FROM campaigns WHERE id = $1 AND user_id = $2', [id, userId]);
+
+      if (rowCount === 0) {
+        // This case should ideally not be reached if the first query succeeded
+        return res.status(404).json({ error: 'Campaign not found or access denied after asset deletion.' });
+      }
+
+      return res.status(200).json({ message: 'Campaign and associated assets deleted successfully.' });
     } catch (error) {
       console.error(`[DELETE /api/campaigns/${id}] Error for user ${userId}:`, error);
+      // Check if the error is from the blob deletion
+      if (error.message.includes('blob')) {
+        return res.status(500).json({ error: 'Failed to delete one or more assets from storage. Campaign not deleted.' });
+      }
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   } else {

--- a/src/utils/campaignUtils.js
+++ b/src/utils/campaignUtils.js
@@ -1,0 +1,29 @@
+/**
+ * Extracts all Vercel Blob Storage URLs from a campaign data object.
+ * @param {object} data The campaign data object.
+ * @returns {string[]} A list of unique asset URLs.
+ */
+export function extractAssetUrls(data) {
+  const urls = new Set();
+  const blobUrlPattern = /blob\.vercel-storage\.com/;
+
+  function traverse(obj) {
+    if (!obj || typeof obj !== 'object') {
+      return;
+    }
+
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key];
+        if (typeof value === 'string' && blobUrlPattern.test(value)) {
+          urls.add(value);
+        } else if (typeof value === 'object') {
+          traverse(value);
+        }
+      }
+    }
+  }
+
+  traverse(data);
+  return [...urls];
+}

--- a/test/campaigns.test.js
+++ b/test/campaigns.test.js
@@ -1,0 +1,127 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import handler from '../api/campaigns/[id].js';
+import { del } from '@vercel/blob';
+
+// Mock the Vercel Blob module to spy on the 'del' function
+vi.mock('@vercel/blob', () => ({
+  del: vi.fn(),
+}));
+
+// Mock the auth middleware to bypass it
+vi.mock('../api/middleware/auth.js', () => ({
+  withAuth: (handler) => handler,
+}));
+
+// Mock the database module directly to avoid pg-mem issues
+const mockDb = {
+  campaigns: [],
+  users: [],
+};
+
+vi.mock('../api/db.js', () => ({
+  query: vi.fn((sql, params) => {
+    const table = sql.includes('FROM campaigns') ? 'campaigns' : 'users';
+
+    if (sql.startsWith('SELECT')) {
+      if (table === 'campaigns') {
+        // Ensure ID is treated as a number for comparison, as it comes from query as a string
+        const campaign = mockDb.campaigns.find(c => c.id === Number(params[0]) && c.user_id === params[1]);
+        return Promise.resolve({ rows: campaign ? [campaign] : [] });
+      }
+    }
+
+    if (sql.startsWith('DELETE')) {
+      if (table === 'campaigns') {
+        const initialLength = mockDb.campaigns.length;
+        // Ensure ID is treated as a number for comparison
+        mockDb.campaigns = mockDb.campaigns.filter(c => !(c.id === Number(params[0]) && c.user_id === params[1]));
+        const finalLength = mockDb.campaigns.length;
+        return Promise.resolve({ rowCount: initialLength - finalLength });
+      }
+    }
+
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  }),
+}));
+
+
+describe('Campaigns API Endpoint with Mocked DB', () => {
+
+  beforeEach(() => {
+    // Reset mocks and the mock database before each test
+    vi.clearAllMocks();
+
+    // Setup initial state for the mock DB
+    mockDb.users = [{ id: 1, sub: 'test-user-sub' }];
+    mockDb.campaigns = [
+      {
+        id: 101,
+        user_id: 1,
+        name: 'Test Campaign',
+        campaign_data: {
+          title: 'Test Campaign',
+          imageUrl: 'https://123.blob.vercel-storage.com/image.png',
+          videoUrl: 'https://456.blob.vercel-storage.com/video.mp4',
+          nested: {
+            audio: 'https://789.blob.vercel-storage.com/audio.mp3',
+          },
+          nonBlobUrl: 'https://example.com/image.jpg',
+        },
+      },
+    ];
+  });
+
+  it('should delete a campaign and its associated assets', async () => {
+    const campaignId = 101;
+    const userId = 1;
+
+    const req = {
+      method: 'DELETE',
+      user: { id: userId, sub: 'test-user-sub' },
+      query: { id: campaignId.toString() },
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    // Execute the handler
+    await handler(req, res);
+
+    // Assertions
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Campaign and associated assets deleted successfully.' });
+
+    const expectedUrlsToDelete = [
+      'https://123.blob.vercel-storage.com/image.png',
+      'https://456.blob.vercel-storage.com/video.mp4',
+      'https://789.blob.vercel-storage.com/audio.mp3',
+    ];
+
+    expect(del).toHaveBeenCalledTimes(1);
+    const deletedUrls = del.mock.calls[0][0];
+    expect(deletedUrls).toHaveLength(expectedUrlsToDelete.length);
+    expect(deletedUrls).toEqual(expect.arrayContaining(expectedUrlsToDelete));
+
+    // Verify the campaign was removed from our mock DB
+    expect(mockDb.campaigns.find(c => c.id === campaignId)).toBeUndefined();
+  });
+
+  it('should return 404 if campaign to delete is not found', async () => {
+    const req = {
+      method: 'DELETE',
+      user: { id: 1, sub: 'test-user-sub' },
+      query: { id: '999' }, // Non-existent ID
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Campaign not found or access denied.' });
+    expect(del).not.toHaveBeenCalled();
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,6 +7,7 @@ const db = newDb();
 db.public.query(`
     CREATE TABLE users (
         id SERIAL PRIMARY KEY,
+        sub TEXT UNIQUE, -- Added for consistency with how user is identified in tests
         email VARCHAR(255) UNIQUE NOT NULL,
         password VARCHAR(255) NOT NULL,
         name VARCHAR(255),


### PR DESCRIPTION
…deletion

This commit introduces a mechanism to automatically delete assets from the Vercel Blob Store when a campaign is deleted. This prevents orphaned files and reduces storage costs.

Key changes:
- A new utility function `extractAssetUrls` is created in `src/utils/campaignUtils.js` to recursively find all Vercel Blob Storage URLs within a campaign's data object.
- The `DELETE /api/campaigns/[id]` API endpoint is updated to first fetch the campaign data, extract the asset URLs, and then call the `@vercel/blob` `del` function to remove the assets before deleting the campaign from the database.
- Added comprehensive unit tests in `test/campaigns.test.js` to verify the new deletion logic, mocking the database and the Vercel Blob `del` function to ensure correct behavior.
- Corrected a minor bug in the campaign handler to use `req.user.id` instead of `req.user.sub` for database queries.