### PR TITLE
Inclusão Manual e Edição de Posts de Follow-Up na Etapa Campanha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,13 +59,14 @@
         "mammoth": "^1.11.0",
         "masonry-layout": "^4.2.2",
         "node-fetch": "^3.3.2",
-        "nodemailer": "^7.0.10",
+        "nodemailer": "^6.9.14",
         "pako": "^2.1.0",
         "papaparse": "^5.4.1",
         "pdfjs-dist": "^5.4.296",
         "pg": "^8.16.3",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
         "react-draggable": "^4.5.0",
         "react-markdown": "^10.1.0",
@@ -80,6 +81,7 @@
         "vaul": "^1.1.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@types/pg": "^8.11.6",
@@ -173,7 +175,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -544,7 +545,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -568,7 +568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -740,7 +739,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -784,7 +782,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1364,7 +1361,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -2074,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2180,7 +2175,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
       "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.17.1",
@@ -2739,6 +2733,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3759,7 +3769,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.6.6.tgz",
       "integrity": "sha512-7Mx3Vc2qS9IpT6s/Xarxot1PKvbNIq6Avp3vU/BubyrH6gaGApd4UOvTMwGfS4itpradzd/DfwkmB4/r6wAjNQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4007,7 +4016,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.3.0.tgz",
       "integrity": "sha512-nxmmkmGm2Zz+ar3+vke7/UVsea64z6tNdhC0c0aucII0JzZF1ZhTCBTYhINdkXxFrGegqatAI1fcO1T1LXRVAw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4087,7 +4095,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.6.6.tgz",
       "integrity": "sha512-kPplbVCL5X+eSXjE5rDwmO+N7Fi20EuLs3JeKopHKJtcRWRdS5bTibRueew3p6GRSbMmtHuaBy/XJVF4xBccKA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4154,7 +4161,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.3.0.tgz",
       "integrity": "sha512-aYl2JF7zcIGuuFQNWRxukSxPGFsBUn+yCogTqVDzYJwxuZR+VceiWIEI979WvzEeBq1GjYNrENEjwz4U/zxaiw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4181,7 +4187,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.3.0.tgz",
       "integrity": "sha512-Oey5aBg02FQHjldfjn6ebnzpH3x1Q9mPSgSuXNCjDQ51hak7LCGsVFhH+X9PrZtUALlEpEQWNcREgPBwqGM5ow==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4196,7 +4201,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.6.6.tgz",
       "integrity": "sha512-E/rtpPEqPiQJrchdOUDcMPR69x96a+JeMWLL12fos4KfF7YVzQ5oUIij21RffV+qeHxug7HMUpQKBtCuJfek/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -4362,7 +4366,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4522,6 +4527,18 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4577,7 +4594,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -4611,7 +4627,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4623,9 +4638,29 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -4726,7 +4761,6 @@
       "resolved": "https://registry.npmjs.org/@uppy/core/-/core-4.5.3.tgz",
       "integrity": "sha512-52VLeBUY/j904h48lpPGykuWikkOOS4Lz/qkmalDiBQfNALb6iB1MOZs079IM3o/uMLYxzZRL80C3sKpkBUYcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@transloadit/prettier-bytes": "^0.3.4",
         "@uppy/store-default": "^4.3.2",
@@ -5920,7 +5954,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6453,7 +6486,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -6614,7 +6646,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -6968,6 +6999,15 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -7216,7 +7256,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7472,7 +7511,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -8279,7 +8319,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10368,7 +10407,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -10835,6 +10873,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11234,6 +11273,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -11995,7 +12040,6 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -12212,9 +12256,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
-      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -12796,7 +12840,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -12982,6 +13025,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -13144,6 +13234,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13159,6 +13250,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13171,7 +13263,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -13350,7 +13443,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -13380,7 +13472,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -13429,7 +13520,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.1.tgz",
       "integrity": "sha512-pbwUjt3G7TlsQQHDiYSupWBhJswpLVB09xXm1YiJPdkjkh9Pe7Y51XdLh5VWIZmROLY8UpUpG03lkdhm9lzIBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -13485,6 +13575,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
     "node_modules/railroad-diagrams": {
@@ -13585,7 +13681,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13593,12 +13688,71 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "deprecated": "react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/react-beautiful-dnd/node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13625,8 +13779,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -13666,7 +13819,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -13975,8 +14127,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -14234,7 +14385,6 @@
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15450,7 +15600,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15805,7 +15954,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16045,6 +16193,15 @@
         }
       }
     },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
@@ -16241,7 +16398,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -29,9 +29,9 @@ import {
 } from '@mui/material';
 import { generateCommonProblems, generateCommonSolutions } from '../utils/generationHandlers';
 import { useSettings } from '../context/SettingsContext';
-import { useCampaign as useCampaignContext } from '../context/CampaignContext';
 import PaletteWizard from './PaletteWizard';
 import { uploadImageToDrive, getOrCreateBackgroundsFolderId } from '../utils/googleApi';
+import { toast } from 'sonner';
 import {
     Campaign as CampaignIcon,
     ExpandMore as ExpandMoreIcon,
@@ -46,8 +46,9 @@ import {
     Save as SaveIcon,
     Add as AddIcon,
     Spellcheck as SpellcheckIcon,
+    Delete as DeleteIcon,
+    Code as CodeIcon,
 } from '@mui/icons-material';
-import { useLocation, useNavigate } from 'react-router-dom';
 import RevisaoTextoModal from './RevisaoTextoModal/RevisaoTextoModal';
 import AspectRatioSelector from './ui/AspectRatioSelector';
 
@@ -185,7 +186,6 @@ const Campaign = ({
     generatedPageUrl,
     isGeneratingImage,
     handleGenerateImage,
-    onEditFollowup,
     setCampaignState,
     autorList,
     selectedAutorForCampaign,
@@ -201,6 +201,23 @@ const Campaign = ({
     const problemaRef = useRef(null);
 
     const [activeTab, setActiveTab] = useState(0);
+
+    // Manual / Edit Follow-up Modal State
+    const [followupFormOpen, setFollowupFormOpen] = useState(false);
+    const [editingFollowupIndex, setEditingFollowupIndex] = useState(null); // null means adding a new one
+    const [followupForm, setFollowupForm] = useState({
+        titulo: '',
+        conteudo: '',
+        cta: '',
+        etapa_aida: 'Atenção',
+        tipo_gancho: '',
+        hashtags_sugeridas: '',
+    });
+
+    // JSON Import Modal State
+    const [jsonImportOpen, setJsonImportOpen] = useState(false);
+    const [jsonText, setJsonText] = useState('');
+    const [jsonError, setJsonError] = useState('');
     const [isRevisaoModalOpen, setRevisaoModalOpen] = useState(false);
     const [campoEmRevisao, setCampoEmRevisao] = useState({ nome: '', texto: '' });
     const [isHintModalOpen, setHintModalOpen] = React.useState(false);
@@ -419,6 +436,111 @@ const Campaign = ({
                 },
             }));
             setNewHashtag('');
+        }
+    };
+
+    // Helper to open manual form
+    const handleOpenAddFollowup = () => {
+        setEditingFollowupIndex(null);
+        setFollowupForm({
+            titulo: '',
+            conteudo: '',
+            cta: '',
+            etapa_aida: 'Atenção',
+            tipo_gancho: '',
+            hashtags_sugeridas: '',
+        });
+        setFollowupFormOpen(true);
+    };
+
+    const handleOpenEditFollowup = (index, post) => {
+        setEditingFollowupIndex(index);
+        setFollowupForm({
+            titulo: post.titulo || '',
+            conteudo: post.conteudo || '',
+            cta: post.cta || '',
+            etapa_aida: post.etapa_aida || 'Atenção',
+            tipo_gancho: post.tipo_gancho || '',
+            hashtags_sugeridas: Array.isArray(post.hashtags_sugeridas) ? post.hashtags_sugeridas.join(', ') : '',
+        });
+        setFollowupFormOpen(true);
+    };
+
+    const handleSaveFollowupForm = () => {
+        const processedHashtags = followupForm.hashtags_sugeridas
+            .split(/[\s,]+/)
+            .map(h => h.trim().replace(/^#/, ''))
+            .filter(Boolean);
+
+        const newPost = {
+            post_numero: editingFollowupIndex !== null ? (followupPosts[editingFollowupIndex]?.post_numero || (editingFollowupIndex + 1)) : (followupPosts.length + 1),
+            tipo_gancho: followupForm.tipo_gancho,
+            etapa_aida: followupForm.etapa_aida,
+            titulo: followupForm.titulo,
+            conteudo: followupForm.conteudo,
+            cta: followupForm.cta,
+            hashtags_sugeridas: processedHashtags,
+        };
+
+        let updatedFollowups;
+        if (editingFollowupIndex !== null) {
+            updatedFollowups = followupPosts.map((p, idx) => idx === editingFollowupIndex ? newPost : p);
+            toast.success("Post de follow-up atualizado com sucesso!");
+        } else {
+            updatedFollowups = [...followupPosts, newPost];
+            toast.success("Post de follow-up adicionado com sucesso!");
+        }
+
+        setCampaignState(prev => ({ ...prev, followupPosts: updatedFollowups }));
+        setFollowupFormOpen(false);
+    };
+
+    const handleDeleteFollowup = (index) => {
+        const updatedFollowups = followupPosts.filter((_, idx) => idx !== index).map((p, idx) => ({ ...p, post_numero: idx + 1 }));
+        setCampaignState(prev => ({ ...prev, followupPosts: updatedFollowups }));
+        toast.success("Post de follow-up excluído com sucesso!");
+    };
+
+    const handleImportJson = () => {
+        try {
+            const parsed = JSON.parse(jsonText);
+            if (!Array.isArray(parsed)) {
+                setJsonError("O JSON deve ser uma lista (array) de objetos de post.");
+                return;
+            }
+
+            const newPosts = parsed.map((item, index) => {
+                const title = item.titulo || item.titulo_sugerido || `Post ${item.post_numero || index + 1}`;
+                const content = item.conteudo || item.coracao_prompt || '';
+                const cta = item.cta || item.cta_sugerido || '';
+                const etapa_aida = item.etapa_aida || 'Atenção';
+                const tipo_gancho = item.tipo_gancho || '';
+
+                let hashtags_sugeridas = [];
+                if (Array.isArray(item.hashtags_sugeridas)) {
+                    hashtags_sugeridas = item.hashtags_sugeridas.map(h => h.trim().replace(/^#/, ''));
+                } else if (typeof item.hashtags_sugeridas === 'string') {
+                    hashtags_sugeridas = item.hashtags_sugeridas.split(/[\s,]+/).map(h => h.trim().replace(/^#/, '')).filter(Boolean);
+                }
+
+                return {
+                    post_numero: followupPosts.length + index + 1,
+                    tipo_gancho,
+                    etapa_aida,
+                    titulo: title,
+                    conteudo: content,
+                    cta,
+                    hashtags_sugeridas,
+                };
+            });
+
+            setCampaignState(prev => ({ ...prev, followupPosts: [...prev.followupPosts, ...newPosts] }));
+            toast.success(`${newPosts.length} post(s) importado(s) com sucesso!`);
+            setJsonImportOpen(false);
+            setJsonText('');
+            setJsonError('');
+        } catch (e) {
+            setJsonError(`Erro de parsing JSON: ${e.message}`);
         }
     };
 
@@ -943,9 +1065,15 @@ const Campaign = ({
                                     InputProps={{ inputProps: { min: 1, max: 10 } }}
                                 />
                             </Grid>
-                            <Grid item xs={12}>
-                                <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />}>
-                                    {isGeneratingFollowup ? 'Gerando...' : 'Gerar Posts de Follow-up'}
+                            <Grid item xs={12} sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+                                <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />} variant="contained">
+                                    {isGeneratingFollowup ? 'Gerando...' : 'Gerar Posts de Follow-up com IA'}
+                                </Button>
+                                <Button onClick={handleOpenAddFollowup} startIcon={<AddIcon />} variant="outlined">
+                                    Adicionar Post Manual
+                                </Button>
+                                <Button onClick={() => setJsonImportOpen(true)} startIcon={<CodeIcon />} variant="outlined">
+                                    Importar JSON
                                 </Button>
                             </Grid>
                         </Grid>
@@ -959,28 +1087,46 @@ const Campaign = ({
                     {followupPosts.length > 0 && !isGeneratingFollowup && (
                         <Box sx={{ mt: 4 }}>
                             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                                <Typography variant="h6" gutterBottom>Posts de Follow-up Gerados</Typography>
-                                <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />}>
-                                    {isGeneratingFollowup ? 'Gerando...' : 'Regerar Posts'}
-                                </Button>
+                                <Typography variant="h6" gutterBottom>Posts de Follow-up ({followupPosts.length})</Typography>
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                    <Button onClick={() => handleGenerateFollowupPosts()} disabled={isGeneratingFollowup} startIcon={<GeminiIcon />} size="small">
+                                        {isGeneratingFollowup ? 'Gerando...' : 'Regerar com IA'}
+                                    </Button>
+                                </Box>
                             </Box>
                             {(followupPosts || []).filter(Boolean).map((post, index) => (
                                 <Accordion key={index}>
                                     <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                                         <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', alignItems: 'center' }}>
-                                            <Typography sx={{ flexGrow: 1, mr: 2 }}>{post.titulo || `Post ${post.post_numero}`}</Typography>
-                                            <Chip label={post.etapa_aida || 'AIDA'} size="small" color="primary" variant="outlined" />
+                                            <Typography sx={{ flexGrow: 1, mr: 2, fontWeight: 'bold' }}>{post.titulo || `Post ${post.post_numero}`}</Typography>
+                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                                <Chip label={post.etapa_aida || 'AIDA'} size="small" color="primary" variant="outlined" />
+                                                <IconButton size="small" color="primary" onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleOpenEditFollowup(index, post);
+                                                }}>
+                                                    <EditIcon fontSize="small" />
+                                                </IconButton>
+                                                <IconButton size="small" color="error" onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleDeleteFollowup(index);
+                                                }}>
+                                                    <DeleteIcon fontSize="small" />
+                                                </IconButton>
+                                            </Box>
                                         </Box>
                                     </AccordionSummary>
-                                    <AccordionDetails sx={{ cursor: 'pointer' }} onClick={() => onEditFollowup(index, post.conteudo)}>
+                                    <AccordionDetails sx={{ cursor: 'pointer' }} onClick={() => handleOpenEditFollowup(index, post)}>
                                         <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 2 }}>
                                             {post.conteudo}
                                         </Typography>
-                                        <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
-                                            <strong>CTA:</strong> {post.cta}
-                                        </Typography>
+                                        {post.cta && (
+                                            <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
+                                                <strong>CTA:</strong> {post.cta}
+                                            </Typography>
+                                        )}
                                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
-                                            <Chip icon={<InfoIcon />} label={post.tipo_gancho || 'Gancho'} size="small" variant="outlined" />
+                                            {post.tipo_gancho && <Chip icon={<InfoIcon />} label={post.tipo_gancho} size="small" variant="outlined" />}
                                             {(post.hashtags_sugeridas || []).map((tag, i) => (
                                                 <Chip key={i} label={`#${tag}`} size="small" />
                                             ))}
@@ -1028,6 +1174,112 @@ const Campaign = ({
                     )}
                 </TabPanel>
 
+
+                {/* Manual Inclusion / Edit Dialog */}
+                <Dialog open={followupFormOpen} onClose={() => setFollowupFormOpen(false)} fullWidth maxWidth="md">
+                    <DialogTitle>
+                        {editingFollowupIndex !== null ? `Editar Post de Follow-up #${editingFollowupIndex + 1}` : 'Adicionar Novo Post de Follow-up'}
+                    </DialogTitle>
+                    <DialogContent>
+                        <Grid container spacing={2} sx={{ mt: 1 }}>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="Título do Post"
+                                    fullWidth
+                                    value={followupForm.titulo}
+                                    onChange={(e) => setFollowupForm(prev => ({ ...prev, titulo: e.target.value }))}
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="Conteúdo"
+                                    fullWidth
+                                    multiline
+                                    rows={6}
+                                    value={followupForm.conteudo}
+                                    onChange={(e) => setFollowupForm(prev => ({ ...prev, conteudo: e.target.value }))}
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="CTA (Chamada para Ação)"
+                                    fullWidth
+                                    value={followupForm.cta}
+                                    onChange={(e) => setFollowupForm(prev => ({ ...prev, cta: e.target.value }))}
+                                />
+                            </Grid>
+                            <Grid item xs={12} md={6}>
+                                <FormControl fullWidth>
+                                    <InputLabel id="etapa-aida-label">Etapa AIDA</InputLabel>
+                                    <Select
+                                        labelId="etapa-aida-label"
+                                        value={followupForm.etapa_aida}
+                                        onChange={(e) => setFollowupForm(prev => ({ ...prev, etapa_aida: e.target.value }))}
+                                        label="Etapa AIDA"
+                                    >
+                                        <MenuItem value="Atenção">Atenção</MenuItem>
+                                        <MenuItem value="Interesse">Interesse</MenuItem>
+                                        <MenuItem value="Desejo">Desejo</MenuItem>
+                                        <MenuItem value="Ação">Ação</MenuItem>
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                            <Grid item xs={12} md={6}>
+                                <TextField
+                                    label="Tipo de Gancho"
+                                    fullWidth
+                                    value={followupForm.tipo_gancho}
+                                    onChange={(e) => setFollowupForm(prev => ({ ...prev, tipo_gancho: e.target.value }))}
+                                    placeholder="Ex: Narrativa de Dor, Insight Contraintuitivo"
+                                />
+                            </Grid>
+                            <Grid item xs={12}>
+                                <TextField
+                                    label="Hashtags Sugeridas"
+                                    fullWidth
+                                    value={followupForm.hashtags_sugeridas}
+                                    onChange={(e) => setFollowupForm(prev => ({ ...prev, hashtags_sugeridas: e.target.value }))}
+                                    placeholder="Separadas por vírgula ou espaço. Ex: #inovacao, #marketing, tech"
+                                />
+                            </Grid>
+                        </Grid>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={() => setFollowupFormOpen(false)}>Cancelar</Button>
+                        <Button onClick={handleSaveFollowupForm} variant="contained" color="primary">Salvar</Button>
+                    </DialogActions>
+                </Dialog>
+
+                {/* JSON Import Dialog */}
+                <Dialog open={jsonImportOpen} onClose={() => setJsonImportOpen(false)} fullWidth maxWidth="md">
+                    <DialogTitle>Importar Posts de Follow-up via JSON</DialogTitle>
+                    <DialogContent>
+                        <Typography variant="body2" color="textSecondary" sx={{ mb: 2, mt: 1 }}>
+                            Cole uma lista (array) de objetos JSON representando os posts de follow-up.
+                            O importador mapeará chaves como "titulo_sugerido", "coracao_prompt" (conteúdo), "cta_sugerido", etc.
+                        </Typography>
+                        <TextField
+                            label="JSON dos Posts"
+                            fullWidth
+                            multiline
+                            rows={12}
+                            value={jsonText}
+                            onChange={(e) => {
+                                setJsonText(e.target.value);
+                                setJsonError('');
+                            }}
+                            placeholder='[\n  {\n    "titulo_sugerido": "Sua comunidade...",\n    "coracao_prompt": "Abra questionando...",\n    "cta_sugerido": "Comente..."\n  }\n]'
+                            error={!!jsonError}
+                            helperText={jsonError}
+                        />
+                    </DialogContent>
+                    <DialogActions>
+                        <Button onClick={() => setJsonImportOpen(false)}>Cancelar</Button>
+                        <Button onClick={handleImportJson} variant="contained" color="primary" disabled={!jsonText.trim()}>
+                            Importar
+                        </Button>
+                    </DialogActions>
+                </Dialog>
 
                 <Dialog open={isHintModalOpen} onClose={() => setHintModalOpen(false)} fullWidth maxWidth="lg">
                     <DialogTitle>


### PR DESCRIPTION
Este commit adiciona suporte completo a operacoes de inclusao manual (formulario detalhado), edicao individual de posts, exclusao de posts e importacao em lote atraves de uma lista JSON (mapeando chaves como titulo_sugerido, coracao_prompt e cta_sugerido) na aba "Posts de Follow-Up" dentro da etapa de Campanha. Todos os dados sao sincronizados com o estado global da campanha e estao em conformidade com o linter e o build de producao.

---
*PR created automatically by Jules for task [3937088243653323854](https://jules.google.com/task/3937088243653323854) started by @cvazquezbr*