### PR TITLE
style(Coverflow): Replicate effect from user-provided reference

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
 
   <title>Midiator</title>
-  <script type="module" crossorigin src="/assets/index-U_HGxxcr.js"></script>
+  <script type="module" crossorigin src="/assets/index-Cy8gPgu8.js"></script>
   <link rel="stylesheet" crossorigin href="/assets/index-DUgQFaMz.css">
 </head>
 

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -32,7 +32,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
         coverflowEffect={{
           rotate: 50,
-          stretch: 0,
+          stretch: -20,
           depth: 100,
           modifier: 1,
           slideShadows: true,


### PR DESCRIPTION
This commit adjusts the `coverflowEffect` properties in `CampaignCoverFlow.jsx` to closely match the visual style of a CodePen example provided by the user.

The key change is setting `stretch: -20`. This creates a negative space between slides, causing them to overlap and creating a more compact and pronounced 3D effect. The previous value of `0` resulted in a 'flatter' appearance that occupied too much horizontal space on smaller screens.

This change directly implements the user's feedback and is designed to achieve the specific visual of angled, tucked-in side slides.