### PR TITLE
Fix: Correct missing Alert import in BriefingWizard

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,9 +1,6 @@
+Re-optimizing dependencies because lockfile has changed
 
-> midiator-google-drive-frontend@0.0.0 dev
-> vite
-
-
-  VITE v5.4.19  ready in 342 ms
+  VITE v5.4.19  ready in 479 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose

--- a/src/components/BriefingWizard.jsx
+++ b/src/components/BriefingWizard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Box, Button, Typography, Grid, FormControl, InputLabel, Select, MenuItem, TextField, Chip, IconButton, Tooltip, Paper, Dialog, DialogTitle, DialogContent, CircularProgress, Radio, RadioGroup, FormControlLabel, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Divider, useMediaQuery
+  Box, Button, Typography, Grid, FormControl, InputLabel, Select, MenuItem, TextField, Chip, IconButton, Tooltip, Paper, Dialog, DialogTitle, DialogContent, CircularProgress, Radio, RadioGroup, FormControlLabel, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Divider, useMediaQuery, Alert
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { Add, ArrowBack, ArrowForward, AutoAwesome as AutoAwesomeIcon } from '@mui/icons-material';


### PR DESCRIPTION
Resolves a `ReferenceError: Alert is not defined` by adding the missing `Alert` import from `@mui/material` to the `src/components/BriefingWizard.jsx` file.