### PR TITLE
Fix(api): Use user UUID for briefings endpoint

### DIFF
--- a/add_briefings_table.sql
+++ b/add_briefings_table.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS public.briefings
     updated_at timestamp with time zone DEFAULT now(),
     CONSTRAINT briefings_pkey PRIMARY KEY (id),
     CONSTRAINT briefings_user_id_fkey FOREIGN KEY (user_id)
-        REFERENCES auth.users (id) MATCH SIMPLE
+        REFERENCES public.users (uuid) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
 )

--- a/api/briefings/index.js
+++ b/api/briefings/index.js
@@ -16,15 +16,28 @@ const parseBody = async (req) => {
 const handler = async (req, res) => {
   const userId = req.user.sub;
 
+  // First, get the user's UUID from their integer ID (from JWT sub)
+  let userUUID;
+  try {
+    const { rows } = await query('SELECT uuid FROM users WHERE id = $1', [userId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+    userUUID = rows[0].uuid;
+  } catch (error) {
+    console.error(`[GET /api/briefings] Error fetching user UUID for user ${userId}:`, error);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+
   if (req.method === 'GET') {
     try {
       const { rows } = await query(
         'SELECT id, name, briefing_data, updated_at FROM briefings WHERE user_id = $1',
-        [userId]
+        [userUUID]
       );
       return res.status(200).json(rows);
     } catch (error) {
-      console.error(`[GET /api/briefings] Error for user ${userId}:`, error);
+      console.error(`[GET /api/briefings] Error for user ${userId} (UUID: ${userUUID}):`, error);
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   } else if (req.method === 'POST') {
@@ -38,12 +51,12 @@ const handler = async (req, res) => {
 
       const { rows } = await query(
         'INSERT INTO briefings (user_id, name, briefing_data) VALUES ($1, $2, $3) RETURNING id, name, briefing_data, updated_at',
-        [userId, name, briefingData]
+        [userUUID, name, briefingData]
       );
 
       return res.status(201).json(rows[0]);
     } catch (error) {
-      console.error(`[POST /api/briefings] Error for user ${userId}:`, error);
+      console.error(`[POST /api/briefings] Error for user ${userId} (UUID: ${userUUID}):`, error);
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   } else {

--- a/jules-scratch/verification/verify_briefings_fix.py
+++ b/jules-scratch/verification/verify_briefings_fix.py
@@ -1,0 +1,52 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Listen for console logs to catch client-side errors
+    page.on("console", lambda msg: print(f"CONSOLE LOG: {msg.text}"))
+
+    try:
+        # Navigate to the login page
+        page.goto("http://localhost:5173/login")
+
+        # Wait for the email input to be editable before trying to fill it
+        email_input = page.get_by_label("Email")
+        expect(email_input).to_be_editable(timeout=15000)
+        email_input.fill("user@example.com")
+
+        # Wait for the password input to be editable
+        password_input = page.get_by_label("Senha")
+        expect(password_input).to_be_editable()
+        password_input.fill("user_password")
+
+        page.get_by_role("button", name="Entrar").click()
+
+        # Wait for navigation to the home page and for the "Briefings" button to be visible
+        expect(page).to_have_url(re.compile(r".*/$"), timeout=15000)
+        briefings_button = page.get_by_role("button", name="Briefings")
+        expect(briefings_button).to_be_visible()
+        briefings_button.click()
+
+        # Verify that the "Novo Briefing" button is visible, which indicates the page has loaded
+        novo_briefing_button = page.get_by_role("button", name="Novo Briefing")
+        expect(novo_briefing_button).to_be_visible()
+
+        # Take a screenshot of the briefings page
+        page.screenshot(path="jules-scratch/verification/briefings_page.png")
+        print("Screenshot taken successfully.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        page.screenshot(path="jules-scratch/verification/error.png")
+
+    finally:
+        # Clean up
+        context.close()
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
- The `GET /api/briefings` endpoint was failing with a 500 error due to a data type mismatch. The code was using the user's integer ID to query the `briefings` table, which expects a UUID for the `user_id`.

- This commit modifies the API handler to first fetch the user's UUID from the `users` table and then uses this UUID for all queries related to briefings. It also corrects the foreign key constraint in the `add_briefings_table.sql` migration to properly reference the `uuid` column in the `users` table.