### PR TITLE
fix: Correctly render in-memory images in editor preview

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -35,6 +35,7 @@ const DraggableElementInternal = ({
   enableHtmlRendering = false,
   darkMode,
   onDoubleClick,
+  pendingAssets,
 }) => {
   console.log('[DraggableElement] PROPS RECEIVED:', { element, content });
   const [isDragging, setIsDragging] = useState(false);
@@ -47,6 +48,28 @@ const DraggableElementInternal = ({
   const [initialPosition, setInitialPosition] = useState({ x: 0, y: 0 });
   const [initialSize, setInitialSize] = useState({ width: 0, height: 0 });
   const [initialRotation, setInitialRotation] = useState(0);
+  const [imageUrl, setImageUrl] = useState(content);
+
+  useEffect(() => {
+    let objectUrl = null;
+    if (content && typeof content === 'string' && content.startsWith('blob:') && pendingAssets) {
+      const blob = pendingAssets[content];
+      if (blob) {
+        objectUrl = URL.createObjectURL(blob);
+        setImageUrl(objectUrl);
+      } else {
+        setImageUrl(content); // Fallback to broken link if blob not found
+      }
+    } else {
+      setImageUrl(content);
+    }
+
+    return () => {
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [content, pendingAssets]);
   // const [isCanvasLoading, setIsCanvasLoading] = useState(true); // Removido
 
   const textBoxRef = useRef(null);
@@ -85,7 +108,7 @@ const DraggableElementInternal = ({
       return null;
     }
     if (element.type === 'image') {
-      return <img src={content} alt="Elemento de imagem" style={{ objectFit: style.objectFit || 'fill' }} />;
+      return <img src={imageUrl} alt="Elemento de imagem" style={{ objectFit: style.objectFit || 'fill' }} />;
     }
 
     if (element.type === 'cropbox') {

--- a/src/components/FieldPositioner.jsx
+++ b/src/components/FieldPositioner.jsx
@@ -75,6 +75,7 @@ const FieldPositioner = ({
   onFontScaleChange,
   isCropping,
   setIsCropping,
+  pendingAssets,
 }) => {
   console.log('[FieldPositioner] props:', { pageTemplate, fieldStyles });
   const [renderedImageMetrics, setRenderedImageMetrics] = useState({ width: 0, height: 0, x: 0, y: 0 });
@@ -447,6 +448,7 @@ const FieldPositioner = ({
             fontScale={element.fontScale}
             enableHtmlRendering={element.enableHtmlRendering}
             darkMode={darkMode}
+            pendingAssets={pendingAssets}
           />
         ))}
       </Box>


### PR DESCRIPTION
This commit resolves a bug where newly added images from the gallery or local files would appear broken in the page editor preview.

The `pendingAssets` map, containing in-memory image data for `blob:` URLs, was not being passed down the full component tree. This meant the final rendering component, `DraggableElement`, could not resolve the blob URLs.

The fix ensures the `pendingAssets` prop is passed through `PageEditor` and `FieldPositioner` to `DraggableElement`.

`DraggableElement` is updated with a `useEffect` hook to create a temporary object URL from the blob data when a `blob:` URL is received. This allows the image to be rendered correctly in the editor preview. The object URL is revoked on cleanup to prevent memory leaks.

Also fixes a signature mismatch in the `onOpenImageGallery` callback to prevent runtime errors.