### PR TITLE
fix: Correct race condition and state handling for image assets

### DIFF
--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -1,15 +1,5 @@
 import React, { createContext, useContext, useState, useMemo, useCallback, useEffect, useRef } from 'react';
 
-// A simple debounce utility
-function debounce(func, wait) {
-  let timeout;
-  return function(...args) {
-    const context = this;
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func.apply(context, args), wait);
-  };
-}
-
 const defaultPageTemplate = {
     backgroundColor: '#FFFFFF',
     gradient: null,
@@ -53,81 +43,54 @@ export const CampaignProvider = ({ children }) => {
   const [customPalette, setCustomPalette] = useState(null);
   const [imageColorPalette, setImageColorPalette] = useState([]);
 
-  // Asset queue for debounced updates
-  const assetQueue = useRef({});
-
-  // Debounced function to flush the asset queue into the main state
-  const flushAssetQueue = useCallback(() => {
-    if (Object.keys(assetQueue.current).length > 0) {
-      console.log('[CampaignContext] Debounced update. Flushing asset queue...', assetQueue.current);
-      setPendingAssets(prev => ({ ...prev, ...assetQueue.current }));
-      assetQueue.current = {}; // Clear the queue after flushing
-    }
-  }, []);
-
-  // Create a memoized debounced version of the flush function
-  const debouncedFlush = useMemo(() => debounce(flushAssetQueue, 300), [flushAssetQueue]);
-
+  // Fingerprint cache to prevent duplicate asset additions.
+  const assetFingerprintCache = useRef(new Map());
 
   // Centralized asset handlers
-    /**
-   * @description Creates a `blob:` URL for a given Blob and adds it to a queue for batch processing.
-   * The queue is flushed automatically after a short delay to prevent race conditions and improve performance.
-   * This function no longer requires an `isSaving` flag.
-   *
-   * ---
-   * **Blob Lifecycle:**
-   * 1. **Creation:** A `blob:` URL is created using `URL.createObjectURL(blob)`.
-   * 2. **Queueing:** The URL and Blob are added to a temporary queue (`assetQueue`).
-   * 3. **Batch Update:** A debounced function (`debouncedFlush`) merges the queue into the main
-   *    `pendingAssets` state after a 300ms delay.
-   * 4. **Serialization:** During a campaign save, `serializeCampaignData` uses the stable `pendingAssets` state.
-   * 5. **Revocation:** The `blob:` URL **must** be revoked using `URL.revokeObjectURL(url)`. This is handled
-   *    by `removePendingAsset` or the component's unmount effect.
-   * ---
-   *
-   * @param {Blob} blob The Blob object to add.
-   * @returns {string|null} The generated `blob:` URL, or null if the input was invalid.
-   */
   const addPendingAsset = useCallback((blob) => {
     if (!(blob instanceof Blob)) {
       console.error("[addPendingAsset] Invalid argument. Expected a Blob.", blob);
       return null;
     }
+
+    // Create a fingerprint to prevent duplicates.
+    // The File object has a name, but a generic Blob might not.
+    const fingerprint = `${blob.name || ''}-${blob.size}-${blob.type}`;
+    if (assetFingerprintCache.current.has(fingerprint)) {
+      const existingUrl = assetFingerprintCache.current.get(fingerprint);
+      return existingUrl;
+    }
+
     const blobUrl = URL.createObjectURL(blob);
-    assetQueue.current[blobUrl] = blob;
-    debouncedFlush();
+    setPendingAssets(prev => ({
+      ...prev,
+      [blobUrl]: blob,
+    }));
+    assetFingerprintCache.current.set(fingerprint, blobUrl);
     return blobUrl;
-  }, [debouncedFlush]);
+  }, []);
 
-    /**
-   * @description Adds a map of pre-existing `blob:` URLs and their Blobs to the asset queue.
-   * This is a batch version of `addPendingAsset` for efficiency.
-   * @param {Object<string, Blob>} assetMap A map of `blob:` URLs to Blob objects.
-   */
   const addPendingAssetMap = useCallback((assetMap) => {
-    assetQueue.current = { ...assetQueue.current, ...assetMap };
-    debouncedFlush();
-  }, [debouncedFlush]);
+    setPendingAssets(prev => ({ ...prev, ...assetMap }));
+    Object.entries(assetMap).forEach(([url, blob]) => {
+      const fingerprint = `${blob.name || ''}-${blob.size}-${blob.type}`;
+      if (!assetFingerprintCache.current.has(fingerprint)) {
+        assetFingerprintCache.current.set(fingerprint, url);
+      }
+    });
+  }, []);
 
-    /**
-   * @description Removes a pending asset from the state and revokes its associated `blob:` URL
-   * to free up memory. This is the primary method for manually cleaning up a temporary asset.
-   * @param {string} blobUrl The `blob:` URL of the asset to remove.
-   */
   const removePendingAsset = useCallback((blobUrl) => {
     if (typeof blobUrl !== 'string' || !blobUrl.startsWith('blob:')) {
-      console.error("[removePendingAsset] Invalid argument. Expected a blob URL string.", blobUrl);
       return;
-    }
-    // Also remove from the queue in case it hasn't been flushed yet
-    if (assetQueue.current[blobUrl]) {
-        delete assetQueue.current[blobUrl];
     }
 
     setPendingAssets(prev => {
       const newAssets = { ...prev };
       if (newAssets[blobUrl]) {
+        const blob = newAssets[blobUrl];
+        const fingerprint = `${blob.name || ''}-${blob.size}-${blob.type}`;
+        assetFingerprintCache.current.delete(fingerprint);
         URL.revokeObjectURL(blobUrl);
         delete newAssets[blobUrl];
       }
@@ -136,23 +99,12 @@ export const CampaignProvider = ({ children }) => {
   }, []);
 
   // Effect to clean up all blob URLs on unmount
-    /**
-   * @description A safety-net effect that runs when the CampaignProvider is unmounted.
-   * It iterates through any remaining assets in `pendingAssets` and revokes their URLs,
-   * preventing memory leaks if the component is unexpectedly destroyed.
-   */
   useEffect(() => {
     return () => {
-      // Clean up assets in the main state
       Object.keys(pendingAssets).forEach(url => {
-        console.log(`[CampaignContext] Revoking blob URL on unmount: ${url}`);
         URL.revokeObjectURL(url);
       });
-      // Clean up any assets still in the queue
-      Object.keys(assetQueue.current).forEach(url => {
-          console.log(`[CampaignContext] Revoking queued blob URL on unmount: ${url}`);
-          URL.revokeObjectURL(url);
-      });
+      assetFingerprintCache.current.clear();
     };
   }, [pendingAssets]);
 


### PR DESCRIPTION
This commit resolves a critical and persistent bug where adding a new image to a page would cause all images to break upon saving the page. The issue was traced to two interacting problems: a race condition in the asset management state and a state corruption bug in the page editor.

The fixes are as follows:

1.  **Eliminated Race Condition in `CampaignContext.jsx`**: The `addPendingAsset` function previously used a 300ms debounce before updating the `pendingAssets` state. This created a race condition where the page rendering could be triggered before the new asset was available in the state, causing the image to fail. The debounce has been removed, and state updates are now synchronous, ensuring the asset list is always up-to-date. A fingerprinting mechanism was also added to prevent duplicate assets from being queued.

2.  **Corrected State Merging in `PageGeneratorFrontendOnly.jsx`**: The logic for loading a page into the editor was incorrectly merging the page's custom template with the global campaign template. This could overwrite the page's specific `images` array. The logic has been corrected to use the page's `customPageTemplate` as the sole source of truth if it exists, preventing this data corruption.

These changes ensure that temporary image assets are handled correctly and reliably throughout their lifecycle, from the moment they are added to when they are rendered in a preview. This resolves the bug for all image sources (Gallery, OS upload, etc.) and restores the application's core functionality.