### PR TITLE
Fixes a state management bug where the base text for the 'Posts Curto…

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -373,7 +373,16 @@ function HomePage() {
     setInputMethod(state.inputMethod ?? 'ia');
     // Default to 10, which matches the slider's max value in PostsCurtosStep.
     setPromptNumRecords(state.promptNumRecords ?? 10);
-    setPromptText(state.promptText ?? '');
+    // Logic for setting the base text for short posts.
+    // Priority: 1. Use saved promptText. 2. Derive from campaign content. 3. Default to empty.
+    if (state.promptText) {
+      setPromptText(state.promptText);
+    } else if (state.campaignContent) {
+      const { titulo, conteudo, cta } = state.campaignContent;
+      setPromptText(`${titulo || ''}\n\n${conteudo || ''}\n\n${cta || ''}`);
+    } else {
+      setPromptText('');
+    }
     setFieldPositions(state.fieldPositions ?? {});
     setTemplateFieldStyles(state.templateFieldStyles ?? {});
     setCustomPalette(state.customPalette ?? null);
@@ -415,6 +424,7 @@ function HomePage() {
       tomDeVoz,
       campaignContent,
       aspectRatio,
+      promptText,
       followupPosts,
       followupPostsQuantity,
       fieldPositions,
@@ -664,13 +674,6 @@ function HomePage() {
     const newSize = getDimensionsFromAspectRatio(aspectRatio) || DEFAULT_IMAGE_SIZE;
     setOriginalImageSize(newSize);
   }, [aspectRatio]);
-
-  useEffect(() => {
-    if (activeStep === 1 && campaignContent) {
-      const { titulo, conteudo, cta } = campaignContent;
-      setPromptText(`${titulo || ''}\n\n${conteudo || ''}\n\n${cta || ''}`);
-    }
-  }, [activeStep, campaignContent]);
 
   useEffect(() => {
     const handleLinkedInRedirect = async () => {
@@ -1177,6 +1180,8 @@ function HomePage() {
         throw new Error("A geração do conteúdo principal falhou e não retornou dados.");
       }
       setCampaignContent(normalizedContent);
+      const { titulo, conteudo, cta } = normalizedContent;
+      setPromptText(`${titulo || ''}\n\n${conteudo || ''}\n\n${cta || ''}`);
 
       if (regenerate) {
         toast.success("Conteúdo principal da campanha foi regenerado.");


### PR DESCRIPTION
…s' step would disappear. The text is now correctly loaded and synchronized throughout the component lifecycle.

Key changes:
- `applyAppState` now intelligently sets the `promptText` state when a campaign is loaded, prioritizing saved `promptText` or deriving it from `campaignContent`.
- `handleSaveCampaign` now includes `promptText` in the campaign data, ensuring manual edits are persisted.
- `handleGenerateCampaignContent` immediately updates `promptText` after generating new content to maintain state consistency.
- Removed the problematic `useEffect` that was causing the state to fall out of sync, as its logic is now handled more reliably.