### PR TITLE
Fix: Corrected responsive layout for campaign carousel

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-11H_y8Pj.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CxY-hvat.css">
+  <script type="module" crossorigin src="/assets/index-BMCAoIm5.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 
 <body>

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -39,7 +39,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '320px' }}>
+          <SwiperSlide key={campaign.id} style={{ maxWidth: '320px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This commit fixes a responsive layout issue in the "Minhas Campanhas" step where the campaign carousel would overflow on mobile devices, requiring horizontal scrolling.

The root cause was a percentage-based width (`width: '80%'`) on the `SwiperSlide` component within `CampaignCoverFlow.jsx`. This forced the slides to be too wide for mobile viewports.

The fix removes this `width` property, allowing the carousel to automatically and correctly size the slides based on the screen width. This resolves the overflow issue and ensures the component is fully responsive.