### PR TITLE
refactor(briefing): Implement responsive multi-step wizard UI

### DIFF
--- a/src/components/TomDeVozModal.jsx
+++ b/src/components/TomDeVozModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Checkbox, Paper
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Radio, RadioGroup, Paper
 } from '@mui/material';
 
 const TONS_DE_VOZ_DATA = [
@@ -46,20 +46,29 @@ const TomDeVozModal = ({ open, onClose, selectedTones, onSave }) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {TONS_DE_VOZ_DATA.map((row) => (
-                <TableRow key={row.tom} hover onClick={() => handleToggle(row.tom)}>
-                  <TableCell padding="checkbox">
-                    <Checkbox
-                      color="primary"
-                      checked={localSelection.includes(row.tom)}
-                    />
-                  </TableCell>
-                  <TableCell>{row.tom}</TableCell>
-                  <TableCell>{row.quando}</TableCell>
-                  <TableCell>{row.como}</TableCell>
-                  <TableCell>{row.exemplo}</TableCell>
-                </TableRow>
-              ))}
+              <RadioGroup
+                aria-label="tom-de-voz"
+                value={localSelection[0] || ''}
+                onChange={(e) => handleToggle(e.target.value)}
+              >
+                {TONS_DE_VOZ_DATA.map((row) => (
+                  <TableRow
+                    key={row.tom}
+                    hover
+                    onClick={() => handleToggle(row.tom)}
+                    selected={localSelection.includes(row.tom)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    <TableCell padding="checkbox">
+                      <Radio value={row.tom} />
+                    </TableCell>
+                    <TableCell>{row.tom}</TableCell>
+                    <TableCell>{row.quando}</TableCell>
+                    <TableCell>{row.como}</TableCell>
+                    <TableCell>{row.exemplo}</TableCell>
+                  </TableRow>
+                ))}
+              </RadioGroup>
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
This refactors the briefing creation and editing process into a new, five-step wizard to improve user experience and guide the user through the campaign setup process. This change also incorporates responsive design improvements and UI corrections based on user feedback.

The new wizard is composed of the following steps:
1.  **Motivação:** Allows the user to select the primary motivation for the campaign. The UI is now responsive, showing a table on desktop and a more touch-friendly card layout on mobile devices.
2.  **Objeto:** Captures the brand, product/service, and a detailed description with character limits.
3.  **Referências:** Gathers a wide range of guidelines, including tone of voice, DOs and DON'Ts, content quantity, product shipment details, and inspirations. The "Tom de Voz" selection now correctly uses radio buttons for a more intuitive single-choice selection.
4.  **Mensagem:** A detailed step for crafting the core message, including an AI assistant to generate a "Mensagem Principal" from a "Texto Base" with specific constraints, a color-coded character counter, and view toggling.
5.  **Finalização:** Provides a comprehensive summary of all the entered data for a final review before saving.

The implementation includes significant UI changes in `BriefingWizard.jsx`, updates to the data structure, and adjustments to the `TomDeVozModal.jsx` to enforce a single selection with the correct UI pattern. All old components and logic related to the previous briefing form have been removed.