### PR TITLE
feat: Adjust campaign cover flow for responsive layout

### DIFF
--- a/preview_output.log
+++ b/preview_output.log
@@ -1,9 +1,0 @@
-
-> midiator-google-drive-frontend@0.0.0 dev /app
-> vite
-
-
-  VITE v5.4.20  ready in 1364 ms
-
-  ➜  Local:   http://localhost:5173/
-  ➜  Network: use --host to expose

--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -16,6 +16,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
     <Box sx={{ py: 4 }}>
       <Swiper
         onSwiper={onSwiper}
+        effect={'coverflow'}
         grabCursor={true}
         centeredSlides={true}
         initialSlide={initialSlide}
@@ -29,18 +30,23 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-pagination-color': '#fff',
         }}
         breakpoints={{
+          // For mobile
           0: {
-            effect: 'slide',
-            slidesPerView: 1,
-            spaceBetween: 10,
+            slidesPerView: 3,
+            coverflowEffect: {
+              rotate: 25,
+              stretch: -20,
+              depth: 100,
+              modifier: 1,
+              slideShadows: true,
+            },
           },
+          // For tablet and desktop
           768: {
-            effect: 'coverflow',
-            slidesPerView: 'auto',
-            spaceBetween: 0,
+            slidesPerView: 3,
             coverflowEffect: {
               rotate: 50,
-              stretch: -20,
+              stretch: 0,
               depth: 100,
               modifier: 1,
               slideShadows: true,
@@ -49,7 +55,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '280px' }}>
+          <SwiperSlide key={campaign.id}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
Adjusts the Swiper.js configuration in the `CampaignCoverFlow` component to create a responsive cover flow effect for the 'Minhas Campanhas' section.

This change addresses the user's request to have a more compact layout on small screens by displaying three slides at once (one central, two on the sides).

- The `breakpoints` property is used to define different `coverflowEffect` parameters for mobile and desktop viewports.
- `slidesPerView` is set to 3 for all screen sizes to meet the user's requirement.
- The effect parameters (`rotate`, `stretch`) are adjusted to be less pronounced on smaller screens, preventing visual overflow and creating a cleaner look.