### PR TITLE
feat: Format briefing summary as a single text block

### DIFF
--- a/src/components/BriefingWizard.jsx
+++ b/src/components/BriefingWizard.jsx
@@ -935,8 +935,19 @@ const BriefingWizard = ({ open, onClose, onSave, briefingData, onBriefingDataCha
             } else {
                 text += "Tom de Voz: Não definido\n";
             }
-            text += `\nDOs: ${(briefingData.faca || []).join(', ') || 'Nenhum'}\n`;
-            text += `DON'Ts: ${(briefingData.nao_faca || []).join(', ') || 'Nenhum'}\n\n`;
+            const formatListItems = (items) => {
+                if (!items || !items.length) {
+                    return "  Nenhum.\n";
+                }
+                return items.map((item, index) => `  ${item}${index === items.length - 1 ? '.' : ';'}`).join('\n') + '\n';
+            };
+
+            text += "\nDOs:\n";
+            text += formatListItems(briefingData.faca);
+
+            text += "DON'Ts:\n";
+            text += formatListItems(briefingData.nao_faca);
+            text += "\n";
 
             text += "Entregas;\n";
             (briefingData.entregas || []).forEach((entrega, index) => {


### PR DESCRIPTION
Refactors the finalization step of the BriefingWizard to display the entire briefing summary as a single, formatted text block, following a user-specified structure.

This change replaces the previous grid-based layout with a `Paper` component containing a pre-formatted text block, improving readability and providing a concise overview of the created briefing. A helper function, `generateBriefingText`, has been added to handle the new text formatting.

This commit also refines the formatting for the 'DOs' and 'DON'Ts' lists within the summary. Each item is now displayed on a new line, ending with a semicolon (except for the last item, which ends with a period), as per the user's request.