### PR TITLE
Fix: Select new image from gallery in PageEditor

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -103,16 +103,34 @@ const PageEditor = ({
   const [editingField, setEditingField] = useState(null);
   const [imageSwatches, setImageSwatches] = useState([]);
   const isMobile = useIsMobile();
+  const prevImagesRef = useRef();
 
   useEffect(() => {
+    // Sincronizar paleta de cores da imagem
     const firstImage = editedPageTemplate?.images?.[0];
     if (firstImage?.src) {
       extractColorPalette(firstImage.src, setImageSwatches);
     } else {
-      // Fallback to the campaign palette if no image in the editor
       setImageSwatches(colorPalette || []);
     }
-  }, [editedPageTemplate?.images?.[0]?.src, colorPalette]);
+
+    // Lógica para detectar e selecionar a nova imagem
+    const currentImages = editedPageTemplate?.images || [];
+    const previousImages = prevImagesRef.current || [];
+
+    if (currentImages.length > previousImages.length) {
+      const newImage = currentImages.find(
+        (img) => !previousImages.some((prevImg) => prevImg.id === img.id)
+      );
+      if (newImage) {
+        handleInternalFieldSelection(newImage.id);
+      }
+    }
+
+    // Atualizar a referência para o próximo render
+    prevImagesRef.current = currentImages;
+  }, [editedPageTemplate?.images, colorPalette, handleInternalFieldSelection]);
+
 
   const handleOpenHtmlEditor = (fieldId) => {
     setEditingField(fieldId);


### PR DESCRIPTION
When adding an image from the gallery to a generated page, the image was correctly added to the page's data model but was not being set as the selected element within the `PageEditor`. This forced the user to manually click the new image to edit it.

This was caused by the `PageEditor` component initializing its state from props only when it was first opened. It did not react to subsequent prop changes, such as when the gallery component updated the underlying page template.

This commit adds a `useEffect` hook to `PageEditor.jsx`. The hook uses a `useRef` to keep track of the previous state of the `images` array in the `editedPageTemplate` prop. It compares the previous and current arrays on each render. If a new image is found, its ID is passed to the `handleInternalFieldSelection` function, making it the active element in the editor.