### PR TITLE
Fix: Resolve collapsing preview and improve layout responsiveness

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -393,7 +393,7 @@ const FieldPositioner = ({
     : pageTemplate.backgroundColor || '#FFFFFF';
 
   return (
-    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+    <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box
         sx={{
           position: 'relative',


### PR DESCRIPTION
This commit addresses a regression where the page preview would collapse. It also finalizes the responsive layout fixes.

1.  The collapsing issue was caused by conflicting flexbox properties (`alignItems` and `justifyContent`) on a parent container, which prevented the child from growing correctly. These properties were removed, simplifying the layout and allowing the preview to expand as intended.

2.  This commit retains the previous fixes that ensure the preview scales correctly within the available vertical space while maintaining its aspect ratio and improves the layout on mobile devices by using `dvh` for height calculation.