### PR TITLE
fix: Resolve page preview collapsing issue

### DIFF
--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -388,6 +388,7 @@ const FieldPositioner = ({
         margin: 'auto',
         background: backgroundValue,
         aspectRatio: aspectRatio,
+        width: '100%',
         maxWidth: '100%',
         maxHeight: '100%',
         border: '2px solid #ddd',


### PR DESCRIPTION
Adds `width: '100%'` to the `FieldPositioner` component's root element. This ensures the component correctly calculates its aspect ratio-based height within a flex container, preventing it from collapsing into a single dot. This fixes the page preview in the 'Modelo de Página' and 'Edição de Páginas' steps.