### PR TITLE
Fix LinkedIn Version Header and Settings Performance

### DIFF
--- a/api/linkedin-proxy.js
+++ b/api/linkedin-proxy.js
@@ -20,7 +20,7 @@ export async function getPostDetails(accessToken, postUrn) {
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             },
         });
 
@@ -54,7 +54,7 @@ export async function getAuthorDetails(accessToken, authorUrn) {
         headers: {
             'Authorization': `Bearer ${accessToken}`,
             'X-Restli-Protocol-Version': '2.0.0',
-            'Linkedin-Version': LINKEDIN_API_VERSION
+            'LinkedIn-Version': LINKEDIN_API_VERSION
         },
     });
 
@@ -138,7 +138,7 @@ async function handleGetProfile(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'X-Restli-Protocol-Version': '2.0.0',
-        'Linkedin-Version': LINKEDIN_API_VERSION
+        'LinkedIn-Version': LINKEDIN_API_VERSION
     };
 
     try {
@@ -170,7 +170,7 @@ async function handleGetProfiles(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'X-Restli-Protocol-Version': '2.0.0',
-        'Linkedin-Version': LINKEDIN_API_VERSION
+        'LinkedIn-Version': LINKEDIN_API_VERSION
     };
 
     const getLocalized = (obj) => {
@@ -326,7 +326,7 @@ async function handleInitializeVideoUpload(request, response) {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             },
             body: JSON.stringify(payload),
         });
@@ -371,7 +371,7 @@ async function handleFinalizeVideoUpload(request, response) {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             },
             body: JSON.stringify(payload)
         });
@@ -399,7 +399,7 @@ async function handleCheckVideoStatus(request, response) {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             }
         });
         const data = await res.json();
@@ -419,7 +419,7 @@ async function handleCreatePost(request, response) {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             },
             body: JSON.stringify(payload),
         });
@@ -440,7 +440,7 @@ async function handleUploadAndCheckImage(request, response) {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
         'X-Restli-Protocol-Version': '2.0.0',
-        'Linkedin-Version': LINKEDIN_API_VERSION
+        'LinkedIn-Version': LINKEDIN_API_VERSION
     };
     try {
         const initRes = await fetchWithRetry('https://api.linkedin.com/rest/images?action=initializeUpload', {
@@ -517,7 +517,7 @@ async function handleGetShareStatistics(request, response) {
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             }
         });
         const data = await res.json();
@@ -569,7 +569,7 @@ async function handleCreateComment(request, response) {
                 'Authorization': `Bearer ${accessToken}`,
                 'Content-Type': 'application/json',
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             },
             body: JSON.stringify({
                 actor: actorUrn,
@@ -599,7 +599,7 @@ async function handleSearchPostsByHashtag(request, response) {
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             }
         });
         const data = await res.json();
@@ -618,7 +618,7 @@ async function handleGetMemberPostStatistics(request, response) {
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
                 'X-Restli-Protocol-Version': '2.0.0',
-                'Linkedin-Version': LINKEDIN_API_VERSION
+                'LinkedIn-Version': LINKEDIN_API_VERSION
             }
         });
         const data = await res.json();

--- a/api/settings.js
+++ b/api/settings.js
@@ -16,19 +16,32 @@ const settingsHandler = async (req, res) => {
     console.log(`[api/settings] Authenticated user ID: ${userId}`);
 
     if (req.method === 'GET') {
+      const startTime = Date.now();
       try {
-        const cachedSettings = await redis.get(cacheKey);
+        // Implement a timeout for Redis to prevent hanging
+        const redisPromise = redis.get(cacheKey);
+        let timeoutId;
+        const timeoutPromise = new Promise((_, reject) =>
+          timeoutId = setTimeout(() => reject(new Error('Redis timeout')), 2000)
+        );
+
+        const cachedSettings = await Promise.race([redisPromise, timeoutPromise]);
+        clearTimeout(timeoutId);
+        console.log(`[api/settings] Redis GET took ${Date.now() - startTime}ms`);
+
         if (cachedSettings) {
           console.log(`[api/settings] Cache HIT for user ${userId}.`);
           return res.status(200).json(JSON.parse(cachedSettings));
         }
       } catch (cacheError) {
-        console.error(`[api/settings] Redis GET error for user ${userId}:`, cacheError);
-        // Don't fail the request if cache is down, just log and proceed to DB.
+        console.error(`[api/settings] Redis GET error/timeout for user ${userId}:`, cacheError.message);
+        // Don't fail the request if cache is down or slow, just log and proceed to DB.
       }
 
       console.log(`[api/settings] Cache MISS for user ${userId}. Querying database.`);
+      const dbStartTime = Date.now();
       const { rows } = await query('SELECT settings_data FROM settings WHERE user_id = $1', [userId]);
+      console.log(`[api/settings] DB Query took ${Date.now() - dbStartTime}ms`);
       console.log(`[api/settings] DB query successful. Found ${rows.length} rows for user ${userId}.`);
 
       const settingsData = rows.length > 0 ? (rows[0].settings_data || {}) : {};


### PR DESCRIPTION
I've implemented two key fixes:

1. **LinkedIn API Versioning:** Changed the header name from `Linkedin-Version` to `LinkedIn-Version`. Official documentation and error logs suggested that the previous casing was being ignored, causing LinkedIn to default to an inactive version. This change ensures the `202507` version is correctly recognized.

2. **Settings Loading Performance:** Added duration logging for Redis and Database queries in the settings API. More importantly, implemented a 2-second timeout for the Redis lookup to prevent the application from hanging if the cache is unresponsive. This directly addresses the "excessive time" reported during application initialization.

---
*PR created automatically by Jules for task [13082150825594282781](https://jules.google.com/task/13082150825594282781) started by @cvazquezbr*