### PR TITLE
fix: Stabilize campaign cover flow rendering

### DIFF
--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -12,57 +12,46 @@ import 'swiper/css/navigation';
 import { Box } from '@mui/material';
 
 const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlideChange, initialSlide, onSwiper }) => {
-  const hasEnoughCampaignsForCoverflow = campaigns.length >= 3;
-
-  const swiperParams = {
-    onSwiper,
-    grabCursor: true,
-    initialSlide,
-    navigation: true,
-    pagination: { clickable: true },
-    modules: [EffectCoverflow, Pagination, Navigation],
-    onSlideChange: (swiper) => onSlideChange(swiper.realIndex),
-    className: "mySwiper",
-    style: {
-      '--swiper-navigation-color': '#fff',
-      '--swiper-pagination-color': '#fff',
-    },
-  };
-
-  if (hasEnoughCampaignsForCoverflow) {
-    swiperParams.effect = 'coverflow';
-    swiperParams.centeredSlides = true;
-    swiperParams.slidesPerView = 3;
-    swiperParams.coverflowEffect = {
-      rotate: 25,
-      stretch: -20,
-      depth: 100,
-      modifier: 1,
-      slideShadows: true,
-    };
-    swiperParams.breakpoints = {
-      768: {
-        coverflowEffect: {
-          rotate: 50,
-          stretch: 0,
+  return (
+    <Box sx={{ py: 4 }}>
+      <Swiper
+        onSwiper={onSwiper}
+        effect={'coverflow'}
+        grabCursor={true}
+        centeredSlides={true}
+        slidesPerView={'auto'} // Use 'auto' for coverflow with variable slide widths
+        initialSlide={initialSlide}
+        navigation={true}
+        pagination={{ clickable: true }}
+        modules={[EffectCoverflow, Pagination, Navigation]}
+        onSlideChange={(swiper) => onSlideChange(swiper.realIndex)}
+        className="mySwiper"
+        style={{
+          '--swiper-navigation-color': '#fff',
+          '--swiper-pagination-color': '#fff',
+        }}
+        // Base coverflow effect for mobile, less pronounced
+        coverflowEffect={{
+          rotate: 30,
+          stretch: -10,
           depth: 100,
           modifier: 1,
           slideShadows: true,
-        },
-      },
-    };
-  } else {
-    swiperParams.effect = 'slide';
-    swiperParams.slidesPerView = 1;
-    swiperParams.centeredSlides = true;
-    swiperParams.spaceBetween = 10;
-  }
-
-  return (
-    <Box sx={{ py: 4 }}>
-      <Swiper {...swiperParams}>
+        }}
+        breakpoints={{
+          // More pronounced effect for desktop
+          768: {
+            coverflowEffect: {
+              rotate: 50,
+              stretch: 0,
+            },
+          },
+        }}
+      >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id} style={!hasEnoughCampaignsForCoverflow ? { width: '80%', maxWidth: '280px' } : {}}>
+          // Define a width on the slides so 'auto' works correctly.
+          // This configuration ensures roughly 3 slides are visible.
+          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '280px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This commit refactors the Swiper.js configuration in the `CampaignCoverFlow` component to prevent a rendering issue where the component would "flash" and then disappear.

The root cause was an unstable configuration that caused an internal layout calculation error, resulting in extremely large slide widths and positions.

This fix addresses the issue by:
- Setting `slidesPerView` to `'auto'`.
- Applying a `maxWidth` to the `SwiperSlide` components.
- Using `breakpoints` only to adjust the visual intensity of the cover flow effect.

This ensures a more stable layout calculation during re-renders while preserving the intended responsive behavior.