### PR TITLE
Add email notification for LinkedIn publications

### DIFF
--- a/add_notification_email_to_linkedin_schedules.sql
+++ b/add_notification_email_to_linkedin_schedules.sql
@@ -1,0 +1,2 @@
+ALTER TABLE linkedin_schedules ADD COLUMN IF NOT EXISTS notification_email VARCHAR(255);
+COMMENT ON COLUMN linkedin_schedules.notification_email IS 'Email para receber notificações de publicação bem-sucedida.';

--- a/api/cron/linkedin.js
+++ b/api/cron/linkedin.js
@@ -3,6 +3,7 @@ import { query } from '../db.js';
 import fetch from 'node-fetch';
 import { processDiscoverySession } from '../engagement/ai-worker.js';
 import { escapeLinkedinText, markdownToLinkedinText } from '../utils.js';
+import { sendPublicationNotification } from '../email-utils.js';
 
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET;
 const PROXY_BASE = process.env.VITE_API_BASE_URL || 'http://localhost:5173';
@@ -246,7 +247,7 @@ export async function handleRunScheduler(response) {
     // Query pending scheduled posts (schema public)
     const now = new Date();
     const { rows } = await query(
-      `SELECT ls.*, c.campaign_data, u.linkedin_access_token
+      `SELECT ls.*, c.campaign_data, c.name as campaign_name, u.linkedin_access_token
              FROM linkedin_schedules ls
              JOIN users u ON ls.user_id = u.id
              LEFT JOIN campaigns c ON ls.campaign_id = c.id
@@ -563,6 +564,24 @@ export async function handleRunScheduler(response) {
 
           if (updateResult.rowCount === 0) {
             throw new Error(`DB update failed for post ${postId}. Post was published but its status could not be updated in the database.`);
+          }
+
+          // Send notification email if specified
+          if (row.notification_email) {
+            try {
+              const campaignTitle = row.campaign_name || payload.titulo || (payload.content && payload.content.titulo) || 'Publicação no LinkedIn';
+              const postText = (payload.content && payload.content.fullText) || payload.conteudo || payload.fullText || '';
+
+              await sendPublicationNotification({
+                to: row.notification_email,
+                campaignTitle,
+                postUrl,
+                postContent: postText
+              });
+              console.log(`[Cron LinkedIn] Notification email sent for post ${postId} to ${row.notification_email}`);
+            } catch (emailErr) {
+              console.error(`[Cron LinkedIn] Failed to send notification email for post ${postId}:`, emailErr);
+            }
           }
 
         } else {

--- a/api/email-utils.js
+++ b/api/email-utils.js
@@ -1,0 +1,68 @@
+import nodemailer from 'nodemailer';
+
+/**
+ * Sends a notification email when a LinkedIn post is successfully published.
+ *
+ * @param {Object} params
+ * @param {string} params.to - The recipient email address.
+ * @param {string} params.campaignTitle - The title of the campaign.
+ * @param {string} params.postUrl - The URL of the published LinkedIn post.
+ * @param {string} params.postContent - The full content of the post.
+ */
+export async function sendPublicationNotification({ to, campaignTitle, postUrl, postContent }) {
+    if (!to) {
+        console.warn('[Email Utils] No recipient email provided for notification.');
+        return;
+    }
+
+    try {
+        const transporter = nodemailer.createTransport({
+            host: process.env.EMAIL_HOST,
+            port: process.env.EMAIL_PORT,
+            secure: process.env.EMAIL_PORT == 465, // true for 465, false for other ports
+            auth: {
+                user: process.env.EMAIL_USER,
+                pass: process.env.EMAIL_PASS,
+            },
+        });
+
+        // Truncate content to 180 characters for the preview
+        const contentPreview = postContent && postContent.length > 180
+            ? postContent.substring(0, 177) + '...'
+            : postContent;
+
+        const mailOptions = {
+            from: `"${process.env.EMAIL_FROM_NAME || 'Midiator'}" <${process.env.EMAIL_FROM_ADDRESS}>`,
+            to: to,
+            subject: `Publicação Realizada: ${campaignTitle}`,
+            html: `
+                <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; border: 1px solid #eee; padding: 20px; border-radius: 10px;">
+                    <h2 style="color: #0077B5;">Sua publicação está no ar!</h2>
+                    <p>Olá,</p>
+                    <p>A publicação da campanha <strong>"${campaignTitle}"</strong> foi realizada com sucesso no LinkedIn.</p>
+
+                    <div style="background-color: #f3f6f8; padding: 15px; border-radius: 5px; margin: 20px 0;">
+                        <p style="margin-top: 0; color: #666; font-size: 0.9em;">Prévia do conteúdo:</p>
+                        <p style="font-style: italic; color: #333;">"${contentPreview}"</p>
+                    </div>
+
+                    <p style="text-align: center; margin: 30px 0;">
+                        <a href="${postUrl}" style="background-color: #0077B5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; font-weight: bold; display: inline-block;">Ver publicação no LinkedIn</a>
+                    </p>
+
+                    <hr style="border: 0; border-top: 1px solid #eee; margin: 30px 0;">
+                    <p style="font-size: 0.8em; color: #999; text-align: center;">
+                        Este é um e-mail automático enviado pelo Midiator.
+                    </p>
+                </div>
+            `,
+        };
+
+        const info = await transporter.sendMail(mailOptions);
+        console.log(`[Email Utils] Notification sent to ${to}: ${info.messageId}`);
+        return info;
+    } catch (error) {
+        console.error('[Email Utils] Error sending notification email:', error);
+        throw error;
+    }
+}

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -1,6 +1,7 @@
 import { withAuth } from './middleware/auth.js';
 import { query } from './db.js';
 import { parseBody } from './utils.js';
+import { sendPublicationNotification } from './email-utils.js';
 
 // Helper function to create a schedule
 async function handleCreateSchedule(request, response) {
@@ -12,7 +13,8 @@ async function handleCreateSchedule(request, response) {
             content,
             authorUrn,
             status = 'scheduled', // Default to 'scheduled'
-            linkedin_post_url = null
+            linkedin_post_url = null,
+            notification_email = null
         } = request.body.payload;
 
         if (!scheduled_at || !content || !authorUrn) {
@@ -30,8 +32,8 @@ async function handleCreateSchedule(request, response) {
         const contentObject = typeof content === 'string' ? JSON.parse(content) : content;
 
         const { rows } = await query(
-            `INSERT INTO linkedin_schedules (user_id, campaign_id, parent_id, scheduled_at, user_selected_time, post_content, status, linkedin_post_url, linkedin_post_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *`,
+            `INSERT INTO linkedin_schedules (user_id, campaign_id, parent_id, scheduled_at, user_selected_time, post_content, status, linkedin_post_url, linkedin_post_id, notification_email)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *`,
             [
                 userId,
                 campaign_id || null,
@@ -41,11 +43,41 @@ async function handleCreateSchedule(request, response) {
                 JSON.stringify({ ...contentObject, authorUrn }),
                 status,
                 linkedin_post_url,
-                linkedin_post_id
+                linkedin_post_id,
+                notification_email
             ]
         );
 
-        return response.status(201).json(rows[0]);
+        const newSchedule = rows[0];
+
+        // If immediately published, send notification if email is provided
+        if (status === 'published' && notification_email && linkedin_post_url) {
+            try {
+                let campaignTitle = contentObject.titulo || 'Publicação no LinkedIn';
+
+                // Try to get campaign name if campaign_id is provided
+                if (campaign_id) {
+                    const { rows: campRows } = await query('SELECT name FROM campaigns WHERE id = $1', [campaign_id]);
+                    if (campRows.length > 0) {
+                        campaignTitle = campRows[0].name;
+                    }
+                }
+
+                const postText = contentObject.fullText || contentObject.conteudo || '';
+
+                await sendPublicationNotification({
+                    to: notification_email,
+                    campaignTitle,
+                    postUrl: linkedin_post_url,
+                    postContent: postText
+                });
+            } catch (emailErr) {
+                console.error('[Schedule API] Failed to send immediate notification:', emailErr);
+                // We don't fail the request if only the email fails
+            }
+        }
+
+        return response.status(201).json(newSchedule);
     } catch (error) {
         console.error('Error creating schedule:', error);
         return response.status(500).json({ error: 'Internal Server Error' });

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -658,6 +658,19 @@ const Campaign = ({
                                     {isGeneratingSummaryMedio ? 'Gerando...' : 'Gerar'}
                                 </Button>
                             </Grid>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="Email de Notificação"
+                                    value={campaignContent.notification_email || ''}
+                                    onChange={(e) => setCampaignState(prev => ({
+                                        ...prev,
+                                        campaignContent: { ...campaignContent, notification_email: e.target.value }
+                                    }))}
+                                    variant="outlined"
+                                    fullWidth
+                                    placeholder="email@exemplo.com (para receber o link da publicação)"
+                                />
+                            </Grid>
                             <Grid item xs={12} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                                 <TextField
                                     label="Conteúdo Pequeno (máx. 130 caracteres)"

--- a/src/components/Publisher.jsx
+++ b/src/components/Publisher.jsx
@@ -664,6 +664,7 @@ const Publisher = React.memo(({
         campaign_id: selectedCampaignId || null,
         scheduled_at: mainPostUtcDate.toISOString(),
         authorUrn: `urn:li:${selectedTarget.type}:${selectedTarget.id}`,
+        notification_email: campaignContent?.notification_email || null,
         content: {
             // Salva o texto final, já formatado, para garantir consistência.
             fullText: content,
@@ -702,6 +703,7 @@ const Publisher = React.memo(({
             parent_id: mainPostSchedule.id,
             scheduled_at: followupUtcDate.toISOString(),
             authorUrn: `urn:li:${selectedTarget.type}:${selectedTarget.id}`,
+            notification_email: campaignContent?.notification_email || null,
             content: {
               titulo: post.titulo || '',
               conteudo: post.conteudo || '',
@@ -842,6 +844,7 @@ const Publisher = React.memo(({
                 campaign_id: selectedCampaignId || null,
                 scheduled_at: new Date().toISOString(), // Immediate publication
                 authorUrn: `urn:li:${selectedTarget.type}:${selectedTarget.id}`,
+                notification_email: campaignContent?.notification_email || null,
                 content: {
                     titulo: campaignContent?.titulo || 'Publicação Avulsa',
                     conteudo: content, // Use the final content from the text field


### PR DESCRIPTION
This change introduces an email notification system for LinkedIn publications. 

Key changes:
- Database: Added a `notification_email` column to the `linkedin_schedules` table.
- Backend: Created a new `api/email-utils.js` to handle sending emails via nodemailer.
- API & Cron: Modified `api/schedule.js` and `api/cron/linkedin.js` to trigger a success email containing the LinkedIn post link, campaign title, and a 180-character content preview.
- Frontend: Added a new "Email de Notificação" field in the Campaign editor (Main Content tab) and ensured it's correctly passed during the publication/scheduling process.

---
*PR created automatically by Jules for task [15803651788523786870](https://jules.google.com/task/15803651788523786870) started by @cvazquezbr*