### PR TITLE
fix: resolve LinkedIn connection 401 and infinite "Saving..." hang

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -440,9 +440,24 @@ async function handleGetProfiles(request, response) {
         const personalData = await personalResponse.json();
         const memberUrn = `urn:li:person:${personalData.id}`;
 
+        // Helper to extract localized strings from LinkedIn objects
+        const getLocalized = (obj) => {
+            if (!obj) return '';
+            if (typeof obj === 'string') return obj;
+            if (obj.localized) {
+                const locale = Object.keys(obj.localized)[0];
+                return obj.localized[locale] || '';
+            }
+            if (obj.preferredLocale && obj.localized) {
+               const localeKey = `${obj.preferredLocale.language}_${obj.preferredLocale.country}`;
+               return obj.localized[localeKey] || obj.localized[Object.keys(obj.localized)[0]] || '';
+            }
+            return '';
+        };
+
         // Map field names with fallbacks for different LinkedIn API versions/schemas
-        const firstName = personalData.givenName || personalData.firstName || personalData.localizedFirstName || '';
-        const lastName = personalData.familyName || personalData.lastName || personalData.localizedLastName || '';
+        const firstName = getLocalized(personalData.givenName || personalData.firstName || personalData.localizedFirstName);
+        const lastName = getLocalized(personalData.familyName || personalData.lastName || personalData.localizedLastName);
         const profilePicture = personalData.picture || personalData.profilePicture || '';
 
         const personal = {
@@ -476,7 +491,7 @@ async function handleGetProfiles(request, response) {
                         const orgId = orgUrn.split(':').pop();
                         // LinkedIn batch API might return keys as IDs or full URNs. Try both.
                         const orgDetails = batchOrgData.results[orgId] || batchOrgData.results[orgUrn];
-                        const orgName = orgDetails?.localizedName || orgDetails?.name?.localized?.en_US || 'Nome da Página Indisponível';
+                        const orgName = getLocalized(orgDetails?.localizedName || orgDetails?.name);
 
                         return {
                             id: orgId,

--- a/api/upload-client.js
+++ b/api/upload-client.js
@@ -1,26 +1,6 @@
 import { handleUpload } from '@vercel/blob/client';
 import { withAuth } from './middleware/auth.js';
-
-// Helper to parse body in a Vercel Node.js environment
-const getBody = async (req) => {
-  return new Promise((resolve, reject) => {
-    let body = '';
-    req.on('data', (chunk) => {
-      body += chunk.toString();
-    });
-    req.on('end', () => {
-      try {
-        // If the body is empty, resolve with null, otherwise parse it.
-        resolve(body ? JSON.parse(body) : null);
-      } catch (e) {
-        reject(e);
-      }
-    });
-    req.on('error', (err) => {
-      reject(err);
-    });
-  });
-};
+import { parseBody } from './utils.js';
 
 const handler = async (req, res) => {
   if (req.method !== 'POST') {
@@ -33,7 +13,7 @@ const handler = async (req, res) => {
 
   try {
     // Manually parse the JSON body from the request stream
-    const body = await getBody(req);
+    const body = await parseBody(req);
 
     if (!body) {
       return res.status(400).json({ error: 'Request body is empty or invalid.' });

--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -112,9 +112,19 @@ const LinkedinAuthSetup = ({ onBeforeRedirect }) => {
         if (!response.ok) throw new Error('Falha ao buscar detalhes do usuário.');
         const data = await response.json();
 
+        const getLocalized = (obj) => {
+            if (!obj) return '';
+            if (typeof obj === 'string') return obj;
+            if (obj.localized) {
+                const locale = Object.keys(obj.localized)[0];
+                return obj.localized[locale] || '';
+            }
+            return '';
+        };
+
         // Map field names with fallbacks for different LinkedIn API versions/schemas
-        const firstName = data.givenName || data.firstName || data.localizedFirstName || '';
-        const lastName = data.familyName || data.lastName || data.localizedLastName || '';
+        const firstName = getLocalized(data.givenName || data.firstName || data.localizedFirstName);
+        const lastName = getLocalized(data.familyName || data.lastName || data.localizedLastName);
 
         setConnectedUser({ localizedFirstName: firstName, localizedLastName: lastName });
       } catch (err) {


### PR DESCRIPTION
- Migrated LinkedIn API integration to version 202601.
- Implemented robust `parseBody` utility to fix request stream hangs in Vercel environment.
- Updated user profile handling to support LinkedIn's new localized name schema, fixing "Unknown User" and "[object Object]" display issues.
- Changed auth cookie to `SameSite=Lax` to maintain session context during OAuth redirects.
- Added defensive fallbacks for LinkedIn profile fetching and organization ACL lookups.
- Centralized LinkedIn text escaping and markdown utilities.
- Added backend validation for settings persistence to prevent data loss.