### PR TITLE
Fix: Correct image asset rendering pipeline and resolve regression

### DIFF
--- a/src/components/DraggableElement.jsx
+++ b/src/components/DraggableElement.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import styles from './DraggableElement.module.css';
 import { wrapTextInArea } from '../utils/imageComposer';
 import { applyColorHighlight } from '../utils/filterUtils';


### PR DESCRIPTION
This commit resolves a critical bug where images on generated pages would break after adding a new image from the gallery and saving. It also fixes a `ReferenceError` regression introduced in the initial fix.

The root cause of the original bug was a broken data pipeline. The `pendingAssets` map, which holds in-memory blobs for newly added images (using `blob:` URLs), was not being passed down to the components responsible for rendering the editor preview.

The fix involves the following changes:

1.  **Prop Drilling:** The `pendingAssets` prop is now correctly passed from `HomePage` through `PageGeneratorFrontendOnly`, `PageEditor`, and `FieldPositioner` down to the `DraggableElement` component.
2.  **Blob URL Resolution:** In `DraggableElement`, a `useEffect` hook has been added to resolve `blob:` URLs from the `pendingAssets` map into displayable object URLs using `URL.createObjectURL`. This ensures the editor preview can now render images that are staged but not yet saved.
3.  **State Management:** The logic in `HomePage` for `handleImageSelected` and `addNewImageToCanvas` has been refactored to correctly update the `customPageTemplate` of a specific generated page, removing a flawed snapshotting mechanism and preventing state corruption.
4.  **Regression Fix:** A `ReferenceError: Typography is not defined` in `DraggableElement.jsx` has been resolved by adding the missing import from `@mui/material`. This error occurred when an image failed to load and the component tried to render an error message.

These changes ensure that images added from the gallery or local uploads are correctly displayed in the editor preview immediately, providing a stable and predictable user experience.