### PR TITLE
fix: Stabilize campaign cover flow rendering

### DIFF
--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -12,53 +12,56 @@ import 'swiper/css/navigation';
 import { Box } from '@mui/material';
 
 const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlideChange, initialSlide, onSwiper }) => {
-  // The coverflow effect with slidesPerView=3 requires at least 3 slides to work correctly.
-  // This flag determines which Swiper configuration to use.
   const hasEnoughCampaignsForCoverflow = campaigns.length >= 3;
+
+  const swiperParams = {
+    onSwiper,
+    grabCursor: true,
+    initialSlide,
+    navigation: true,
+    pagination: { clickable: true },
+    modules: [EffectCoverflow, Pagination, Navigation],
+    onSlideChange: (swiper) => onSlideChange(swiper.realIndex),
+    className: "mySwiper",
+    style: {
+      '--swiper-navigation-color': '#fff',
+      '--swiper-pagination-color': '#fff',
+    },
+  };
+
+  if (hasEnoughCampaignsForCoverflow) {
+    swiperParams.effect = 'coverflow';
+    swiperParams.centeredSlides = true;
+    swiperParams.slidesPerView = 3;
+    swiperParams.coverflowEffect = {
+      rotate: 25,
+      stretch: -20,
+      depth: 100,
+      modifier: 1,
+      slideShadows: true,
+    };
+    swiperParams.breakpoints = {
+      768: {
+        coverflowEffect: {
+          rotate: 50,
+          stretch: 0,
+          depth: 100,
+          modifier: 1,
+          slideShadows: true,
+        },
+      },
+    };
+  } else {
+    swiperParams.effect = 'slide';
+    swiperParams.slidesPerView = 1;
+    swiperParams.centeredSlides = true;
+    swiperParams.spaceBetween = 10;
+  }
 
   return (
     <Box sx={{ py: 4 }}>
-      <Swiper
-        onSwiper={onSwiper}
-        grabCursor={true}
-        initialSlide={initialSlide}
-        navigation={true}
-        pagination={{ clickable: true }}
-        modules={[EffectCoverflow, Pagination, Navigation]}
-        onSlideChange={(swiper) => onSlideChange(swiper.realIndex)}
-        className="mySwiper"
-        style={{
-          '--swiper-navigation-color': '#fff',
-          '--swiper-pagination-color': '#fff',
-        }}
-        // Conditionally apply props based on the number of campaigns
-        {...(hasEnoughCampaignsForCoverflow
-          ? { // --- Coverflow Configuration (for >= 3 campaigns) ---
-              effect: 'coverflow',
-              centeredSlides: true,
-              breakpoints: {
-                // For mobile
-                0: {
-                  slidesPerView: 3,
-                  coverflowEffect: { rotate: 25, stretch: -20, depth: 100, modifier: 1, slideShadows: true },
-                },
-                // For tablet and desktop
-                768: {
-                  slidesPerView: 3,
-                  coverflowEffect: { rotate: 50, stretch: 0, depth: 100, modifier: 1, slideShadows: true },
-                },
-              },
-            }
-          : { // --- Simple Slider Configuration (for < 3 campaigns) ---
-              effect: 'slide',
-              slidesPerView: 1,
-              centeredSlides: true, // Center the single slide(s)
-              spaceBetween: 10,
-            }
-        )}
-      >
+      <Swiper {...swiperParams}>
         {campaigns.map((campaign) => (
-          // When not in coverflow mode, we must constrain the slide width manually.
           <SwiperSlide key={campaign.id} style={!hasEnoughCampaignsForCoverflow ? { width: '80%', maxWidth: '280px' } : {}}>
             {({ isActive }) => (
               <CampaignCard


### PR DESCRIPTION
This commit refactors the Swiper.js configuration in the `CampaignCoverFlow` component to prevent a rendering issue where the component would "flash" and then disappear.

The root cause was an unstable configuration within the `breakpoints` property. The fix simplifies the implementation by setting a consistent `slidesPerView` at the top level and using `breakpoints` only to adjust the visual intensity of the cover flow effect for different screen sizes. This ensures a more stable layout calculation during re-renders.

This change also preserves the logic to handle cases with fewer than three campaigns, ensuring the component remains robust.