### PR TITLE
This commit fixes a bug where page thumbnails would fail to render ne…

### DIFF
--- a/src/components/PageGeneratorFrontendOnly.jsx
+++ b/src/components/PageGeneratorFrontendOnly.jsx
@@ -59,7 +59,7 @@ const PageGeneratorFrontendOnly = ({
   handleImageUpload, // New prop
   onOpenImageGallery,
   imagePalette,
-  // pendingAssets is now sourced from context
+  pendingAssets,
   addPendingAsset,
 }) => {
   const {
@@ -70,7 +70,6 @@ const PageGeneratorFrontendOnly = ({
     brandElements,
     pageTemplate,
     setGeneratedPagesData,
-    pendingAssets, // Use the latest pendingAssets from context
   } = useCampaign();
   const [isGenerating, setIsGenerating] = useState(false);
   const [progress, setProgress] = useState(0);

--- a/src/context/CampaignContext.jsx
+++ b/src/context/CampaignContext.jsx
@@ -1,14 +1,4 @@
-import React, { createContext, useContext, useState, useMemo, useCallback, useEffect, useRef } from 'react';
-
-// A simple debounce utility
-function debounce(func, wait) {
-  let timeout;
-  return function(...args) {
-    const context = this;
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func.apply(context, args), wait);
-  };
-}
+import React, { createContext, useContext, useState, useMemo, useCallback, useEffect } from 'react';
 
 const defaultPageTemplate = {
     backgroundColor: '#FFFFFF',
@@ -53,108 +43,57 @@ export const CampaignProvider = ({ children }) => {
   const [customPalette, setCustomPalette] = useState(null);
   const [imageColorPalette, setImageColorPalette] = useState([]);
 
-  // Asset queue for debounced updates
-  const assetQueue = useRef({});
-
-  // Debounced function to flush the asset queue into the main state
-  const flushAssetQueue = useCallback(() => {
-    if (Object.keys(assetQueue.current).length > 0) {
-      console.log('[CampaignContext] Debounced update. Flushing asset queue...', assetQueue.current);
-      setPendingAssets(prev => ({ ...prev, ...assetQueue.current }));
-      assetQueue.current = {}; // Clear the queue after flushing
-    }
-  }, []);
-
-  // Create a memoized debounced version of the flush function
-  const debouncedFlush = useMemo(() => debounce(flushAssetQueue, 300), [flushAssetQueue]);
-
-
   // Centralized asset handlers
-    /**
-   * @description Creates a `blob:` URL for a given Blob and adds it to a queue for batch processing.
-   * The queue is flushed automatically after a short delay to prevent race conditions and improve performance.
-   * This function no longer requires an `isSaving` flag.
-   *
-   * ---
-   * **Blob Lifecycle:**
-   * 1. **Creation:** A `blob:` URL is created using `URL.createObjectURL(blob)`.
-   * 2. **Queueing:** The URL and Blob are added to a temporary queue (`assetQueue`).
-   * 3. **Batch Update:** A debounced function (`debouncedFlush`) merges the queue into the main
-   *    `pendingAssets` state after a 300ms delay.
-   * 4. **Serialization:** During a campaign save, `serializeCampaignData` uses the stable `pendingAssets` state.
-   * 5. **Revocation:** The `blob:` URL **must** be revoked using `URL.revokeObjectURL(url)`. This is handled
-   *    by `removePendingAsset` or the component's unmount effect.
-   * ---
-   *
-   * @param {Blob} blob The Blob object to add.
-   * @returns {string|null} The generated `blob:` URL, or null if the input was invalid.
-   */
   const addPendingAsset = useCallback((blob) => {
     if (!(blob instanceof Blob)) {
       console.error("[addPendingAsset] Invalid argument. Expected a Blob.", blob);
       return null;
     }
     const blobUrl = URL.createObjectURL(blob);
-    assetQueue.current[blobUrl] = blob;
-    debouncedFlush();
+    setPendingAssets(prev => ({
+      ...prev,
+      [blobUrl]: blob,
+    }));
+    console.log(`[CampaignContext] Synchronously added new asset: ${blobUrl}`);
     return blobUrl;
-  }, [debouncedFlush]);
+  }, []);
 
-    /**
-   * @description Adds a map of pre-existing `blob:` URLs and their Blobs to the asset queue.
-   * This is a batch version of `addPendingAsset` for efficiency.
-   * @param {Object<string, Blob>} assetMap A map of `blob:` URLs to Blob objects.
-   */
   const addPendingAssetMap = useCallback((assetMap) => {
-    assetQueue.current = { ...assetQueue.current, ...assetMap };
-    debouncedFlush();
-  }, [debouncedFlush]);
+    setPendingAssets(prev => ({
+      ...prev,
+      ...assetMap,
+    }));
+    console.log('[CampaignContext] Synchronously added asset map.');
+  }, []);
 
-    /**
-   * @description Removes a pending asset from the state and revokes its associated `blob:` URL
-   * to free up memory. This is the primary method for manually cleaning up a temporary asset.
-   * @param {string} blobUrl The `blob:` URL of the asset to remove.
-   */
   const removePendingAsset = useCallback((blobUrl) => {
     if (typeof blobUrl !== 'string' || !blobUrl.startsWith('blob:')) {
       console.error("[removePendingAsset] Invalid argument. Expected a blob URL string.", blobUrl);
       return;
     }
-    // Also remove from the queue in case it hasn't been flushed yet
-    if (assetQueue.current[blobUrl]) {
-        delete assetQueue.current[blobUrl];
-    }
-
     setPendingAssets(prev => {
       const newAssets = { ...prev };
       if (newAssets[blobUrl]) {
         URL.revokeObjectURL(blobUrl);
         delete newAssets[blobUrl];
+        console.log(`[CampaignContext] Removed and revoked asset: ${blobUrl}`);
       }
       return newAssets;
     });
   }, []);
 
   // Effect to clean up all blob URLs on unmount
-    /**
-   * @description A safety-net effect that runs when the CampaignProvider is unmounted.
-   * It iterates through any remaining assets in `pendingAssets` and revokes their URLs,
-   * preventing memory leaks if the component is unexpectedly destroyed.
-   */
   useEffect(() => {
     return () => {
-      // Clean up assets in the main state
-      Object.keys(pendingAssets).forEach(url => {
-        console.log(`[CampaignContext] Revoking blob URL on unmount: ${url}`);
-        URL.revokeObjectURL(url);
-      });
-      // Clean up any assets still in the queue
-      Object.keys(assetQueue.current).forEach(url => {
-          console.log(`[CampaignContext] Revoking queued blob URL on unmount: ${url}`);
+      setPendingAssets(currentAssets => {
+        Object.keys(currentAssets).forEach(url => {
+          console.log(`[CampaignContext] Revoking blob URL on unmount: ${url}`);
           URL.revokeObjectURL(url);
+        });
+        return {}; // Return an empty object to clear the state
       });
     };
-  }, [pendingAssets]);
+  }, []);
 
   const value = useMemo(() => ({
     // State

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1623,6 +1623,7 @@ function HomePage() {
                   generatedPagesData={generatedPagesData}
                   handleImageUpload={handleImageUpload}
                   onOpenImageGallery={handleOpenImageGallery}
+                  pendingAssets={pendingAssets}
                   addPendingAsset={addPendingAsset}
                 />
               )}


### PR DESCRIPTION
…w images after an individual page save.

The root cause was a race condition in the `CampaignContext`. The context used a debounced queue to manage the `pendingAssets` state. This delay meant that when a user added a new image and immediately saved the page, the thumbnail regeneration process would start before the new image's blob was officially added to the state, leading to a `net::ERR_FILE_NOT_FOUND` error.

The fix refactors the asset management in `CampaignContext.jsx` to be fully synchronous. The debounced queue has been removed, and the `addPendingAsset` and `addPendingAssetMap` functions now update the state directly and immediately. This ensures that any new asset is instantly available application-wide, resolving the race condition and allowing the thumbnail generation to reliably find all necessary image blobs.