### PR TITLE
This commit fixes a bug where page thumbnails would fail to render ne…

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -59,8 +59,8 @@ const PageGeneratorFrontendOnly = ({
   handleImageUpload, // New prop
   onOpenImageGallery,
   imagePalette,
-  pendingAssets,
-  addPendingAsset, 
+  // pendingAssets is now sourced from context
+  addPendingAsset,
 }) => {
   const {
     csvData,
@@ -70,6 +70,7 @@ const PageGeneratorFrontendOnly = ({
     brandElements,
     pageTemplate,
     setGeneratedPagesData,
+    pendingAssets, // Use the latest pendingAssets from context
   } = useCampaign();
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1623,8 +1623,7 @@ function HomePage() {
                   generatedPagesData={generatedPagesData}
                   handleImageUpload={handleImageUpload}
                   onOpenImageGallery={handleOpenImageGallery}
-                  pendingAssets={pendingAssets}
-                  addPendingAsset={addPendingAsset} 
+                  addPendingAsset={addPendingAsset}
                 />
               )}
               {activeStep === 5 && (


### PR DESCRIPTION
…w images after an individual page save.

The root cause was that `PageGeneratorFrontendOnly.jsx` was using a stale `pendingAssets` map passed via props when calling the thumbnail regeneration function. This meant that newly added images, which exist only as in-memory blobs, could not be found.

The fix refactors `PageGeneratorFrontendOnly.jsx` to source the `pendingAssets` map directly from the `CampaignContext`. This ensures that the component always has the most up-to-date list of assets, including new blobs created during an editing session. The redundant prop was also removed from the parent component (`HomePage.jsx`) to complete the fix.