### PR TITLE
fix: Resolve internal server error on empty briefing list

### DIFF
--- a/api/briefings/index.js
+++ b/api/briefings/index.js
@@ -19,7 +19,7 @@ const handler = async (req, res) => {
   if (req.method === 'GET') {
     try {
       const { rows } = await query(
-        'SELECT id, name, briefing_data, updated_at FROM briefings WHERE user_id = $1 ORDER BY updated_at DESC',
+        'SELECT id, name, briefing_data, updated_at FROM briefings WHERE user_id = $1',
         [userId]
       );
       return res.status(200).json(rows);


### PR DESCRIPTION
This commit addresses a bug where an 'Internal Server Error' was displayed when a user with no briefings accessed the feature. The error was likely caused by an `ORDER BY` clause on an empty table.

The `ORDER BY updated_at DESC` clause has been removed from the GET request in `api/briefings/index.js` to ensure the query executes correctly even when no briefings exist for the user.

feat: Add briefing management feature

This commit introduces a new 'Briefing' management feature, analogous to the existing Atores, Campanhas, and Personas sections.

Key changes include:
- A new 'briefings' table in the database to store briefing data.
- Backend API endpoints (`/api/briefings`) for CRUD operations on briefings.
- A new `BriefingPage` component that provides the main UI for managing briefings, including a list view and a creation/editing area.
- A `BriefingWizard` component with a two-step process for creating and reviewing briefings.
- UI elements for all specified fields, including a dropdown for 'Tom de Voz', chip inputs for 'DOs' and 'DON'Ts', and text fields with AI suggestion capabilities.
- An `AISuggestionModal` component to provide AI-powered content suggestions for relevant fields.
- Integration of the new page into the main application navigation.