### PR TITLE
Fix: Select new image from gallery in PageEditor

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Dialog,
   DialogTitle,


### PR DESCRIPTION
When adding an image from the gallery to a generated page, the image was correctly added to the page's data model but was not being set as the selected element within the `PageEditor`. This forced the user to manually click the new image to edit it.

This was caused by the `PageEditor` component initializing its state from props only when it was first opened. It did not react to subsequent prop changes, such as when the gallery component updated the underlying page template.

This commit adds a `useEffect` hook to `PageEditor.jsx`. The hook uses a `useRef` to keep track of the previous state of the `images` array in the `editedPageTemplate` prop. It compares the previous and current arrays on each render. If a new image is found, its ID is passed to the `handleInternalFieldSelection` function, making it the active element in the editor.

This commit also fixes a follow-up bug where `useRef` was used without being imported from React.