### PR TITLE
feat: Adjust campaign cover flow for responsive layout

### DIFF
--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -12,13 +12,15 @@ import 'swiper/css/navigation';
 import { Box } from '@mui/material';
 
 const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlideChange, initialSlide, onSwiper }) => {
+  // The coverflow effect with slidesPerView=3 requires at least 3 slides to work correctly.
+  // This flag determines which Swiper configuration to use.
+  const hasEnoughCampaignsForCoverflow = campaigns.length >= 3;
+
   return (
     <Box sx={{ py: 4 }}>
       <Swiper
         onSwiper={onSwiper}
-        effect={'coverflow'}
         grabCursor={true}
-        centeredSlides={true}
         initialSlide={initialSlide}
         navigation={true}
         pagination={{ clickable: true }}
@@ -29,33 +31,35 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-navigation-color': '#fff',
           '--swiper-pagination-color': '#fff',
         }}
-        breakpoints={{
-          // For mobile
-          0: {
-            slidesPerView: 3,
-            coverflowEffect: {
-              rotate: 25,
-              stretch: -20,
-              depth: 100,
-              modifier: 1,
-              slideShadows: true,
-            },
-          },
-          // For tablet and desktop
-          768: {
-            slidesPerView: 3,
-            coverflowEffect: {
-              rotate: 50,
-              stretch: 0,
-              depth: 100,
-              modifier: 1,
-              slideShadows: true,
-            },
-          },
-        }}
+        // Conditionally apply props based on the number of campaigns
+        {...(hasEnoughCampaignsForCoverflow
+          ? { // --- Coverflow Configuration (for >= 3 campaigns) ---
+              effect: 'coverflow',
+              centeredSlides: true,
+              breakpoints: {
+                // For mobile
+                0: {
+                  slidesPerView: 3,
+                  coverflowEffect: { rotate: 25, stretch: -20, depth: 100, modifier: 1, slideShadows: true },
+                },
+                // For tablet and desktop
+                768: {
+                  slidesPerView: 3,
+                  coverflowEffect: { rotate: 50, stretch: 0, depth: 100, modifier: 1, slideShadows: true },
+                },
+              },
+            }
+          : { // --- Simple Slider Configuration (for < 3 campaigns) ---
+              effect: 'slide',
+              slidesPerView: 1,
+              centeredSlides: true, // Center the single slide(s)
+              spaceBetween: 10,
+            }
+        )}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id}>
+          // When not in coverflow mode, we must constrain the slide width manually.
+          <SwiperSlide key={campaign.id} style={!hasEnoughCampaignsForCoverflow ? { width: '80%', maxWidth: '280px' } : {}}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
Adjusts the Swiper.js configuration in the `CampaignCoverFlow` component to create a responsive cover flow effect for the 'Minhas Campanhas' section.

This change addresses the user's request to have a more compact layout on small screens by displaying three slides at once (one central, two on the sides).

- The `breakpoints` property is used to define different `coverflowEffect` parameters for mobile and desktop viewports.
- `slidesPerView` is set to 3 for all screen sizes to meet the user's requirement.
- The effect parameters (`rotate`, `stretch`) are adjusted to be less pronounced on smaller screens, preventing visual overflow and creating a cleaner look.

Fixes a bug where the component would crash if there were fewer than three campaigns to display. The component now conditionally renders a simpler slider in this scenario.