### PR TITLE
revert(style): Restore maxWidth to CampaignCoverFlow slides

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-DSwZbmdV.js"></script>
+  <script type="module" crossorigin src="/assets/index-CfUo_JyX.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -39,7 +39,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '80%' }}>
+          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '320px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This reverts the change that removed `maxWidth` from the `SwiperSlide` component in `CampaignCoverFlow.jsx`.

The removal of `maxWidth: '320px'` was a misstep that broke the intended visual design of the cover flow, making the slides too large on desktop and tablet screens. This property is crucial for achieving the effect of a central slide being flanked by others.

The primary responsiveness issues were already solved by removing the restrictive `<Container>` components in the parent layout. Restoring this style corrects the visual regression while maintaining the overall responsiveness of the page.