### PR TITLE
Fix: Correct structural layout for responsive campaign steps

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-kP7aEveB.js"></script>
+  <script type="module" crossorigin src="/assets/index-gBvd8Sww.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -39,7 +39,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '60%', maxWidth: '280px' }}>
+          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '320px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}

--- a/src/components/MyCampaignsStep.jsx
+++ b/src/components/MyCampaignsStep.jsx
@@ -73,7 +73,7 @@ const MyCampaignsStep = ({ onEditCampaign, onCreateNew }) => {
   };
 
   return (
-    <Container maxWidth={false} sx={{ maxWidth: '1200px', px: { xs: 1, sm: 2 } }}>
+    <Box>
       <Paper sx={{ p: { xs: 2, sm: 3, md: 4 }, mt: 4, position: 'relative', overflow: 'hidden' }}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
           <Typography variant={{ xs: 'h5', sm: 'h4' }} component="h1">
@@ -148,7 +148,7 @@ const MyCampaignsStep = ({ onEditCampaign, onCreateNew }) => {
           <AddIcon />
         </Fab>
       </Paper>
-    </Container>
+    </Box>
   );
 };
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1532,54 +1532,52 @@ function HomePage() {
                   />
                 )}
                 {activeStep === 1 && (
-                  <Container maxWidth="lg">
-                    <Campaign
-                      steps={steps}
-                      activeStep={activeStep}
-                      {...campaignData}
-                      setProblema={setProblema}
-                      setSolucao={setSolucao}
-                      objetivo={objetivo}
-                      setObjetivo={setObjetivo}
-                      tomDeVoz={tomDeVoz}
-                      setTomDeVoz={setTomDeVoz}
-                      isGeneratingCampaign={isGeneratingCampaign}
-                      campaignGenerationFailed={campaignGenerationFailed}
-                      generationError={generationError}
-                      handleGenerateCampaignContent={handleGenerateCampaignContent}
-                      handleResetCampaign={handleResetCampaign}
-                      handleExportHtml={() => exportHtml(campaignData)}
-                      editingField={editingField}
-                      setEditingField={(field) => {
-                        setEditingField(field);
-                        setIsHtmlField(field === 'conteudoFormatado');
-                      }}
-                      isGeneratingSummaryMedio={isGeneratingSummaryMedio}
-                      handleGenerateSummary={handleGenerateSummary}
-                      isGeneratingSummaryPequeno={isGeneratingSummaryPequeno}
-                      isGeneratingConteudoFormatado={isGeneratingConteudoFormatado}
-                      handleGenerateFormattedContent={handleGenerateFormattedContent}
-                      isGeneratingFollowup={isGeneratingFollowup}
-                      handleGenerateFollowupPosts={handleGenerateFollowupPosts}
-                      generatedPageUrl={generatedPageUrl}
-                      isGeneratingImage={isGeneratingImage}
-                      handleGenerateImage={handleGenerateImage}
-                      setCampaignContent={setCampaignContent}
-                      onEditFollowup={handleEditFollowup}
-                      followupPostsQuantity={followupPostsQuantity}
-                      setFollowupPostsQuantity={setFollowupPostsQuantity}
-                      setAspectRatio={setAspectRatio}
-                      autorList={autorList}
-                      selectedAutorForCampaign={selectedAutorForCampaign}
-                      setSelectedAutorForCampaign={setSelectedAutorForCampaign}
-                      personaList={personaList}
-                      selectedPersonaForCampaign={selectedPersonaForCampaign}
-                      setSelectedPersonaForCampaign={setSelectedPersonaForCampaign}
-                      palettes={palettes}
-                      onRequestNewAutor={handleRequestNewAutor}
-                      onRequestNewPersona={handleRequestNewPersona}
-                    />
-                  </Container>
+                  <Campaign
+                    steps={steps}
+                    activeStep={activeStep}
+                    {...campaignData}
+                    setProblema={setProblema}
+                    setSolucao={setSolucao}
+                    objetivo={objetivo}
+                    setObjetivo={setObjetivo}
+                    tomDeVoz={tomDeVoz}
+                    setTomDeVoz={setTomDeVoz}
+                    isGeneratingCampaign={isGeneratingCampaign}
+                    campaignGenerationFailed={campaignGenerationFailed}
+                    generationError={generationError}
+                    handleGenerateCampaignContent={handleGenerateCampaignContent}
+                    handleResetCampaign={handleResetCampaign}
+                    handleExportHtml={() => exportHtml(campaignData)}
+                    editingField={editingField}
+                    setEditingField={(field) => {
+                      setEditingField(field);
+                      setIsHtmlField(field === 'conteudoFormatado');
+                    }}
+                    isGeneratingSummaryMedio={isGeneratingSummaryMedio}
+                    handleGenerateSummary={handleGenerateSummary}
+                    isGeneratingSummaryPequeno={isGeneratingSummaryPequeno}
+                    isGeneratingConteudoFormatado={isGeneratingConteudoFormatado}
+                    handleGenerateFormattedContent={handleGenerateFormattedContent}
+                    isGeneratingFollowup={isGeneratingFollowup}
+                    handleGenerateFollowupPosts={handleGenerateFollowupPosts}
+                    generatedPageUrl={generatedPageUrl}
+                    isGeneratingImage={isGeneratingImage}
+                    handleGenerateImage={handleGenerateImage}
+                    setCampaignContent={setCampaignContent}
+                    onEditFollowup={handleEditFollowup}
+                    followupPostsQuantity={followupPostsQuantity}
+                    setFollowupPostsQuantity={setFollowupPostsQuantity}
+                    setAspectRatio={setAspectRatio}
+                    autorList={autorList}
+                    selectedAutorForCampaign={selectedAutorForCampaign}
+                    setSelectedAutorForCampaign={setSelectedAutorForCampaign}
+                    personaList={personaList}
+                    selectedPersonaForCampaign={selectedPersonaForCampaign}
+                    setSelectedPersonaForCampaign={setSelectedPersonaForCampaign}
+                    palettes={palettes}
+                    onRequestNewAutor={handleRequestNewAutor}
+                    onRequestNewPersona={handleRequestNewPersona}
+                  />
                 )}
                 {activeStep === 2 && (
                   <PostsCurtosStep


### PR DESCRIPTION
This commit addresses a core structural problem that caused unresponsive layouts on the "Minhas Campanhas" and "Campanha" pages.

The issue was traced to restrictive `<Container>` components that were wrapping these specific steps, but not others that were functioning correctly. This inconsistency created a fixed-width environment that broke the layout on mobile screens.

This fix removes the unnecessary `<Container>` wrappers from both `HomePage.jsx` and `MyCampaignsStep.jsx`. By doing so, all campaign steps are now rendered within the same main, flexible layout, ensuring a consistent and fully responsive experience across the application.