### PR TITLE
Fix: Limit page preview height to available space

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -393,103 +393,110 @@ const FieldPositioner = ({
     : pageTemplate.backgroundColor || '#FFFFFF';
 
   return (
-    <Box sx={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+      <Box
+        sx={{
+          position: 'relative',
+          width: '100%',
+          flex: '1 1 0',
+          minHeight: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+      >
         <Box
           ref={containerRef}
           className="text-container"
-              sx={{
-                position: 'relative',
-                border: '2px solid #ddd',
-                background: backgroundValue,
-                cursor: 'default',
-                touchAction: 'pan-x pan-y',
-                WebkitOverflowScrolling: 'touch',
-                '&.interacting': {
-                  touchAction: 'none'
-                },
-                aspectRatio: aspectRatio,
-                width: 'auto',
-                height: 'auto',
-                maxWidth: '100%',
-                maxHeight: '100%',
-                overflow: 'hidden',
-                borderRadius: 2,
-              }}
-              onTouchStart={handleContainerTouchStart}
-              onTouchEnd={handleContainerTouchEnd}
-            >
-                <>
-                  <Box
-                    className="elements-wrapper"
-                    sx={{
-                      position: 'absolute',
-                      left: 0,
-                      top: 0,
-                      width: '100%',
-                      height: '100%',
-                    }}
-                    onClick={(e) => {
-                      if (e.target === e.currentTarget) {
-                        setSelectedField('__page_background__');
-                      }
-                    }}
-                    onTouchStart={(e) => {
-                      if (e.target === e.currentTarget) {
-                        setSelectedField('__page_background__');
-                      }
-                    }}
-                  >
-                    {renderableElements.map(element => (
-                      <DraggableElement
-                        key={element.id}
-                        element={{ ...element.position, type: element.type, id: element.id }}
-                        position={element.position}
-                        style={element.style}
-                        content={element.content}
-                        isSelected={selectedField === element.id}
-                        onSelect={setSelectedField}
-                        onPositionChange={handlePositionChange}
-                        onSizeChange={handleSizeChange}
-                        containerSize={renderedImageMetrics}
-                        onContentChange={element.type === 'text' ? handleContentChange : undefined}
-                        onDoubleClick={() => {
-                          if (element.type === 'text' && isHtmlField(element.id)) {
-                            onOpenHtmlEditor(element.id);
-                          }
-                        }}
-                        rotation={element.rotation}
-                        originalImageSize={effectiveImageSize}
-                        fontScale={element.fontScale}
-                        enableHtmlRendering={element.enableHtmlRendering}
-                        darkMode={darkMode}
-                      />
-                    ))}
-                  </Box>
-                </>
-            </Box>
+          sx={{
+            position: 'relative',
+            background: backgroundValue,
+            aspectRatio: aspectRatio,
+            maxWidth: '100%',
+            maxHeight: '100%',
+            border: '2px solid #ddd',
+            borderRadius: 2,
+            overflow: 'hidden',
+            cursor: 'default',
+            touchAction: 'pan-x pan-y',
+            WebkitOverflowScrolling: 'touch',
+            '&.interacting': {
+              touchAction: 'none'
+            },
+          }}
+          onTouchStart={handleContainerTouchStart}
+          onTouchEnd={handleContainerTouchEnd}
+        >
+          <Box
+            className="elements-wrapper"
+            sx={{
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              width: '100%',
+              height: '100%',
+            }}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) {
+                setSelectedField('__page_background__');
+              }
+            }}
+            onTouchStart={(e) => {
+              if (e.target === e.currentTarget) {
+                setSelectedField('__page_background__');
+              }
+            }}
+          >
+            {renderableElements.map(element => (
+              <DraggableElement
+                key={element.id}
+                element={{ ...element.position, type: element.type, id: element.id }}
+                position={element.position}
+                style={element.style}
+                content={element.content}
+                isSelected={selectedField === element.id}
+                onSelect={setSelectedField}
+                onPositionChange={handlePositionChange}
+                onSizeChange={handleSizeChange}
+                containerSize={renderedImageMetrics}
+                onContentChange={element.type === 'text' ? handleContentChange : undefined}
+                onDoubleClick={() => {
+                  if (element.type === 'text' && isHtmlField(element.id)) {
+                    onOpenHtmlEditor(element.id);
+                  }
+                }}
+                rotation={element.rotation}
+                originalImageSize={effectiveImageSize}
+                fontScale={element.fontScale}
+                enableHtmlRendering={element.enableHtmlRendering}
+                darkMode={darkMode}
+              />
+            ))}
+          </Box>
         </Box>
+      </Box>
 
-            {colorPalette && colorPalette.length > 0 && (
-              <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>
-                {colorPalette.map((color, index) => (
-                  <Box
-                    key={index}
-                    sx={{
-                      width: 30,
-                      height: 30,
-                      borderRadius: '50%',
-                      backgroundColor: color,
-                      cursor: 'pointer',
-                      border: '2px solid #fff',
-                      boxShadow: '0 0 5px rgba(0,0,0,0.2)',
-                      touchAction: 'manipulation',
-                      '&:active': { transform: 'scale(0.95)' }
-                    }}
-                    onClick={() => handleColorCircleClick(color)}
-                  />
-                ))}
-              </Box>
-            )}
+      {colorPalette && colorPalette.length > 0 && (
+        <Box sx={{ flexShrink: 0, mt: 2, display: 'flex', justifyContent: 'center', gap: 1 }}>
+          {colorPalette.map((color, index) => (
+            <Box
+              key={index}
+              sx={{
+                width: 30,
+                height: 30,
+                borderRadius: '50%',
+                backgroundColor: color,
+                cursor: 'pointer',
+                border: '2px solid #fff',
+                boxShadow: '0 0 5px rgba(0,0,0,0.2)',
+                touchAction: 'manipulation',
+                '&:active': { transform: 'scale(0.95)' }
+              }}
+              onClick={() => handleColorCircleClick(color)}
+            />
+          ))}
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
The page preview in the page template stage was not correctly sized, causing it to overflow its container on certain screen aspect ratios.

This change refactors the JSX structure within `FieldPositioner.jsx` to correctly implement a flexbox-based layout. The preview container is now set to grow and shrink within the available space, while the preview itself uses `maxWidth`, `maxHeight`, and `aspectRatio` to scale properly without overflowing. This also resolves a syntax error that was causing the build to fail.