### PR TITLE
feat: Reintroduce Palette Previews in Wizard

### DIFF
--- a/src/components/PalettePreview.jsx
+++ b/src/components/PalettePreview.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Grid,
+  Card,
+  CardContent,
+  Button,
+  Chip,
+} from '@mui/material';
+
+// Helper function to determine text color (black or white) based on background color
+const getContrastTextColor = (hexColor) => {
+  if (!hexColor) return '#000000';
+  const r = parseInt(hexColor.substr(1, 2), 16);
+  const g = parseInt(hexColor.substr(3, 2), 16);
+  const b = parseInt(hexColor.substr(5, 2), 16);
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+  return (yiq >= 128) ? '#000000' : '#ffffff';
+};
+
+const PalettePreview = ({ paletteData }) => {
+  if (!paletteData || !paletteData.colors || paletteData.colors.length === 0) {
+    return (
+      <Paper sx={{ p: 2, textAlign: 'center', height: '100%' }}>
+        <Typography color="text.secondary">A pré-visualização da paleta aparecerá aqui.</Typography>
+      </Paper>
+    );
+  }
+
+  const { colors } = paletteData;
+
+  // Assign default colors if the palette has fewer than required
+  const primary = colors.find(c => c.role?.toLowerCase().includes('primária')) || colors[0] || { hex: '#cccccc' };
+  const secondary = colors.find(c => c.role?.toLowerCase().includes('secundária')) || colors[1] || { hex: '#e0e0e0' };
+  const accent = colors.find(c => c.role?.toLowerCase().includes('acento')) || colors[2] || { hex: '#f5f5f5' };
+  const text = colors.find(c => c.role?.toLowerCase().includes('texto')) || { hex: '#212121' };
+  const background = colors.find(c => c.role?.toLowerCase().includes('fundo')) || { hex: '#ffffff' };
+
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Pré-visualização da Paleta
+      </Typography>
+
+      {/* Watch Preview */}
+      <Card
+        sx={{
+          mb: 3,
+          border: '1px solid rgba(0, 0, 0, 0.12)',
+          backgroundColor: background.hex,
+          color: getContrastTextColor(background.hex)
+        }}
+      >
+        <CardContent>
+          <Typography variant="h5" component="div" sx={{ color: primary.hex }}>
+            Título de Exemplo
+          </Typography>
+          <Typography sx={{ mb: 1.5, color: text.hex }}>
+            Este é um texto de exemplo para demonstrar a aplicação das cores da sua paleta em um componente de interface.
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              variant="contained"
+              sx={{
+                backgroundColor: primary.hex,
+                color: getContrastTextColor(primary.hex),
+                '&:hover': { backgroundColor: secondary.hex, color: getContrastTextColor(secondary.hex) }
+              }}
+            >
+              Ação Principal
+            </Button>
+            <Button
+              variant="outlined"
+              sx={{
+                borderColor: accent.hex,
+                color: accent.hex,
+                '&:hover': { backgroundColor: accent.hex, color: getContrastTextColor(accent.hex) }
+              }}
+            >
+              Ação Secundária
+            </Button>
+          </Box>
+        </CardContent>
+      </Card>
+
+      {/* Color Swatches */}
+      <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+        Cores Individuais
+      </Typography>
+      <Grid container spacing={2}>
+        {colors.map((color, index) => (
+          <Grid item xs={12} sm={6} key={index}>
+            <Paper
+              variant="outlined"
+              sx={{
+                p: 1.5,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 50,
+                  height: 50,
+                  borderRadius: 1,
+                  backgroundColor: color.hex,
+                  border: '1px solid #ccc',
+                }}
+              />
+              <Box>
+                <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+                  {color.name || 'Sem nome'}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {color.role || 'Sem papel'}
+                </Typography>
+                <Chip label={color.hex} size="small" sx={{ mt: 0.5, fontFamily: 'monospace' }} />
+              </Box>
+            </Paper>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default PalettePreview;

--- a/src/components/PaletteWizard.jsx
+++ b/src/components/PaletteWizard.jsx
@@ -25,6 +25,7 @@ import { UploadFile as UploadFileIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
 import ColorThief from 'colorthief';
 import PaletteEditor from './PaletteEditor';
+import PalettePreview from './PalettePreview';
 import * as generationHandlers from '../utils/generationHandlers';
 
 const steps = [
@@ -299,13 +300,21 @@ const PaletteWizard = ({
                 <strong>Falha na Geração:</strong> {generationError}
               </Alert>
             )}
-            {paletteData ? (
-              <PaletteEditor
-                paletteData={paletteData}
-                onPaletteDataChange={setPaletteData} // Always use our unified setter
-              />
-            ) : (
-              !generationError && <Typography>A paleta gerada será exibida aqui para edição.</Typography>
+            {!paletteData && !generationError && (
+              <Typography>A paleta gerada e sua pré-visualização serão exibidas aqui para edição.</Typography>
+            )}
+            {paletteData && (
+            <Grid container spacing={4}>
+                <Grid item xs={12} md={6}>
+                  <PaletteEditor
+                    paletteData={paletteData}
+                    onPaletteDataChange={setPaletteData}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <PalettePreview paletteData={paletteData} />
+                </Grid>
+              </Grid>
             )}
           </Box>
         );


### PR DESCRIPTION
This commit reintroduces the color palette previews ("watches") that were missing from the palette generation and editing workflow.

A new `PalettePreview.jsx` component was created to render a live preview of a color palette. This includes a sample UI card and individual color swatches to demonstrate how the colors work together.

The `PalettePreview` component is now integrated into the `PaletteWizard.jsx`. The wizard's second step features a two-column layout, displaying the `PaletteEditor` on the left and the `PalettePreview` on the right, providing users with immediate visual feedback.