### PR TITLE
fix: Correctly implement responsive Swiper configuration

### DIFF
--- a/src/components/CampaignCoverFlow.jsx
+++ b/src/components/CampaignCoverFlow.jsx
@@ -27,18 +27,21 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
           '--swiper-navigation-color': '#fff',
           '--swiper-pagination-color': '#fff',
         }}
-        // Default to mobile-first: 1 slide, simple slide effect
-        effect={'slide'}
-        slidesPerView={1}
+        effect="coverflow"
         centeredSlides={true}
+        slidesPerView={1} // Default mobile: 1 card
         spaceBetween={20}
-
+        coverflowEffect={{
+          rotate: 0,
+          stretch: 0,
+          depth: 0,
+          modifier: 0,
+          slideShadows: false, // No effect on mobile
+        }}
         breakpoints={{
-          // At 768px and up, switch to coverflow with 3 slides
           768: {
-            effect: 'coverflow',
-            slidesPerView: 3,
-            centeredSlides: true,
+            slidesPerView: 3, // Desktop: 3 cards
+            spaceBetween: 40,
             coverflowEffect: {
               rotate: 50,
               stretch: 0,
@@ -50,7 +53,7 @@ const CampaignCoverFlow = ({ campaigns, onEditCampaign, onDeleteCampaign, onSlid
         }}
       >
         {campaigns.map((campaign) => (
-          <SwiperSlide key={campaign.id}>
+          <SwiperSlide key={campaign.id} style={{ maxWidth: '320px' }}>
             {({ isActive }) => (
               <CampaignCard
                 campaign={campaign}


### PR DESCRIPTION
This commit applies the definitive fix for the campaign carousel, addressing the rendering bug that caused the component to crash or disappear.

The root cause of the issue was an incorrect attempt to change the Swiper `effect` property within the `breakpoints` configuration, which is not supported by the library and leads to layout calculation errors.

The correct implementation, guided by user feedback, is as follows:
- The `effect` is now consistently set to `'coverflow'` at the top level of the Swiper component.
- For mobile viewports (the default), the `coverflowEffect` parameters are all set to 0, effectively disabling the 3D effect and making it behave like a simple slider.
- For desktop viewports (768px and up), the `breakpoints` are used to apply the intended 3D cover flow effect with `slidesPerView: 3`.

This ensures a stable and robust implementation that provides the desired responsive experience without causing rendering issues.