### PR TITLE
refactor: Correct field order in Briefing Wizard

### DIFF
--- a/src/components/BriefingWizard.jsx
+++ b/src/components/BriefingWizard.jsx
@@ -160,9 +160,9 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
       **Tom de Voz:** ${tom_de_voz}\n
       **O que FAZER:**\n${faca.map(item => `- ${item}`).join('\n')}\n
       **O que NÃO FAZER:**\n${nao_faca.map(item => `- ${item}`).join('\n')}\n
+      **Objetivo:** ${objetivo}\n
       **Saudação:** ${saudacao}\n
-      **Entregas:** ${entregas}\n
-      **Objetivo:** ${objetivo}
+      **Entregas:** ${entregas}
     `;
     onBriefingDataChange(prev => ({ ...prev, briefing_final: finalBriefing.trim() }));
   };
@@ -217,6 +217,32 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
             </Grid>
             <Grid item xs={12}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <TextField name="objetivo" label="Objetivo" fullWidth value={briefingData.objetivo || ''} onChange={handleChange} multiline rows={3} />
+                <Tooltip title="Gerar com IA">
+                  <IconButton color="primary" onClick={() => handleOpenModal('objetivo', 'Sugestões de Objetivo', () => `'A partir do texto do usuário ${briefingData.objetivo} e considerando os critérios de comunicação da marca fornecidos nos Do’s ${briefingData.faca.join(', ')} e Don’ts ${briefingData.nao_faca.join(', ')}, gere até 5 opções de texto revisado que estejam alinhadas com o tom de voz da marca.
+Cada opção deve:
+Seguir fielmente os Do’s, incorporando boas práticas de tom, estilo e linguagem;
+Evitar estritamente os Don’ts, como termos, expressões ou estilos proibidos;
+Manter o significado original do texto do usuário, aprimorando clareza, engajamento e adequação à marca;
+Ser concisa, clara e com impacto emocional adequado ao público.
+O JSON de saída deve ter a seguinte estrutura:
+{
+  "opcoes_revisadas": [
+    {"opcao": 1, "texto": "{texto_revisado_1}"},
+    {"opcao": 2, "texto": "{texto_revisado_2}"},
+    {"opcao": 3, "texto": "{texto_revisado_3}"},
+    {"opcao": 4, "texto": "{texto_revisado_4}"},
+    {"opcao": 5, "texto": "{texto_revisado_5}"}
+  ]
+}
+'`)}>
+                    <AutoAwesomeIcon />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            </Grid>
+            <Grid item xs={12}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <TextField name="saudacao" label="Saudação" fullWidth value={briefingData.saudacao || ''} onChange={handleChange} multiline rows={2} />
                 <Tooltip title="Gerar com IA">
                   <IconButton color="primary" onClick={() => handleOpenModal('saudacao', 'Sugestões de Saudação', () => `{
@@ -252,32 +278,6 @@ Regras:
 Cada descrição deve ser clara, objetiva e prática.
 Incluir quantidade de conteúdos, formato, links ou cupons, e prazo se mencionados no texto de referência.
 Adaptar o tom para facilitar o entendimento e execução do participante.'`)}>
-                    <AutoAwesomeIcon />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-            </Grid>
-            <Grid item xs={12}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <TextField name="objetivo" label="Objetivo" fullWidth value={briefingData.objetivo || ''} onChange={handleChange} multiline rows={3} />
-                <Tooltip title="Gerar com IA">
-                  <IconButton color="primary" onClick={() => handleOpenModal('objetivo', 'Sugestões de Objetivo', () => `'A partir do texto do usuário ${briefingData.objetivo} e considerando os critérios de comunicação da marca fornecidos nos Do’s ${briefingData.faca.join(', ')} e Don’ts ${briefingData.nao_faca.join(', ')}, gere até 5 opções de texto revisado que estejam alinhadas com o tom de voz da marca.
-Cada opção deve:
-Seguir fielmente os Do’s, incorporando boas práticas de tom, estilo e linguagem;
-Evitar estritamente os Don’ts, como termos, expressões ou estilos proibidos;
-Manter o significado original do texto do usuário, aprimorando clareza, engajamento e adequação à marca;
-Ser concisa, clara e com impacto emocional adequado ao público.
-O JSON de saída deve ter a seguinte estrutura:
-{
-  "opcoes_revisadas": [
-    {"opcao": 1, "texto": "{texto_revisado_1}"},
-    {"opcao": 2, "texto": "{texto_revisado_2}"},
-    {"opcao": 3, "texto": "{texto_revisado_3}"},
-    {"opcao": 4, "texto": "{texto_revisado_4}"},
-    {"opcao": 5, "texto": "{texto_revisado_5}"}
-  ]
-}
-'`)}>
                     <AutoAwesomeIcon />
                   </IconButton>
                 </Tooltip>


### PR DESCRIPTION
This commit addresses user feedback to change the order of fields in the briefing creation wizard.

- The 'Objetivo' field has been moved to appear before the 'Saudação' field in the UI.
- The order of fields in the final summary text has been updated to match the new layout.

fix: Resolve internal server error on empty briefing list

This commit addresses a bug where an 'Internal Server Error' was displayed when a user with no briefings accessed the feature. The error was likely caused by an `ORDER BY` clause on an empty table.

The `ORDER BY updated_at DESC` clause has been removed from the GET request in `api/briefings/index.js` to ensure the query executes correctly even when no briefings exist for the user.

feat: Add briefing management feature

This commit introduces a new 'Briefing' management feature, analogous to the existing Atores, Campanhas, and Personas sections.

Key changes include:
- A new 'briefings' table in the database to store briefing data.
- Backend API endpoints (`/api/briefings`) for CRUD operations on briefings.
- A new `BriefingPage` component that provides the main UI for managing briefings.
- A `BriefingWizard` component with a two-step process for creating and reviewing briefings.
- UI elements for all specified fields, including a dropdown for 'Tom de Voz', chip inputs for 'DOs' and 'DON'Ts', and text fields with AI suggestion capabilities.
- An `AISuggestionModal` component to provide AI-powered content suggestions for relevant fields.
- Integration of the new page into the main application navigation.