### PR TITLE
Fix: Final solution for page preview layout and responsiveness

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -396,13 +396,11 @@ const FieldPositioner = ({
     <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
       <Box
         sx={{
-          position: 'relative',
           width: '100%',
           flex: '1 1 0',
           minHeight: 0,
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center'
+          p: 1,
         }}
       >
         <Box
@@ -410,6 +408,7 @@ const FieldPositioner = ({
           className="text-container"
           sx={{
             position: 'relative',
+            margin: 'auto',
             background: backgroundValue,
             aspectRatio: aspectRatio,
             maxWidth: '100%',


### PR DESCRIPTION
This commit resolves all outstanding issues with the page preview layout, including the initial overflow problem, mobile scaling, and a subsequent collapsing regression.

The `FieldPositioner` component's layout has been simplified to a more robust flexbox structure. The preview container is now a flex item that grows to fill available space (`flex: '1 1 0'`) and centers its content (`margin: 'auto'`). This, combined with `maxWidth: '100%'` and `maxHeight: '100%'` on the preview itself, ensures it scales correctly without overflowing or collapsing.

The `ImageStepUI` component retains the `calc(100dvh - 140px)` height for mobile, ensuring the container is properly sized on smaller viewports.

This combination of fixes provides a stable and responsive layout for the page preview across all devices.