### PR TITLE
fix: resolve useRef ReferenceError, implement robust LinkedIn fallbac…

### DIFF
--- a/src/components/LinkedinAuthSetup.jsx
+++ b/src/components/LinkedinAuthSetup.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   Dialog,
   DialogTitle,


### PR DESCRIPTION
…ks, and atomic persistence

- Fixed 'useRef is not defined' ReferenceError in LinkedinAuthSetup.jsx.
- Standardized LinkedIn interaction via fetchLinkedInWithFallback in api/linkedin-proxy.js.
- Implemented brute-force versioning (confirmed 202606 baseline) and header casing fallbacks.
- Prioritized legacy /v2/ for organizational resources to bypass 426 errors.
- Fixed token persistence by re-fetching and merging settings before saving.
- Added useRef guard to prevent double-processing of OAuth codes.
- Optimized settings API with Redis timeouts and logging.