### PR TITLE
feat(briefing): Enhance AI prompts and add CTA suggestions

### DIFF
--- a/jules-scratch/verification/verify_entregas_update.py
+++ b/jules-scratch/verification/verify_entregas_update.py
@@ -1,0 +1,58 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        # 1. Login
+        page.goto("http://localhost:5173/login")
+        expect(page.get_by_role("heading", name="Sign In")).to_be_visible()
+        page.get_by_label("Email Address").fill("user@example.com")
+        page.get_by_label("Password").fill("user_password")
+        page.get_by_role("button", name="Sign In").click()
+        expect(page).to_have_url(re.compile(".*briefings"), timeout=10000)
+
+        # 2. Create a new briefing and select a Tone of Voice
+        page.get_by_role("button", name="Novo Briefing").click()
+        expect(page.get_by_role("heading", name="Qual é a principal motivação?")).to_be_visible()
+
+        # Navigate to Guia da Marca
+        page.get_by_role("button", name="Próximo").click() # -> Step 2
+        page.get_by_role("button", name="Próximo").click() # -> Step 3 (Guia da Marca)
+
+        # Select a Tone of Voice
+        page.get_by_role("button", name="Selecionar").click()
+        expect(page.get_by_role("heading", name="Selecione o Tom de Voz")).to_be_visible()
+        page.get_by_text("Inspirador e Aspiracional").click()
+        page.get_by_role("button", name="Confirmar").click()
+
+        # Navigate to Entregas
+        page.get_by_role("button", name="Próximo").click() # -> Step 4 (Entregas)
+        expect(page.get_by_role("heading", name="Entregas")).to_be_visible()
+
+        # 3. Fill in Texto Base and generate Mensagem Principal
+        texto_base_input = page.get_by_label("Texto Base").first
+        expect(texto_base_input).to_be_editable()
+        texto_base_input.fill("Este é um texto base para testar a geração de mensagem e CTA.")
+
+        page.get_by_role("button", name="Gerar Mensagem Principal").first.click()
+        expect(page.get_by_role("heading", name="Sugestões para Mensagem Principal")).to_be_visible()
+        # Select the first suggestion to populate the field
+        page.get_by_role("button", name=re.compile(r"Usar sugestão")).first.click()
+        expect(page.get_by_role("heading", name="Sugestões para Mensagem Principal")).not_to_be_visible()
+
+        # 4. Generate CTA suggestions
+        page.get_by_role("button", name="Gerar sugestões de CTA com IA").first.click()
+
+        # 5. Wait for the CTA modal and take a screenshot
+        expect(page.get_by_role("heading", name="Sugestões de Call-to-Action (CTA)")).to_be_visible()
+        page.screenshot(path="jules-scratch/verification/entregas_cta_modal_verification.png", full_page=True)
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/components/BriefingWizard.jsx
+++ b/src/components/BriefingWizard.jsx
@@ -5,7 +5,7 @@ import {
 import { useTheme } from '@mui/material/styles';
 import { Add, ArrowBack, ArrowForward, AutoAwesome as AutoAwesomeIcon, Delete as DeleteIcon } from '@mui/icons-material';
 import { toast } from 'sonner';
-import TomDeVozModal from './TomDeVozModal';
+import TomDeVozModal, { TONS_DE_VOZ_DATA } from './TomDeVozModal';
 import SuggestionModal from './SuggestionModal';
 import ProductSuggestionModal from './ProductSuggestionModal';
 import InfoBox from './InfoBox';
@@ -24,12 +24,6 @@ const ctaBestPractices = (
         <Typography variant="body2" gutterBottom><strong>6. Teste Cores e Contraste:</strong> O botão de CTA deve se destacar visualmente do resto da página para atrair a atenção.</Typography>
     </Box>
 );
-
-const TONS_DE_VOZ = [
-  "Inspirador", "Educativo", "Confiante", "Próximo", "Engraçado / Descontraído",
-  "Elegante / Sofisticado", "Inovador", "Institucional", "Cuidadoso / Humano",
-  "Visionário", "Provocador", "Acessível / Democrático"
-];
 
 const MOTIVACOES = [
     { id: 'reconhecimento', nome: 'Aumentar reconhecimento da marca', descricao: 'Tornar a marca mais conhecida e presente na mente do público-alvo.' },
@@ -152,6 +146,9 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
   const [messageSuggestionModalOpen, setMessageSuggestionModalOpen] = useState(false);
   const [messageSuggestions, setMessageSuggestions] = useState([]);
   const [loadingMessageSuggestions, setLoadingMessageSuggestions] = useState(false);
+  const [ctaSuggestionModalOpen, setCtaSuggestionModalOpen] = useState(false);
+  const [ctaSuggestions, setCtaSuggestions] = useState([]);
+  const [loadingCtaSuggestions, setLoadingCtaSuggestions] = useState(false);
   const [activeEntregaIndex, setActiveEntregaIndex] = useState(null);
 
 
@@ -369,6 +366,19 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
     const entrega = briefingData.entregas[entregaIndex];
     const motivacaoObj = MOTIVACOES.find(m => m.id === motivacao);
 
+    // Find the detailed tone of voice object
+    const selectedToneName = (tom_de_voz || [])[0]; // Assuming only one can be selected
+    const toneOfVoiceData = TONS_DE_VOZ_DATA.find(t => t.tom === selectedToneName);
+
+    // Build the detailed tone of voice string for the prompt
+    let toneOfVoicePromptSection = `1.4. TOM DE VOZ - ${selectedToneName || 'Não definido'}`;
+    if (toneOfVoiceData) {
+        toneOfVoicePromptSection += `
+        1.4.1. QUANDO USAR: ${toneOfVoiceData.quando}
+        1.4.2. COMO SOA: ${toneOfVoiceData.como}
+        1.4.3. EXEMPLO: ${toneOfVoiceData.exemplo}`;
+    }
+
     const prompt = `
       Aja como um especialista em comunicação e marketing. Analise o "Texto Base" fornecido pelo usuário e critique-o com base no seguinte PROMPT:
 
@@ -385,7 +395,7 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
         1.1. Objetivo principal
         1.2. DOS - ${faca.join(', ')}
         1.3. DONTS - ${nao_faca.join(', ')}
-        1.4. TOM DE VOZ - ${tom_de_voz.join(', ')}
+        ${toneOfVoicePromptSection}
 
       2.  **Gere 2 Sugestões Alternativas:**
 
@@ -420,6 +430,82 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
         console.error("Message suggestion error:", error);
     } finally {
         setLoadingMessageSuggestions(false);
+    }
+  };
+
+  const handleGenerateCtaSuggestions = async (entregaIndex) => {
+    if (!geminiAPI.isInitialized) {
+      const apiKey = getGeminiApiKey();
+      if (!apiKey) {
+        toast.error('Chave de API do Gemini não configurada.');
+        return;
+      }
+      geminiAPI.initialize(apiKey);
+    }
+
+    setLoadingCtaSuggestions(true);
+    setActiveEntregaIndex(entregaIndex);
+    setCtaSuggestions([]);
+
+    const { motivacao, produtoServico, descricao, tom_de_voz, faca, nao_faca } = briefingData;
+    const entrega = briefingData.entregas[entregaIndex];
+    const motivacaoObj = MOTIVACOES.find(m => m.id === motivacao);
+
+    // Find the detailed tone of voice object
+    const selectedToneName = (tom_de_voz || [])[0];
+    const toneOfVoiceData = TONS_DE_VOZ_DATA.find(t => t.tom === selectedToneName);
+
+    // Build the detailed tone of voice string for the prompt
+    let toneOfVoicePromptSection = `Tom de Voz: ${selectedToneName || 'Não definido'}`;
+    if (toneOfVoiceData) {
+        toneOfVoicePromptSection += `\n    - QUANDO USAR: ${toneOfVoiceData.quando}\n    - COMO SOA: ${toneOfVoiceData.como}\n    - EXEMPLO: ${toneOfVoiceData.exemplo}`;
+    }
+
+    const prompt = `
+        Aja como um especialista em marketing digital. Com base nas seguintes informações de um briefing de campanha, gere 3 sugestões de Call-to-Action (CTA) curtas e eficazes.
+
+        **Contexto da Campanha:**
+        - **Objetivo Principal:** ${motivacaoObj ? motivacaoObj.nome : 'Não definido'}
+        - **Produto/Serviço:** ${produtoServico || 'Não definido'}
+        - **Descrição do Produto/Serviço:** ${descricao || 'Não definida'}
+        - **Tom de Voz Desejado:**
+          - ${toneOfVoicePromptSection}
+        - **DOS:** ${faca.join(', ')}
+        - **DONTS:** ${nao_faca.join(', ')}
+        - **Mensagem Principal:** ${entrega.mensagemPrincipal || 'Não definida'}
+
+        **Requisitos para as sugestões de CTA:**
+        1.  Cada CTA deve ser claro, conciso e orientado para a ação.
+        2.  As sugestões devem ser variadas, explorando diferentes gatilhos (urgência, benefício, curiosidade, etc.).
+        3.  O CTA deve estar alinhado com a motivação e o objetivo da campanha.
+        4.  O CTA deve ter no mínimo 8 palavras e no máximo 15 palavras.
+        5.  Evite jargões ou termos muito técnicos; o CTA deve ser facilmente compreendido pelo público geral.
+        6.  Não use pontuação excessiva (ex: "Compre agora!!!" ou "Clique aqui...").
+        7.  Não repita palavras ou ideias entre os CTAs.
+        8.  Não use mais de um número em cada CTA (ex: "Compre 1 e ganhe 1" não é permitido).
+        9.  Não inclua nenhum elemento que não seja texto (ex: emojis, símbolos).
+        10. Não use frases que já foram usadas em outros CTAs famosos ou clichês.
+        11.  O formato da resposta deve ser um array JSON de strings. Exemplo: ["CTA 1", "CTA 2", "CTA 3"]
+
+        Gere o JSON com as 3 sugestões de CTA.
+    `;
+
+    try {
+        const response = await geminiAPI.generateContent(prompt);
+        const match = response.match(/\[(.*?)\]/s);
+        if (match) {
+            const jsonString = `[${match[1]}]`;
+            const jsonResponse = JSON.parse(jsonString);
+            setCtaSuggestions(jsonResponse);
+            setCtaSuggestionModalOpen(true);
+        } else {
+            throw new Error("Nenhum array JSON válido encontrado na resposta da IA.");
+        }
+    } catch (error) {
+        toast.error('Erro ao gerar sugestões de CTA.');
+        console.error("CTA suggestion error:", error);
+    } finally {
+        setLoadingCtaSuggestions(false);
     }
   };
 
@@ -625,12 +711,25 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
                                         />
                                     </Grid>
                                     <Grid item xs={12}>
-                                        <TextField
-                                          label="CTA (Call to Action)"
-                                          fullWidth
-                                          value={entrega.cta}
-                                          onChange={(e) => handleEntregaChange(index, 'cta', e.target.value)}
-                                        />
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                            <TextField
+                                              label="CTA (Call to Action)"
+                                              fullWidth
+                                              value={entrega.cta}
+                                              onChange={(e) => handleEntregaChange(index, 'cta', e.target.value)}
+                                            />
+                                            <Tooltip title="Gerar sugestões de CTA com IA">
+                                                <span>
+                                                    <IconButton
+                                                        color="primary"
+                                                        onClick={() => handleGenerateCtaSuggestions(index)}
+                                                        disabled={loadingCtaSuggestions && activeEntregaIndex === index}
+                                                    >
+                                                        {loadingCtaSuggestions && activeEntregaIndex === index ? <CircularProgress size={24} /> : <AutoAwesomeIcon />}
+                                                    </IconButton>
+                                                </span>
+                                            </Tooltip>
+                                        </Box>
                                     </Grid>
                                     <Grid item xs={12}>
                                        <Tooltip title="Gerar sugestões para a Mensagem Principal com IA">
@@ -819,6 +918,22 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
         }}
         onRegenerate={() => handleGenerateMessageSuggestions(activeEntregaIndex)}
         loading={loadingMessageSuggestions}
+        error={null}
+      />
+      <SuggestionModal
+        open={ctaSuggestionModalOpen}
+        onClose={() => setCtaSuggestionModalOpen(false)}
+        title="Sugestões de Call-to-Action (CTA)"
+        suggestionTitle="Sugestões Geradas pela IA"
+        suggestionDescription="Clique em uma sugestão para usá-la no seu briefing."
+        bestPractices={ctaBestPractices}
+        suggestions={ctaSuggestions}
+        onSelectSuggestion={(suggestion) => {
+          handleEntregaChange(activeEntregaIndex, 'cta', suggestion);
+          setCtaSuggestionModalOpen(false);
+        }}
+        onRegenerate={() => handleGenerateCtaSuggestions(activeEntregaIndex)}
+        loading={loadingCtaSuggestions}
         error={null}
       />
       <ProductSuggestionModal

--- a/src/components/TomDeVozModal.jsx
+++ b/src/components/TomDeVozModal.jsx
@@ -3,7 +3,7 @@ import {
   Dialog, DialogTitle, DialogContent, DialogActions, Button, Radio, RadioGroup, Paper, Grid, Typography, Box
 } from '@mui/material';
 
-const TONS_DE_VOZ_DATA = [
+export const TONS_DE_VOZ_DATA = [
   { tom: 'Próximo e Humano', quando: 'Para criar vínculo emocional, campanhas de lifestyle, bem-estar, cuidado.', como: 'Empático, acolhedor, acessível.', exemplo: '“A gente sabe que sua rotina é corrida, por isso criamos essa solução rápida e prática.”' },
   { tom: 'Inspirador e Aspiracional', quando: 'Quando a marca quer elevar autoestima, estilo de vida ou conquistas.', como: 'Motivador, positivo, sonhador.', exemplo: '“Mais que um produto, é um convite para você viver sua melhor versão.”' },
   { tom: 'Didático e Prático', quando: 'Em instruções, briefings de UGC, passo a passo, orientações claras.', como: 'Objetivo, simples, direto.', exemplo: '“Passo 1: escolha o formato. Passo 2: grave em boa luz. Passo 3: suba seu vídeo na plataforma.”' },

--- a/vite.log
+++ b/vite.log
@@ -1,5 +1,6 @@
+Port 5173 is in use, trying another one...
 
-  VITE v5.4.19  ready in 285 ms
+  VITE v5.4.19  ready in 790 ms
 
-  ➜  Local:   http://localhost:5173/
+  ➜  Local:   http://localhost:5174/
   ➜  Network: use --host to expose


### PR DESCRIPTION
This commit enhances the AI capabilities within the `BriefingWizard`'s 'Entregas' step.

- The 'Mensagem Principal' generation prompt is now enriched with the full 'Tom de Voz' details (when, how, example), providing the AI with deeper context for more relevant suggestions.
- A new AI suggestion feature has been implemented for the 'CTA' field for each delivery item.
- This includes a new AI button, a dedicated handler (`handleGenerateCtaSuggestions`), and a comprehensive prompt that leverages the campaign objective, product info, Do's/Don'ts, full tone of voice profile, and the main message.
- Adds a new `SuggestionModal` instance to display and handle CTA suggestions, updating the state of the correct delivery item.
- Exports `TONS_DE_VOZ_DATA` to be shared across components.