### PR TITLE
feat(briefing): Refactor 'Entregas' step and improve suggestion modal UI

### DIFF
--- a/jules-scratch/verification/verify_modal_refactor.py
+++ b/jules-scratch/verification/verify_modal_refactor.py
@@ -1,0 +1,43 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        # 1. Login
+        page.goto("http://localhost:5173/login")
+        expect(page.get_by_role("heading", name="Sign In")).to_be_visible()
+        page.get_by_label("Email Address").fill("user@example.com")
+        page.get_by_label("Password").fill("user_password")
+        page.get_by_role("button", name="Sign In").click()
+        expect(page).to_have_url(re.compile(".*briefings"), timeout=10000)
+
+        # 2. Create a new briefing
+        page.get_by_role("button", name="Novo Briefing").click()
+        expect(page.get_by_role("heading", name="Qual é a principal motivação?")).to_be_visible()
+
+        # 3. Navigate to Entregas step
+        page.get_by_role("button", name="Próximo").click()
+        page.get_by_role("button", name="Próximo").click()
+        page.get_by_role("button", name="Próximo").click()
+        expect(page.get_by_role("heading", name="Entregas")).to_be_visible()
+
+        # 4. Fill in Texto Base and generate suggestions
+        texto_base_input = page.get_by_label("Texto Base").first
+        expect(texto_base_input).to_be_editable()
+        texto_base_input.fill("Este é um texto para verificar o novo design do modal de sugestões.")
+
+        page.get_by_role("button", name="Gerar Mensagem Principal").first.click()
+
+        # 5. Wait for the modal and take a screenshot
+        expect(page.get_by_role("heading", name="Sugestões para Mensagem Principal")).to_be_visible()
+        page.screenshot(path="jules-scratch/verification/suggestion_modal_refactor.png", full_page=True)
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/components/SuggestionModal.jsx
+++ b/src/components/SuggestionModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Dialog, DialogTitle, DialogContent, DialogActions, Button, Grid, Typography, Box, IconButton, CircularProgress, Alert
+  Dialog, DialogTitle, DialogContent, DialogActions, Button, Grid, Typography, Box, IconButton, CircularProgress, Alert, Paper
 } from '@mui/material';
 import { Close as CloseIcon, AutoAwesomeOutlined as GeminiIcon } from '@mui/icons-material';
 
@@ -17,8 +17,10 @@ const SuggestionModal = ({
   loading,
   error,
 }) => {
+  const hasBestPractices = Boolean(bestPractices);
+
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth={hasBestPractices ? "lg" : "md"}>
       <DialogTitle>
         {title}
         <IconButton
@@ -30,8 +32,8 @@ const SuggestionModal = ({
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        <Grid container spacing={4} sx={{ mt: 1 }}>
-          <Grid item xs={12} md={6}>
+        <Grid container spacing={hasBestPractices ? 4 : 2} sx={{ mt: 1 }}>
+          <Grid item xs={12} md={hasBestPractices ? 6 : 12}>
             <Typography variant="h6" gutterBottom>{suggestionTitle}</Typography>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               {suggestionDescription}
@@ -58,23 +60,33 @@ const SuggestionModal = ({
               </Alert>
             )}
             {suggestions.length > 0 && (
-              <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
                 {suggestions.map((suggestion, index) => (
-                  <Alert
+                  <Paper
                     key={index}
-                    severity="info"
+                    variant="outlined"
                     onClick={() => onSelectSuggestion(suggestion)}
-                    sx={{ cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' }, whiteSpace: 'pre-wrap' }}
+                    sx={{
+                      p: 2,
+                      cursor: 'pointer',
+                      '&:hover': {
+                        bgcolor: 'action.hover',
+                        borderColor: 'primary.main'
+                      },
+                      whiteSpace: 'pre-wrap',
+                    }}
                   >
-                    {suggestion}
-                  </Alert>
+                    <Typography variant="body2">{suggestion}</Typography>
+                  </Paper>
                 ))}
               </Box>
             )}
           </Grid>
-          <Grid item xs={12} md={6}>
-            {bestPractices}
-          </Grid>
+          {hasBestPractices && (
+            <Grid item xs={12} md={6}>
+              {bestPractices}
+            </Grid>
+          )}
         </Grid>
       </DialogContent>
       <DialogActions>

--- a/vite.log
+++ b/vite.log
@@ -1,6 +1,7 @@
 Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
 
-  VITE v5.4.19  ready in 790 ms
+  VITE v5.4.19  ready in 772 ms
 
-  ➜  Local:   http://localhost:5174/
+  ➜  Local:   http://localhost:5175/
   ➜  Network: use --host to expose


### PR DESCRIPTION
This commit introduces a major refactoring of the 'Entregas' step in the `BriefingWizard` and enhances the UI of the `SuggestionModal`.

- **Entregas Refactor:** Replaces the single delivery configuration with a dynamic list of complex 'Entrega' objects. Removes the old 'Mensagem' step and integrates its logic into each delivery item.

- **AI Enhancements:**
  - Enriches the 'Mensagem Principal' prompt with detailed 'Tom de Voz' data.
  - Adds a new AI suggestion feature for the 'CTA' field, complete with a new, context-aware prompt and UI integration.

- **UI Improvements:**
  - Refactors the `SuggestionModal` to have a conditional, compact layout that adapts based on the presence of the `bestPractices` prop.
  - Replaces `Alert` components with `Paper` for a cleaner, more space-efficient display of suggestions.

- **Code Quality:** Removes obsolete state and components to streamline the codebase.