### PR TITLE
Allow direct campaign editing and multi-hashtag batch insertion

### DIFF
--- a/src/components/Campaign.jsx
+++ b/src/components/Campaign.jsx
@@ -266,6 +266,24 @@ const Campaign = ({
         }
     }, [campaignContent, prevCampaignContent, isGeneratingCampaign]);
 
+    useEffect(() => {
+        if (activeTab > 0 && !campaignContent) {
+            setCampaignState(prev => ({
+                ...prev,
+                campaignContent: {
+                    titulo: '',
+                    conteudo: '',
+                    conteudoMedio: '',
+                    conteudoPequeno: '',
+                    cta: '',
+                    hashtags: [],
+                    notification_email: '',
+                    conteudoFormatado: '',
+                }
+            }));
+        }
+    }, [activeTab, campaignContent, setCampaignState]);
+
     const handleTabChange = (event, newValue) => {
       setActiveTab(newValue);
     };
@@ -432,17 +450,32 @@ const Campaign = ({
     };
 
     const handleAddHashtag = () => {
-        const tagToAdd = newHashtag.trim();
-        if (tagToAdd) {
-            const currentHashtags = campaignContent.hashtags || [];
-            setCampaignState(prev => ({
-                ...prev,
-                campaignContent: {
-                    ...campaignContent,
-                    hashtags: [...currentHashtags, tagToAdd],
-                },
-            }));
-            setNewHashtag('');
+        const rawInput = newHashtag.trim();
+        if (rawInput) {
+            const parsedTags = rawInput
+                .split(/[\s,#]+/)
+                .map(t => t.trim())
+                .filter(Boolean);
+
+            if (parsedTags.length > 0) {
+                const currentHashtags = campaignContent?.hashtags || [];
+                const updatedHashtags = [...currentHashtags];
+
+                parsedTags.forEach(tag => {
+                    if (!updatedHashtags.includes(tag)) {
+                        updatedHashtags.push(tag);
+                    }
+                });
+
+                setCampaignState(prev => ({
+                    ...prev,
+                    campaignContent: {
+                        ...(campaignContent || {}),
+                        hashtags: updatedHashtags,
+                    },
+                }));
+                setNewHashtag('');
+            }
         }
     };
 
@@ -475,8 +508,8 @@ const Campaign = ({
 
     const handleSaveFollowupForm = () => {
         const processedHashtags = followupForm.hashtags_sugeridas
-            .split(/[\s,]+/)
-            .map(h => h.trim().replace(/^#/, ''))
+            .split(/[\s,#]+/)
+            .map(h => h.trim())
             .filter(Boolean);
 
         const newPost = {
@@ -527,7 +560,7 @@ const Campaign = ({
                 if (Array.isArray(item.hashtags_sugeridas)) {
                     hashtags_sugeridas = item.hashtags_sugeridas.map(h => h.trim().replace(/^#/, ''));
                 } else if (typeof item.hashtags_sugeridas === 'string') {
-                    hashtags_sugeridas = item.hashtags_sugeridas.split(/[\s,]+/).map(h => h.trim().replace(/^#/, '')).filter(Boolean);
+                    hashtags_sugeridas = item.hashtags_sugeridas.split(/[\s,#]+/).map(h => h.trim()).filter(Boolean);
                 }
 
                 return {
@@ -744,10 +777,10 @@ const Campaign = ({
                 <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
                     <Tabs value={activeTab} onChange={handleTabChange} aria-label="abas da campanha" variant="scrollable" scrollButtons="auto">
                         <Tab label="Problema e Solução" />
-                        <Tab label="Conteúdo Principal" disabled={!campaignContent} />
-                        <Tab label="Página" disabled={!campaignContent} />
-                        <Tab label="Posts de Follow-Up" disabled={!campaignContent} />
-                        <Tab label="Conteúdo WordPress" disabled={!campaignContent} />
+                        <Tab label="Conteúdo Principal" />
+                        <Tab label="Página" />
+                        <Tab label="Posts de Follow-Up" />
+                        <Tab label="Conteúdo WordPress" />
                     </Tabs>
                 </Box>
 
@@ -1052,6 +1085,7 @@ const Campaign = ({
                                     <TextField
                                         label="Nova Hashtag"
                                         size="small"
+                                        placeholder="Ex: #SRE #Metricas #FattoConsultoria"
                                         value={newHashtag}
                                         onChange={(e) => setNewHashtag(e.target.value)}
                                         onKeyDown={(e) => {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -604,7 +604,7 @@ function HomePage() {
   const canProceedToStep = (step) => {
     switch (step) {
       case 1: return true;
-      case 2: return campaignState.campaignContent !== null;
+      case 2: return true;
       case 3: return csvData.length > 0;
       case 4: return true;
       case 5: if (generatedPagesData.length === 0 || !generatedPagesData.every(img => img.url)) { toast.error("Gere todas as páginas antes de prosseguir."); return false; } return true;

--- a/test/hashtags.test.js
+++ b/test/hashtags.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+function parseHashtagSequence(rawInput, existingHashtags = []) {
+  if (!rawInput || !rawInput.trim()) return existingHashtags;
+  const parsedTags = rawInput
+    .trim()
+    .split(/[\s,#]+/)
+    .map(t => t.trim())
+    .filter(Boolean);
+
+  const updatedHashtags = [...existingHashtags];
+  parsedTags.forEach(tag => {
+    if (!updatedHashtags.includes(tag)) {
+      updatedHashtags.push(tag);
+    }
+  });
+  return updatedHashtags;
+}
+
+describe('Hashtag Sequence Parsing', () => {
+  it('parses a single string with multiple hashtags separated by space', () => {
+    const input = '#EstabilidadeOperacional #SRE #Metricas #FattoConsultoria #GovernancaTI';
+    const result = parseHashtagSequence(input);
+    expect(result).toEqual([
+      'EstabilidadeOperacional',
+      'SRE',
+      'Metricas',
+      'FattoConsultoria',
+      'GovernancaTI'
+    ]);
+  });
+
+  it('handles commas, extra spaces, and tags without #', () => {
+    const input = '#EstabilidadeOperacional, SRE, #Metricas  #FattoConsultoria';
+    const result = parseHashtagSequence(input);
+    expect(result).toEqual([
+      'EstabilidadeOperacional',
+      'SRE',
+      'Metricas',
+      'FattoConsultoria'
+    ]);
+  });
+
+  it('deduplicates tags against existing list', () => {
+    const existing = ['SRE', 'Metricas'];
+    const input = '#SRE #GovernancaTI #Metricas #NovaTag';
+    const result = parseHashtagSequence(input, existing);
+    expect(result).toEqual([
+      'SRE',
+      'Metricas',
+      'GovernancaTI',
+      'NovaTag'
+    ]);
+  });
+});


### PR DESCRIPTION
Enables direct navigation and editing across all campaign tabs without requiring generation from Problem and Solution first, and adds support for inserting multiple hashtags at once via space/comma/hash-delimited sequences.

---
*PR created automatically by Jules for task [5814769255363988262](https://jules.google.com/task/5814769255363988262) started by @cvazquezbr*