### PR TITLE
fix: improve LinkedIn post enrichment and update API version

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -2,7 +2,7 @@ import { withAuth } from './middleware/auth.js';
 import { query } from './db.js';
 import { delay, fetchWithRetry } from './utils.js';
 
-const LINKEDIN_API_VERSION = '202601';
+const LINKEDIN_API_VERSION = '202505';
 
 // A general-purpose, action-based proxy for LinkedIn API calls.
 // This is more secure than an endpoint-based proxy as it doesn't allow calling arbitrary URLs.


### PR DESCRIPTION
- Updated `extractLinkedinUrn` in `api/utils.js` to preserve the original URN type (activity, ugcPost, share, post) and include `activityId`.
- Added resolution fallback via `/rest/socialActions` in `api/linkedin-proxy.js` to handle non-canonical URNs.
- Critical: Updated `LINKEDIN_API_VERSION` to `'202505'` in `api/linkedin-proxy.js` to avoid initial 400 errors.
- Made post enrichment in `api/engagement/ai-worker.js` non-blocking by catching errors and updating the database with an 'error' status.
- Updated `test/extractLinkedinUrn.test.js` to verify the new extraction logic.