### PR TITLE
feat: add debug logging and in-memory db for testing

### DIFF
--- a/api/campaigns/[id].js
+++ b/api/campaigns/[id].js
@@ -20,8 +20,11 @@ const handler = async (req, res) => {
   const userId = req.user.id; // Correctly use the user's integer ID
   const { id } = req.query;
 
+  console.log(`[API /api/campaigns/${id}] Received request for campaign ID: ${id} from User ID: ${userId}`);
+
   if (req.method === 'GET') {
     try {
+      console.log(`[API /api/campaigns/${id}] Executing SELECT query...`);
       const { rows } = await query(
         'SELECT id, name, campaign_data, autor_id, persona_id, palette_id, updated_at FROM campaigns WHERE id = $1 AND user_id = $2',
         [id, userId]

--- a/api/db.js
+++ b/api/db.js
@@ -1,41 +1,105 @@
 import pg from 'pg';
+import { newDb } from 'pg-mem';
 
 const connectionString = process.env.POSTGRES_URL;
+const isDev = process.env.NODE_ENV !== 'production';
 
 let pool;
 
+// This is a simplified schema for the in-memory DB, based on setup.sql
+const setupInMemoryDb = () => {
+  console.log("Setting up in-memory PostgreSQL database for development...");
+  const db = newDb();
+
+  // pg-mem doesn't support all PostgreSQL features, so we use a simplified schema.
+  // Triggers and some functions like gen_random_uuid are omitted.
+  db.public.query(`
+    CREATE TABLE users (
+        id SERIAL PRIMARY KEY,
+        uuid UUID,
+        name VARCHAR(255),
+        email VARCHAR(255) UNIQUE NOT NULL,
+        password_hash VARCHAR(255),
+        role VARCHAR(50) DEFAULT 'user' NOT NULL,
+        google_id VARCHAR(255) UNIQUE,
+        google_access_token TEXT,
+        google_refresh_token TEXT,
+        linkedin_access_token VARCHAR(2048),
+        linkedin_access_token_expiry TIMESTAMPTZ,
+        linkedin_refresh_token VARCHAR(1024),
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE settings (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+        settings_data JSONB,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE campaigns (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name VARCHAR(255) NOT NULL,
+        campaign_data JSONB,
+        autor_id INTEGER,
+        persona_id INTEGER,
+        palette_id INTEGER,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE linkedin_schedules (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        campaign_id INTEGER REFERENCES campaigns(id) ON DELETE SET NULL,
+        status VARCHAR(50) NOT NULL DEFAULT 'scheduled',
+        scheduled_at TIMESTAMPTZ NOT NULL,
+        user_selected_time VARCHAR(255),
+        post_content JSONB,
+        linkedin_post_id VARCHAR(255),
+        linkedin_post_url VARCHAR(2048),
+        error_message TEXT,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+
+  console.log("In-memory database setup complete.");
+  return db;
+};
+
 const getPool = () => {
   if (!pool) {
-    if (!connectionString) {
-      // This error will be thrown at request time, inside the API handler's try/catch block.
-      throw new Error('Database configuration is missing. The POSTGRES_URL environment variable is not set.');
+    if (isDev) {
+      // Use in-memory database for development
+      pool = setupInMemoryDb();
+    } else {
+      // Use real PostgreSQL for production
+      if (!connectionString) {
+        throw new Error('Database configuration is missing. The POSTGRES_URL environment variable is not set for production.');
+      }
+      console.log("Creating new PostgreSQL connection pool for production.");
+      pool = new pg.Pool({
+        connectionString,
+        max: 10,
+        idleTimeoutMillis: 5000,
+        connectionTimeoutMillis: 2000,
+      });
     }
-
-    console.log("Creating new PostgreSQL connection pool.");
-    pool = new pg.Pool({
-      connectionString,
-      // Vercel recommends these settings for serverless functions
-      // See: https://vercel.com/guides/project-environment-variables-and-secrets
-      max: 10, // Max number of clients in the pool
-      idleTimeoutMillis: 5000, // How long a client is allowed to remain idle before being closed
-      connectionTimeoutMillis: 2000, // How long to wait for a client to connect
-    });
   }
   return pool;
 };
 
-/**
- * A wrapper for the pool.query function that ensures the pool is initialized.
- * @param {string} text - The SQL query text.
- * @param {Array} params - The parameters for the SQL query.
- * @returns {Promise<pg.QueryResult>} The result of the query.
- */
 export const query = (text, params) => {
   const dbPool = getPool();
-  // The call to pool.query() is already wrapped in a try/catch in the API route handlers.
+  // pg-mem has a `query` method on the main object, pg.Pool has it on the pool itself.
+  if (isDev) {
+      return dbPool.public.query(text, params);
+  }
   return dbPool.query(text, params);
 };
 
-// Note: We don't export the pool directly anymore to ensure it's always accessed via getPool.
-// This prevents direct usage without the initialization and connection string check.
 export default { query };

--- a/preview_output.log
+++ b/preview_output.log
@@ -2,8 +2,3 @@
 > midiator-google-drive-frontend@0.0.0 dev /app
 > vite
 
-
-  VITE v5.4.20  ready in 378 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -841,6 +841,7 @@ function HomePage() {
     setActiveStep(1);
   };
   const handleEditCampaign = async (campaign) => {
+    console.log(`[handleEditCampaign] Attempting to load campaign with ID: ${campaign.id} and name: "${campaign.name}"`);
     toast.info(`Carregando "${campaign.name}" para edição...`);
     try {
       await checkAuthStatus();


### PR DESCRIPTION
This commit includes the new UI and architectural fixes, but is primarily intended to facilitate debugging of a persistent 'Failed to load campaign' error.

- Adds an in-memory database (`pg-mem`) for the development environment to allow the server to start without a real PostgreSQL connection.
- Injects detailed console logs into the frontend campaign loading function (`handleEditCampaign`) and the backend API endpoint (`/api/campaigns/[id]`) to trace the data flow.
- Includes the full UI redesign and previous bug fixes for context.