### PR TITLE
Adapt short post generation when problema/solução is missing

### DIFF
--- a/src/components/PostsCurtosStep.jsx
+++ b/src/components/PostsCurtosStep.jsx
@@ -49,6 +49,8 @@ const PostsCurtosStep = ({
   aspectRatio,
   setAspectRatio,
   sidebarOpen,
+  hasProblemaSolucao = true,
+  hasPosts = true,
 }) => {
   const [isDraggingOverSpreadsheet, setIsDraggingOverSpreadsheet] = useState(false);
   const [isGeminiKeyConfigured, setIsGeminiKeyConfigured] = useState(true);
@@ -141,6 +143,16 @@ const PostsCurtosStep = ({
                 {!isGeminiKeyConfigured && (
                   <Alert severity="warning" sx={{ mb: 2 }}>
                     A chave de API do Gemini não está configurada. Por favor, vá para <MuiLink component="button" variant="body2" onClick={() => setShowSetupModal(true)}>Configurações</MuiLink> para adicioná-la.
+                  </Alert>
+                )}
+                {!hasProblemaSolucao && !hasPosts && (
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    Nenhum post de origem ou problema/solução foi encontrado na campanha. Você pode digitar a descrição do conteúdo abaixo, ou utilizar <strong>Carregar Planilha</strong> ou <strong>Criação Manual</strong>.
+                  </Alert>
+                )}
+                {!hasProblemaSolucao && hasPosts && (
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    Sem problema/solução definidos. A IA utilizará os {promptNumRecords} post(s) da campanha (Post Principal e Follow-ups) como base para gerar os posts curtos.
                   </Alert>
                 )}
                 <Typography gutterBottom>Quantidade de Posts</Typography>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -22,6 +22,7 @@ import { checkAuthStatus } from '../utils/auth';
 import { getPersonas, savePersona, updatePersona } from '../utils/personaState';
 import { getAutores } from '../utils/autorState';
 import { getPalettes } from '../utils/paletteState';
+import { hasProblemaSolucao, getAvailableCampaignPosts, buildPromptTextFromPosts } from '../utils/campaignUtils';
 
 import MyCampaignsStep from '../components/MyCampaignsStep';
 import SharedCampaignsStep from '../components/SharedCampaignsStep';
@@ -357,6 +358,28 @@ function HomePage() {
     localStorage.setItem('darkMode', JSON.stringify(darkMode));
     document.documentElement.classList.toggle('dark-mode-active', darkMode);
   }, [darkMode]);
+
+  // Sincroniza a quantidade de posts e o texto base quando não houver problema/solução, mas existirem posts
+  useEffect(() => {
+    if (activeStep === 2) {
+      if (!hasProblemaSolucao(campaignState)) {
+        const posts = getAvailableCampaignPosts(campaignState);
+        if (posts.length > 0) {
+          const autoPromptText = buildPromptTextFromPosts(posts);
+          setCampaignState(prev => {
+            if (prev.promptNumRecords !== posts.length || prev.promptText !== autoPromptText) {
+              return {
+                ...prev,
+                promptNumRecords: posts.length,
+                promptText: autoPromptText,
+              };
+            }
+            return prev;
+          });
+        }
+      }
+    }
+  }, [activeStep, campaignState.problema, campaignState.solucao, campaignState.campaignContent, campaignState.followupPosts, setCampaignState]);
 
   const extractColorPalette = useCallback((url, setter) => {
     if (!url) { setter([]); return; }
@@ -936,10 +959,26 @@ function HomePage() {
   const handleGenerateIAContent = async () => {
     setIsGenerating(true); setGenerationStatus('Gerando posts...');
     try {
-      const { promptText, promptNumRecords } = campaignState;
+      let effectivePromptText = campaignState.promptText;
+      let effectivePromptNumRecords = campaignState.promptNumRecords;
+
+      if (!hasProblemaSolucao(campaignState)) {
+        const posts = getAvailableCampaignPosts(campaignState);
+        if (posts.length > 0) {
+          effectivePromptNumRecords = posts.length;
+          effectivePromptText = buildPromptTextFromPosts(posts);
+        } else if (!effectivePromptText?.trim()) {
+          toast.error('Nenhum conteúdo de post ou problema/solução foi fornecido.');
+          return;
+        }
+      } else if (!effectivePromptText?.trim()) {
+        toast.error('Por favor, forneça uma descrição do conteúdo para gerar com IA.');
+        return;
+      }
+
       const iaResponseText = await generateIAContent({
-        promptText,
-        promptNumRecords,
+        promptText: effectivePromptText,
+        promptNumRecords: effectivePromptNumRecords,
         model: settings.gemini_model,
         apiKey: settings.gemini_api_key
       });
@@ -1165,7 +1204,7 @@ function HomePage() {
               {activeStep === 0 && campaignsView === 'my-campaigns' && <MyCampaignsStep {...{ onEditCampaign: handleEditCampaign, onCreateNew: handleCreateNewCampaign, onCloneComplete: handleLoadClonedCampaign, autorList, personaList }} />}
               {activeStep === 0 && campaignsView === 'shared-campaigns' && <SharedCampaignsStep {...{ onEditCampaign: handleEditCampaign }} />}
               {activeStep === 1 && <Campaign {...{ steps, activeStep, ...campaignState, setCampaignState, isGeneratingCampaign, campaignGenerationFailed, generationError, handleGenerateCampaignContent, handleResetCampaign, handleExportHtml: () => exportHtml(memorialCampaignData), editingField, setEditingField: (field) => { setEditingField(field); setIsHtmlField(field === 'conteudoFormatado'); }, isGeneratingSummaryMedio, handleGenerateSummary, isGeneratingSummaryPequeno, isGeneratingConteudoFormatado, handleGenerateFormattedContent, isGeneratingFollowup: campaignState.isGeneratingFollowup, handleGenerateFollowupPosts, isGeneratingImage, handleGenerateImage, onEditFollowup: handleEditFollowup, palettes, autorList, selectedAutorForCampaign, personaList, selectedPersonaForCampaign, onRequestNewAutor: handleRequestNewAutor, onRequestNewPersona: handleRequestNewPersona, paletteId: campaignState.paletteId, customPalette: campaignState.customPalette }} />}
-              {activeStep === 2 && <PostsCurtosStep {...{ steps, inputMethod, setInputMethod, handleDrop, handleDragOver, fileInputRef, handleCSVUpload, downloadExampleCsv, setShowSetupModal, promptNumRecords: campaignState.promptNumRecords, setPromptNumRecords: (v) => setCampaignState({ promptNumRecords: v }), promptText: campaignState.promptText, setPromptText: (v) => setCampaignState({ promptText: v }), handleGenerateIAContent, isGenerating, csvData, csvHeaders, onDadosAlterados: handleDadosAlterados, darkMode, exportCsv: () => exportCsv(csvData, csvHeaders), aspectRatio, setAspectRatio: (v) => setCampaignState({ aspectRatio: v }), sidebarOpen }} />}
+              {activeStep === 2 && <PostsCurtosStep {...{ steps, inputMethod, setInputMethod, handleDrop, handleDragOver, fileInputRef, handleCSVUpload, downloadExampleCsv, setShowSetupModal, promptNumRecords: campaignState.promptNumRecords, setPromptNumRecords: (v) => setCampaignState({ promptNumRecords: v }), promptText: campaignState.promptText, setPromptText: (v) => setCampaignState({ promptText: v }), handleGenerateIAContent, isGenerating, csvData, csvHeaders, onDadosAlterados: handleDadosAlterados, darkMode, exportCsv: () => exportCsv(csvData, csvHeaders), aspectRatio, setAspectRatio: (v) => setCampaignState({ aspectRatio: v }), sidebarOpen, hasProblemaSolucao: hasProblemaSolucao(campaignState), hasPosts: getAvailableCampaignPosts(campaignState).length > 0 }} />}
               {activeStep === 3 && <ImageStep {...{ steps, isLoading, isDraggingOverImage: false, handleImageDrop: (e) => handleImageSelected(e.dataTransfer.files[0]), handleImageDragOver, handleImageDragEnter: () => {}, handleImageDragLeave: () => {}, imageInputRef, handleImageUpload: handleForegroundImageUpload, onOpenImageGallery: handleOpenImageGallery, initialFieldStyles: campaignState.initialFieldStyles, onImageDisplayedSizeChange: () => {}, onCsvDataUpdate: handleCsvRecordContentUpdate, originalImageSize, onZIndexChange: handleZIndexChange, isMobile, onDeselectField: () => setCampaignState({ selectedField: null }), onOpenHtmlEditor: (fieldId) => setEditingField(fieldId), currentPreviewIndex, setCurrentPreviewIndex, onFontScaleChange: (v) => setCampaignState({ fontScale: v }), templateFieldStyles: campaignState.templateFieldStyles, activeStep, addPendingAsset }} />}
               {activeStep === 4 &&
                 <PageGeneratorFrontendOnly

--- a/src/utils/campaignUtils.js
+++ b/src/utils/campaignUtils.js
@@ -184,3 +184,58 @@ export async function importPageSetToCampaign(pageSet) {
 
   return { campaign_data, pendingAssets };
 }
+
+/**
+ * Checks if a campaign has problem and solution defined.
+ * @param {object} campaignState - The campaign state.
+ * @returns {boolean}
+ */
+export function hasProblemaSolucao(campaignState) {
+  return Boolean(campaignState?.problema?.trim() && campaignState?.solucao?.trim());
+}
+
+/**
+ * Extracts all available posts (main post + follow-up posts) from campaignState.
+ * @param {object} campaignState - The campaign state.
+ * @returns {Array<{tipo: string, titulo: string, conteudo: string, cta: string}>}
+ */
+export function getAvailableCampaignPosts(campaignState) {
+  const posts = [];
+  const mainContent = campaignState?.campaignContent;
+  if (mainContent && (mainContent.titulo?.trim() || mainContent.conteudo?.trim())) {
+    posts.push({
+      tipo: 'Post Principal',
+      titulo: mainContent.titulo || '',
+      conteudo: mainContent.conteudo || '',
+      cta: mainContent.cta || '',
+    });
+  }
+  const followups = campaignState?.followupPosts || [];
+  followups.forEach((post, idx) => {
+    if (post && (post.titulo?.trim() || post.conteudo?.trim())) {
+      posts.push({
+        tipo: `Post Follow-up ${idx + 1}`,
+        titulo: post.titulo || '',
+        conteudo: post.conteudo || '',
+        cta: post.cta || '',
+      });
+    }
+  });
+  return posts;
+}
+
+/**
+ * Builds structured prompt text from available campaign posts.
+ * @param {Array<{tipo: string, titulo: string, conteudo: string, cta: string}>} posts - The list of available posts.
+ * @returns {string}
+ */
+export function buildPromptTextFromPosts(posts) {
+  if (!posts || posts.length === 0) return '';
+  return posts.map((post, idx) => {
+    const parts = [`--- ${post.tipo.toUpperCase()} (${idx + 1}/${posts.length}) ---`];
+    if (post.titulo) parts.push(`Título: ${post.titulo}`);
+    if (post.conteudo) parts.push(`Conteúdo: ${post.conteudo}`);
+    if (post.cta) parts.push(`CTA: ${post.cta}`);
+    return parts.join('\n');
+  }).join('\n\n');
+}

--- a/src/utils/campaignUtils.test.js
+++ b/src/utils/campaignUtils.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hasProblemaSolucao,
+  getAvailableCampaignPosts,
+  buildPromptTextFromPosts,
+} from './campaignUtils';
+
+describe('campaignUtils - short post generation helpers', () => {
+  describe('hasProblemaSolucao', () => {
+    it('returns true when both problema and solucao are non-empty', () => {
+      const campaignState = {
+        problema: 'Empresas não conseguem gerenciar o tempo.',
+        solucao: 'Um software de automação fácil de usar.',
+      };
+      expect(hasProblemaSolucao(campaignState)).toBe(true);
+    });
+
+    it('returns false when problema or solucao is missing or empty', () => {
+      expect(hasProblemaSolucao({})).toBe(false);
+      expect(hasProblemaSolucao({ problema: 'Apenas problema' })).toBe(false);
+      expect(hasProblemaSolucao({ solucao: 'Apenas solução' })).toBe(false);
+      expect(hasProblemaSolucao({ problema: '   ', solucao: '  ' })).toBe(false);
+    });
+  });
+
+  describe('getAvailableCampaignPosts', () => {
+    it('returns empty array when campaign has no posts', () => {
+      expect(getAvailableCampaignPosts({})).toEqual([]);
+    });
+
+    it('extracts main post and followup posts correctly', () => {
+      const campaignState = {
+        campaignContent: {
+          titulo: 'Título do Post Principal',
+          conteudo: 'Conteúdo do post principal.',
+          cta: 'Clique aqui',
+        },
+        followupPosts: [
+          {
+            titulo: 'Followup 1',
+            conteudo: 'Conteúdo do followup 1.',
+            cta: 'Saiba mais',
+          },
+          {
+            titulo: 'Followup 2',
+            conteudo: 'Conteúdo do followup 2.',
+            cta: 'Inscreva-se',
+          },
+        ],
+      };
+
+      const posts = getAvailableCampaignPosts(campaignState);
+      expect(posts.length).toBe(3);
+      expect(posts[0]).toEqual({
+        tipo: 'Post Principal',
+        titulo: 'Título do Post Principal',
+        conteudo: 'Conteúdo do post principal.',
+        cta: 'Clique aqui',
+      });
+      expect(posts[1]).toEqual({
+        tipo: 'Post Follow-up 1',
+        titulo: 'Followup 1',
+        conteudo: 'Conteúdo do followup 1.',
+        cta: 'Saiba mais',
+      });
+      expect(posts[2]).toEqual({
+        tipo: 'Post Follow-up 2',
+        titulo: 'Followup 2',
+        conteudo: 'Conteúdo do followup 2.',
+        cta: 'Inscreva-se',
+      });
+    });
+  });
+
+  describe('buildPromptTextFromPosts', () => {
+    it('returns empty string when no posts are provided', () => {
+      expect(buildPromptTextFromPosts([])).toBe('');
+      expect(buildPromptTextFromPosts(null)).toBe('');
+    });
+
+    it('formats posts into structured prompt text', () => {
+      const posts = [
+        {
+          tipo: 'Post Principal',
+          titulo: 'Título Main',
+          conteudo: 'Conteúdo Main',
+          cta: 'CTA Main',
+        },
+        {
+          tipo: 'Post Follow-up 1',
+          titulo: 'Título Followup',
+          conteudo: 'Conteúdo Followup',
+          cta: 'CTA Followup',
+        },
+      ];
+
+      const result = buildPromptTextFromPosts(posts);
+      expect(result).toContain('--- POST PRINCIPAL (1/2) ---');
+      expect(result).toContain('Título: Título Main');
+      expect(result).toContain('Conteúdo: Conteúdo Main');
+      expect(result).toContain('CTA: CTA Main');
+      expect(result).toContain('--- POST FOLLOW-UP 1 (2/2) ---');
+      expect(result).toContain('Título: Título Followup');
+    });
+  });
+});


### PR DESCRIPTION
Adapted short post generation ('Posts Curtos') for campaigns where posts are manually generated/imported without problem/solution definitions. The application now calculates promptNumRecords based on the total available posts (1 Main Post + N Follow-up Posts), formats the base text from each post, displays contextual UI alerts, and generates 1 short post per campaign post using Gemini AI.

---
*PR created automatically by Jules for task [690587270026504198](https://jules.google.com/task/690587270026504198) started by @cvazquezbr*