### PR TITLE
refactor(briefing): Implement responsive multi-step wizard UI

### DIFF
--- a/src/components/TomDeVozModal.jsx
+++ b/src/components/TomDeVozModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Radio, RadioGroup, Paper
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Radio, RadioGroup, Paper, Grid, Typography, Box
 } from '@mui/material';
 
 const TONS_DE_VOZ_DATA = [
@@ -34,44 +34,47 @@ const TomDeVozModal = ({ open, onClose, selectedTones, onSave }) => {
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
       <DialogTitle>Selecione o Tom de Voz</DialogTitle>
       <DialogContent>
-        <TableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell padding="checkbox"></TableCell>
-                <TableCell>Tom de Voz</TableCell>
-                <TableCell>Quando Usar</TableCell>
-                <TableCell>Como Soa</TableCell>
-                <TableCell>Exemplo de Frase</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              <RadioGroup
-                aria-label="tom-de-voz"
-                value={localSelection[0] || ''}
-                onChange={(e) => handleToggle(e.target.value)}
-              >
-                {TONS_DE_VOZ_DATA.map((row) => (
-                  <TableRow
-                    key={row.tom}
-                    hover
-                    onClick={() => handleToggle(row.tom)}
-                    selected={localSelection.includes(row.tom)}
-                    sx={{ cursor: 'pointer' }}
-                  >
-                    <TableCell padding="checkbox">
-                      <Radio value={row.tom} />
-                    </TableCell>
-                    <TableCell>{row.tom}</TableCell>
-                    <TableCell>{row.quando}</TableCell>
-                    <TableCell>{row.como}</TableCell>
-                    <TableCell>{row.exemplo}</TableCell>
-                  </TableRow>
-                ))}
-              </RadioGroup>
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <RadioGroup
+          aria-label="tom-de-voz"
+          value={localSelection[0] || ''}
+          onChange={(e) => handleToggle(e.target.value)}
+        >
+          <Grid container spacing={2}>
+            {TONS_DE_VOZ_DATA.map((item) => (
+              <Grid item xs={12} md={6} key={item.tom}>
+                <Paper
+                  variant="outlined"
+                  onClick={() => handleToggle(item.tom)}
+                  sx={{
+                    p: 2,
+                    cursor: 'pointer',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    height: '100%',
+                    border: 2,
+                    borderColor: localSelection.includes(item.tom) ? 'primary.main' : 'divider',
+                    backgroundColor: localSelection.includes(item.tom) ? 'action.selected' : 'background.paper',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                    <Radio value={item.tom} checked={localSelection.includes(item.tom)} />
+                    <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+                      {item.tom}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ pl: 4 }}>
+                    <Typography variant="caption" color="text.secondary" display="block">QUANDO USAR</Typography>
+                    <Typography variant="body2" gutterBottom>{item.quando}</Typography>
+                    <Typography variant="caption" color="text.secondary" display="block">COMO SOA</Typography>
+                    <Typography variant="body2" gutterBottom>{item.como}</Typography>
+                    <Typography variant="caption" color="text.secondary" display="block">EXEMPLO</Typography>
+                    <Typography variant="body2" sx={{ fontStyle: 'italic' }}>{item.exemplo}</Typography>
+                  </Box>
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+        </RadioGroup>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancelar</Button>


### PR DESCRIPTION
This refactors the briefing creation and editing process into a new, five-step wizard to improve user experience and guide the user through the campaign setup process. This change also incorporates responsive design improvements and UI corrections based on user feedback.

The new wizard is composed of the following steps:
1.  **Motivação:** Allows the user to select the primary motivation for the campaign. The UI is now responsive, showing a table on desktop and a more touch-friendly card layout on mobile devices.
2.  **Objeto:** Captures the brand, product/service, and a detailed description with character limits.
3.  **Referências:** Gathers a wide range of guidelines, including tone of voice, DOs and DON'Ts, content quantity, product shipment details, and inspirations. The "Tom de Voz" selection now correctly uses a card-based layout with radio buttons for a more intuitive single-choice selection.
4.  **Mensagem:** A detailed step for crafting the core message, including an AI assistant to generate a "Mensagem Principal" from a "Texto Base" with specific constraints, a color-coded character counter, and view toggling. The "Objetivo da Mensagem" field is now a multi-line text area with a character counter.
5.  **Finalização:** Provides a comprehensive summary of all the entered data for a final review before saving.

The implementation includes significant UI changes in `BriefingWizard.jsx`, updates to the data structure, and a complete redesign of `TomDeVozModal.jsx` to enforce a single selection with a user-friendly UI pattern. All old components and logic related to the previous briefing form have been removed.