### PR TITLE
style(Coverflow): Adjust effect for a more compact layout

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-BpYMRZcW.js"></script>
+  <script type="module" crossorigin src="/assets/index-C9CVmgUa.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -32,8 +32,8 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-pagination-color': '#fff',
         }}
         coverflowEffect={{
-          rotate: 50,
-          stretch: 0,
+          rotate: 60,
+          stretch: -40,
           depth: 100,
           modifier: 1,
           slideShadows: true,


### PR DESCRIPTION
This commit fine-tunes the `coverflowEffect` properties in the `CampaignCoverFlow.jsx` component to address user feedback about the visual presentation on smaller screens.

The previous effect was too 'flat', causing the side slides to occupy too much horizontal space. This change:
- Increases the `rotate` value from 50 to 60, making the side slides more angled.
- Sets the `stretch` value to -40, which creates an overlap between slides.

Together, these adjustments create a more three-dimensional and compact carousel that better utilizes screen real estate, especially on tablet-sized devices, as per the user's request.