### PR TITLE
fix: Correct asset rendering and template immutability

### DIFF
--- a/src/utils/imageComposer.js
+++ b/src/utils/imageComposer.js
@@ -145,8 +145,6 @@ const loadImage = (src, pendingAssets = {}) => {
         // If the blob URL is not in pendingAssets, it's a broken link.
         return reject(new Error(`Blob not found for pending asset URL: ${src}`));
       }
-    } else if (src && src.includes('blob.vercel-storage.com')) {
-      finalSrc = `/api/image-proxy?url=${encodeURIComponent(src)}`;
     } else if (src && src.startsWith('http')) {
       img.crossOrigin = 'Anonymous';
     }


### PR DESCRIPTION
This commit resolves a cascade of bugs related to asset rendering and state management.

The primary issue was that new images added from the gallery or local files would appear broken in the editor preview. This was caused by an incomplete data pipeline for in-memory `blob:` URLs. The fix ensures the `pendingAssets` map is passed down the entire component tree to all rendering contexts and that the rendering logic in `FieldPositioner.jsx` correctly resolves these blobs into temporary object URLs.

A secondary, related bug caused existing page thumbnails to break when the main template was modified. This violated the principle that generated pages should be immutable snapshots. The fix introduces a `baseTemplate` property, which is a "frozen" copy of the template at the time of page generation. The rendering logic is updated to prioritize templates in the correct order: `customPageTemplate` > `baseTemplate` > global `pageTemplate`. The reset function is also updated to clear all template variations.

Finally, this commit removes incorrect logic from `imageComposer.js` that was attempting to proxy production Vercel Blob Storage URLs, which caused rendering failures after saving a page.