### PR TITLE
Fix: Correct initialization order in PageEditor

### DIFF
--- a/src/components/PageEditor.jsx
+++ b/src/components/PageEditor.jsx
@@ -105,6 +105,10 @@ const PageEditor = ({
   const isMobile = useIsMobile();
   const prevImagesRef = useRef();
 
+  const handleInternalFieldSelection = useCallback((fieldToSelect) => {
+    setSelectedFieldInternal(fieldToSelect);
+  }, []);
+
   useEffect(() => {
     // Sincronizar paleta de cores da imagem
     const firstImage = editedPageTemplate?.images?.[0];
@@ -148,10 +152,6 @@ const PageEditor = ({
       setEditedPageTemplate
     );
   };
-
-  const handleInternalFieldSelection = useCallback((fieldToSelect) => {
-    setSelectedFieldInternal(fieldToSelect);
-  }, []);
 
   const handleLocalImageUpload = (event) => {
     const file = event.target.files[0];


### PR DESCRIPTION
This commit resolves a `ReferenceError: Cannot access 'L' before initialization` that occurred in the `PageEditor` component.

The error was caused by a `useEffect` hook that depended on the `handleInternalFieldSelection` function. The function was declared after the hook, creating a temporal dead zone issue in the JavaScript execution order.

The fix reorders the code to ensure `handleInternalFieldSelection` is declared and initialized before the `useEffect` hook is defined.

This change is the last in a series of fixes to address the original bug: making images added from the gallery automatically selected in the `PageEditor`. The previous fixes included adding the state synchronization logic and importing the `useRef` hook.