### PR TITLE
fix: Implement responsive campaign carousel with correct breakpoints

### DIFF
--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -16,10 +16,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
     <Box sx={{ py: 4 }}>
       <Swiper
         onSwiper={onSwiper}
-        effect={'coverflow'}
         grabCursor={true}
-        centeredSlides={true}
-        slidesPerView={'auto'} // Use 'auto' for coverflow with variable slide widths
         initialSlide={initialSlide}
         navigation={true}
         pagination={{ clickable: true }}
@@ -30,28 +27,30 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-navigation-color': '#fff',
           '--swiper-pagination-color': '#fff',
         }}
-        // Base coverflow effect for mobile, less pronounced
-        coverflowEffect={{
-          rotate: 30,
-          stretch: -10,
-          depth: 100,
-          modifier: 1,
-          slideShadows: true,
-        }}
+        // Default to mobile-first: 1 slide, simple slide effect
+        effect={'slide'}
+        slidesPerView={1}
+        centeredSlides={true}
+        spaceBetween={20}
+
         breakpoints={{
-          // More pronounced effect for desktop
+          // At 768px and up, switch to coverflow with 3 slides
           768: {
+            effect: 'coverflow',
+            slidesPerView: 3,
+            centeredSlides: true,
             coverflowEffect: {
               rotate: 50,
               stretch: 0,
+              depth: 100,
+              modifier: 1,
+              slideShadows: true,
             },
           },
         }}
       >
         {campaigns.map((campaign) => (
-          // Define a width on the slides so 'auto' works correctly.
-          // This configuration ensures roughly 3 slides are visible.
-          <SwiperSlide key={campaign.id} style={{ width: '80%', maxWidth: '280px' }}>
+          <SwiperSlide key={campaign.id}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This commit implements the final fix for the campaign carousel, addressing all previous issues, including the "flashing" bug and horizontal scroll.

Based on user feedback, the component now provides two distinct experiences:
- **Mobile (default):** A simple, single-slide carousel (`effect: 'slide'`, `slidesPerView: 1`) for a clean and user-friendly view on small screens.
- **Desktop (768px and up):** A 3-card cover flow effect (`effect: 'coverflow'`, `slidesPerView: 3`) for a richer experience on larger screens.

This is achieved by correctly using the Swiper.js `breakpoints` API. The inline styles on `SwiperSlide` have been removed to allow the Swiper instance to correctly manage the layout, which was the root cause of the previous rendering bugs.