### PR TITLE
fix: resolve LinkedIn connection errors and settings save hang

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -62,10 +62,11 @@ export default async function handler(req, res) {
     const token = jwt.sign(tokenPayload, JWT_SECRET, { expiresIn: '7d' });
 
     // Set JWT in a secure, HttpOnly cookie
+    // Using sameSite: 'lax' to ensure the cookie is sent when returning from OAuth redirects.
     const authTokenCookie = serialize('auth_token', token, {
       httpOnly: true,
       secure: process.env.NODE_ENV !== 'development', // Use secure cookies in production
-      sameSite: 'strict',
+      sameSite: 'lax',
       maxAge: 60 * 60 * 24 * 7, // 1 week
       path: '/',
     });

--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -214,10 +214,10 @@ export async function handleGetProfile(request, response) {
     }
 
     // Version 202601 uses /rest/me with explicit fields
-    const profileUrl = 'https://api.linkedin.com/rest/me?fields=id,givenName,familyName,picture';
+    let profileUrl = 'https://api.linkedin.com/rest/me?fields=id,givenName,familyName,picture';
 
     try {
-        const linkedinResponse = await fetch(profileUrl, {
+        let linkedinResponse = await fetch(profileUrl, {
             headers: {
                 Authorization: `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
@@ -225,6 +225,19 @@ export async function handleGetProfile(request, response) {
                 'LinkedIn-Version': LINKEDIN_API_VERSION
             },
         });
+
+        // Fallback: If projection fails (e.g. field not present in specific schema), try without projection
+        if (!linkedinResponse.ok && linkedinResponse.status === 400) {
+            console.warn('[LinkedIn Proxy] handleGetProfile: Projection failed, retrying without fields.');
+            linkedinResponse = await fetch('https://api.linkedin.com/rest/me', {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json',
+                    'X-Restli-Protocol-Version': '2.0.0',
+                    'LinkedIn-Version': LINKEDIN_API_VERSION
+                },
+            });
+        }
 
         const responseText = await linkedinResponse.text();
         let data;
@@ -409,7 +422,12 @@ async function handleGetProfiles(request, response) {
 
     try {
         // Step 1: Fetch personal profile
-        const personalResponse = await fetch('https://api.linkedin.com/rest/me?fields=id,givenName,familyName,picture', { headers });
+        let personalResponse = await fetch('https://api.linkedin.com/rest/me?fields=id,givenName,familyName,picture', { headers });
+
+        if (!personalResponse.ok && personalResponse.status === 400) {
+            console.warn('[LinkedIn Proxy] getProfiles: Projection failed, retrying without fields.');
+            personalResponse = await fetch('https://api.linkedin.com/rest/me', { headers });
+        }
 
         if (!personalResponse.ok) {
             const errorText = await personalResponse.text();
@@ -422,14 +440,14 @@ async function handleGetProfiles(request, response) {
         const personalData = await personalResponse.json();
         const memberUrn = `urn:li:person:${personalData.id}`;
 
-        // Map new field names from /rest/me
-        const firstName = personalData.givenName || '';
-        const lastName = personalData.familyName || '';
-        const profilePicture = personalData.picture || '';
+        // Map field names with fallbacks for different LinkedIn API versions/schemas
+        const firstName = personalData.givenName || personalData.firstName || personalData.localizedFirstName || '';
+        const lastName = personalData.familyName || personalData.lastName || personalData.localizedLastName || '';
+        const profilePicture = personalData.picture || personalData.profilePicture || '';
 
         const personal = {
             id: personalData.id,
-            name: `${firstName} ${lastName}`.trim(),
+            name: `${firstName} ${lastName}`.trim() || 'Usuário do LinkedIn',
             type: 'person',
             profilePicture: profilePicture
         };
@@ -456,7 +474,8 @@ async function handleGetProfiles(request, response) {
                     organizations = orgAclsData.elements.map(acl => {
                         const orgUrn = acl.organization;
                         const orgId = orgUrn.split(':').pop();
-                        const orgDetails = batchOrgData.results[orgId];
+                        // LinkedIn batch API might return keys as IDs or full URNs. Try both.
+                        const orgDetails = batchOrgData.results[orgId] || batchOrgData.results[orgUrn];
                         const orgName = orgDetails?.localizedName || orgDetails?.name?.localized?.en_US || 'Nome da Página Indisponível';
 
                         return {

--- a/api/settings.js
+++ b/api/settings.js
@@ -46,6 +46,11 @@ const settingsHandler = async (req, res) => {
       console.log(`[api/settings] Entering PUT block for user ${userId}.`);
       const settingsData = await parseBody(req);
 
+      if (!settingsData || (typeof settingsData === 'object' && Object.keys(settingsData).length === 0)) {
+        console.warn(`[api/settings] Received empty settings data for user ${userId}. Skipping save to prevent data loss.`);
+        return res.status(400).json({ error: 'Falha ao processar os dados das configurações. Tente novamente.' });
+      }
+
       const upsertQuery = `
         INSERT INTO settings (user_id, settings_data)
         VALUES ($1, $2)

--- a/api/utils.js
+++ b/api/utils.js
@@ -30,21 +30,69 @@ export const parseBody = async (req) => {
         }
     }
 
-    // Fallback: manually collect the stream
-    let body = '';
-    try {
-        const decoder = new TextDecoder();
-        // Check if req is an async iterable (Node.js Request stream)
-        if (Symbol.asyncIterator in req) {
-            for await (const chunk of req) {
-                body += decoder.decode(chunk);
+    // Fallback: manually collect the stream for Node.js
+    return new Promise((resolve) => {
+        let body = '';
+        const onData = (chunk) => {
+            body += chunk.toString();
+        };
+        const onEnd = () => {
+            req.removeListener('data', onData);
+            req.removeListener('end', onEnd);
+            req.removeListener('error', onError);
+            try {
+                resolve(body ? JSON.parse(body) : {});
+            } catch (e) {
+                console.error("[parseBody] JSON Parse Error:", e.message, "Body starts with:", body.substring(0, 50));
+                resolve({});
+            }
+        };
+        const onError = (err) => {
+            console.error("[parseBody] Stream Error:", err.message);
+            req.removeListener('data', onData);
+            req.removeListener('end', onEnd);
+            req.removeListener('error', onError);
+            resolve({});
+        };
+
+        if (req.on) {
+            if (req.readableEnded) {
+                return resolve({});
+            }
+            req.on('data', onData);
+            req.on('end', onEnd);
+            req.on('error', onError);
+
+            // Safety timeout to prevent indefinite hangs
+            setTimeout(() => {
+                req.removeListener('data', onData);
+                req.removeListener('end', onEnd);
+                req.removeListener('error', onError);
+                try {
+                    resolve(body ? JSON.parse(body) : {});
+                } catch (e) {
+                    resolve({});
+                }
+            }, 15000);
+        } else {
+            // If it doesn't have .on, and it reached here, it's not a standard stream we know how to handle.
+            // Try the async iterator as a last resort if it exists.
+            if (Symbol.asyncIterator in req) {
+                (async () => {
+                    try {
+                        for await (const chunk of req) {
+                            body += new TextDecoder().decode(chunk);
+                        }
+                        resolve(body ? JSON.parse(body) : {});
+                    } catch (e) {
+                        resolve({});
+                    }
+                })();
+            } else {
+                resolve({});
             }
         }
-        return body ? JSON.parse(body) : {};
-    } catch (e) {
-        console.error("[parseBody] Error parsing body:", e.message);
-        return {};
-    }
+    });
 };
 
 export async function fetchWithRetry(url, options, retries = 5, initialBackoff = 3000) {

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -112,9 +112,9 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
         if (!response.ok) throw new Error('Falha ao buscar detalhes do usuário.');
         const data = await response.json();
 
-        // Map new field names from /rest/me (givenName, familyName)
-        const firstName = data.givenName || '';
-        const lastName = data.familyName || '';
+        // Map field names with fallbacks for different LinkedIn API versions/schemas
+        const firstName = data.givenName || data.firstName || data.localizedFirstName || '';
+        const lastName = data.familyName || data.lastName || data.localizedLastName || '';
 
         setConnectedUser({ localizedFirstName: firstName, localizedLastName: lastName });
       } catch (err) {


### PR DESCRIPTION
- Migrated LinkedIn profile fetching to API version 202601 with robust field fallbacks and projection retry logic.
- Implemented a more resilient `parseBody` utility in `api/utils.js` using Node.js stream events to prevent infinite hangs in Vercel.
- Updated `auth_token` cookie policy to `SameSite=Lax` to maintain session context during OAuth redirects.
- Fixed organization mapping in `api/linkedin-proxy.js` to handle both ID and URN keys in batch responses.
- Enhanced `SetupModal` and `SettingsContext` with distinct `isLoading` and `isSaving` states for better user feedback.
- Added validation to `api/settings.js` to prevent saving empty configurations on parsing failures.