### PR TITLE
fix(responsive): Remove max-width from CampaignCoverFlow slide

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CfUo_JyX.js"></script>
+  <script type="module" crossorigin src="/assets/index-DSwZbmdV.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -39,7 +39,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '320px' }}>
+          <SwiperSlide key={campaign.id} style={{ width: '80%' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
The `SwiperSlide` component within `CampaignCoverFlow.jsx` had a fixed `maxWidth` of `320px`. This prevented the campaign cards from scaling down correctly on mobile screens narrower than 320px, causing layout overflow.

This commit removes the `maxWidth` property, allowing the slide width to be determined by the `width: '80%'` style. This ensures the component is fully responsive and adapts correctly to all mobile viewport sizes.