### PR TITLE
refactor(responsive): Implement breakpoints for CampaignCoverFlow

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-CfUo_JyX.js"></script>
+  <script type="module" crossorigin src="/assets/index-BpYMRZcW.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -19,17 +19,11 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         effect={'coverflow'}
         grabCursor={true}
         centeredSlides={true}
-        slidesPerView={'auto'}
         initialSlide={initialSlide}
-        coverflowEffect={{
-          rotate: 50,
-          stretch: 0,
-          depth: 100,
-          modifier: 1,
-          slideShadows: true,
-        }}
-        pagination={{ clickable: true }}
+        slidesPerView={1}
+        spaceBetween={10}
         navigation={true}
+        pagination={{ clickable: true }}
         modules={[EffectCoverflow, Pagination, Navigation]}
         onSlideChange={(swiper) => onSlideChange(swiper.realIndex)}
         className="mySwiper"
@@ -37,9 +31,22 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-navigation-color': '#fff',
           '--swiper-pagination-color': '#fff',
         }}
+        coverflowEffect={{
+          rotate: 50,
+          stretch: 0,
+          depth: 100,
+          modifier: 1,
+          slideShadows: true,
+        }}
+        breakpoints={{
+          768: {
+            slidesPerView: 'auto',
+            spaceBetween: 0,
+          },
+        }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '320px' }}>
+          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '280px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This commit introduces a robust responsive solution for the Swiper component in `CampaignCoverFlow.jsx` by using the library's built-in `breakpoints` feature.

The previous approach of using a single `maxWidth` for all screen sizes caused layout issues, either breaking the cover flow effect on desktop or causing overflow on mobile.

This new implementation defines two distinct layouts:
1.  **Mobile (screens < 768px):** Displays a single, centered slide (`slidesPerView: 1`) to ensure a clean, overflow-free experience.
2.  **Desktop (screens >= 768px):** Uses `slidesPerView: 'auto'` to restore the intended cover flow effect with multiple visible slides.

Additionally, the slide's `maxWidth` has been adjusted to `280px` as requested. This approach provides an optimal viewing experience on all devices.