### PR TITLE
Convert campaign posts directly into short post records when no probl…

### DIFF
--- a/src/components/PostsCurtosStep.jsx
+++ b/src/components/PostsCurtosStep.jsx
@@ -152,7 +152,7 @@ const PostsCurtosStep = ({
                 )}
                 {!hasProblemaSolucao && hasPosts && (
                   <Alert severity="info" sx={{ mb: 2 }}>
-                    Sem problema/solução definidos. A IA utilizará os {promptNumRecords} post(s) da campanha (Post Principal e Follow-ups) como base para gerar os posts curtos.
+                    Sem problema/solução definidos. Ao gerar, a aplicação converterá os {promptNumRecords} post(s) da campanha (Post Principal e Follow-ups) diretamente como registros de posts curtos.
                   </Alert>
                 )}
                 <Typography gutterBottom>Quantidade de Posts</Typography>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -22,7 +22,7 @@ import { checkAuthStatus } from '../utils/auth';
 import { getPersonas, savePersona, updatePersona } from '../utils/personaState';
 import { getAutores } from '../utils/autorState';
 import { getPalettes } from '../utils/paletteState';
-import { hasProblemaSolucao, getAvailableCampaignPosts, buildPromptTextFromPosts } from '../utils/campaignUtils';
+import { hasProblemaSolucao, getAvailableCampaignPosts, convertPostsToCsvData, getMainPostPromptText } from '../utils/campaignUtils';
 
 import MyCampaignsStep from '../components/MyCampaignsStep';
 import SharedCampaignsStep from '../components/SharedCampaignsStep';
@@ -359,27 +359,26 @@ function HomePage() {
     document.documentElement.classList.toggle('dark-mode-active', darkMode);
   }, [darkMode]);
 
-  // Sincroniza a quantidade de posts e o texto base quando não houver problema/solução, mas existirem posts
+  // Sincroniza a quantidade de posts e a descrição do conteúdo (Conteúdo + CTA)
   useEffect(() => {
     if (activeStep === 2) {
-      if (!hasProblemaSolucao(campaignState)) {
-        const posts = getAvailableCampaignPosts(campaignState);
-        if (posts.length > 0) {
-          const autoPromptText = buildPromptTextFromPosts(posts);
-          setCampaignState(prev => {
-            if (prev.promptNumRecords !== posts.length || prev.promptText !== autoPromptText) {
-              return {
-                ...prev,
-                promptNumRecords: posts.length,
-                promptText: autoPromptText,
-              };
-            }
-            return prev;
-          });
+      const posts = getAvailableCampaignPosts(campaignState);
+      const mainPromptText = getMainPostPromptText(campaignState);
+      setCampaignState(prev => {
+        let updates = {};
+        if (posts.length > 0 && prev.promptNumRecords !== posts.length) {
+          updates.promptNumRecords = posts.length;
         }
-      }
+        if (mainPromptText && (!prev.promptText || !prev.promptText.trim())) {
+          updates.promptText = mainPromptText;
+        }
+        if (Object.keys(updates).length > 0) {
+          return { ...prev, ...updates };
+        }
+        return prev;
+      });
     }
-  }, [activeStep, campaignState.problema, campaignState.solucao, campaignState.campaignContent, campaignState.followupPosts, setCampaignState]);
+  }, [activeStep, campaignState.campaignContent, campaignState.followupPosts, setCampaignState]);
 
   const extractColorPalette = useCallback((url, setter) => {
     if (!url) { setter([]); return; }
@@ -795,7 +794,8 @@ function HomePage() {
         model: settings.gemini_model,
         apiKey: settings.gemini_api_key
       });
-      setCampaignState(prev => ({ ...prev, campaignContent: content, promptText: `${content.titulo || ''}\n\n${content.conteudo || ''}\n\n${content.cta || ''}` }));
+      const mainPromptText = `${content.conteudo || ''}\n\n${content.cta || ''}`.trim();
+      setCampaignState(prev => ({ ...prev, campaignContent: content, promptText: mainPromptText }));
       if (regenerate) { toast.success("Conteúdo principal regenerado."); return; }
       setCampaignState(prev => ({ ...prev, followupPosts: [] }));
       await Promise.all([ handleGenerateSummary(1800, content), handleGenerateSummary(130, content) ]);
@@ -959,19 +959,49 @@ function HomePage() {
   const handleGenerateIAContent = async () => {
     setIsGenerating(true); setGenerationStatus('Gerando posts...');
     try {
-      let effectivePromptText = campaignState.promptText;
-      let effectivePromptNumRecords = campaignState.promptNumRecords;
-
       if (!hasProblemaSolucao(campaignState)) {
         const posts = getAvailableCampaignPosts(campaignState);
         if (posts.length > 0) {
-          effectivePromptNumRecords = posts.length;
-          effectivePromptText = buildPromptTextFromPosts(posts);
-        } else if (!effectivePromptText?.trim()) {
-          toast.error('Nenhum conteúdo de post ou problema/solução foi fornecido.');
+          const { data: convertedData, headers: convertedHeaders } = convertPostsToCsvData(campaignState);
+
+          const { newPositions, newStyles } = autoArrangeFields({
+            csvHeaders: convertedHeaders,
+            fieldPositions: {},
+            fieldStyles: {},
+            csvData: convertedData,
+            effectiveImageSize: originalImageSize
+          });
+
+          const newGeneratedPagesData = convertedData.map((record, index) => ({
+            index,
+            record,
+            blob: null,
+            url: null,
+            filename: `midiator_${String(index + 1).padStart(3, '0')}.png`
+          }));
+
+          setCampaignState(prev => ({
+            ...prev,
+            csvData: convertedData,
+            csvHeaders: convertedHeaders,
+            fieldPositions: newPositions,
+            fieldStyles: newStyles,
+            initialFieldStyles: newStyles,
+            generatedPagesData: newGeneratedPagesData,
+            promptText: getMainPostPromptText(prev) || prev.promptText,
+            promptNumRecords: convertedData.length,
+          }));
+
+          setInputMethod('manual');
+          toast.success(`${convertedData.length} post(s) da campanha convertidos em registros.`);
           return;
         }
-      } else if (!effectivePromptText?.trim()) {
+      }
+
+      const effectivePromptText = campaignState.promptText || getMainPostPromptText(campaignState);
+      const effectivePromptNumRecords = campaignState.promptNumRecords || 1;
+
+      if (!effectivePromptText?.trim()) {
         toast.error('Por favor, forneça uma descrição do conteúdo para gerar com IA.');
         return;
       }

--- a/src/utils/campaignUtils.js
+++ b/src/utils/campaignUtils.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 const IGNORE_KEYS = new Set([
   'id', 'created_at', 'updated_at', 'user_id', 'paletteId', 'aspectRatio',
   'page_id', 'campaign_id', 'original_url', 'hex', 'rgb', 'prompt_imagem_carrossel',
@@ -222,6 +224,41 @@ export function getAvailableCampaignPosts(campaignState) {
     }
   });
   return posts;
+}
+
+/**
+ * Returns promptText containing only Main Post Content + CTA.
+ * @param {object} campaignState
+ * @returns {string}
+ */
+export function getMainPostPromptText(campaignState) {
+  const content = campaignState?.campaignContent;
+  if (!content) return '';
+  const parts = [];
+  if (content.conteudo?.trim()) parts.push(content.conteudo.trim());
+  if (content.cta?.trim()) parts.push(content.cta.trim());
+  return parts.join('\n\n');
+}
+
+/**
+ * Converts available campaign posts (Main Post + Follow-up Posts) directly into short post records for csvData.
+ * @param {object} campaignState
+ * @returns {{data: Array<object>, headers: Array<string>}}
+ */
+export function convertPostsToCsvData(campaignState) {
+  const posts = getAvailableCampaignPosts(campaignState);
+  if (posts.length === 0) return { data: [], headers: [] };
+
+  const headers = ["Título", "Texto Principal", "Ponte para o Próximo", "prompt_imagem_carrossel"];
+  const data = posts.map((post, index) => ({
+    id: uuidv4(),
+    "Título": post.titulo || `Página ${index + 1}`,
+    "Texto Principal": post.conteudo || '',
+    "Ponte para o Próximo": post.cta || '',
+    "prompt_imagem_carrossel": '',
+  }));
+
+  return { data, headers };
 }
 
 /**

--- a/src/utils/campaignUtils.test.js
+++ b/src/utils/campaignUtils.test.js
@@ -3,6 +3,8 @@ import {
   hasProblemaSolucao,
   getAvailableCampaignPosts,
   buildPromptTextFromPosts,
+  convertPostsToCsvData,
+  getMainPostPromptText,
 } from './campaignUtils';
 
 describe('campaignUtils - short post generation helpers', () => {
@@ -20,6 +22,22 @@ describe('campaignUtils - short post generation helpers', () => {
       expect(hasProblemaSolucao({ problema: 'Apenas problema' })).toBe(false);
       expect(hasProblemaSolucao({ solucao: 'Apenas solução' })).toBe(false);
       expect(hasProblemaSolucao({ problema: '   ', solucao: '  ' })).toBe(false);
+    });
+  });
+
+  describe('getMainPostPromptText', () => {
+    it('returns empty string if campaignContent is missing', () => {
+      expect(getMainPostPromptText({})).toBe('');
+    });
+
+    it('returns formatted content and CTA', () => {
+      const campaignState = {
+        campaignContent: {
+          conteudo: 'Conteúdo do post principal.',
+          cta: 'Clique aqui',
+        },
+      };
+      expect(getMainPostPromptText(campaignState)).toBe('Conteúdo do post principal.\n\nClique aqui');
     });
   });
 
@@ -69,6 +87,43 @@ describe('campaignUtils - short post generation helpers', () => {
         conteudo: 'Conteúdo do followup 2.',
         cta: 'Inscreva-se',
       });
+    });
+  });
+
+  describe('convertPostsToCsvData', () => {
+    it('returns empty data and headers if no posts exist', () => {
+      expect(convertPostsToCsvData({})).toEqual({ data: [], headers: [] });
+    });
+
+    it('converts campaign posts directly into short post records for csvData', () => {
+      const campaignState = {
+        campaignContent: {
+          titulo: 'Título Principal',
+          conteudo: 'Texto Principal',
+          cta: 'CTA Principal',
+        },
+        followupPosts: [
+          {
+            titulo: 'Título Followup 1',
+            conteudo: 'Texto Followup 1',
+            cta: 'CTA Followup 1',
+          },
+        ],
+      };
+
+      const { data, headers } = convertPostsToCsvData(campaignState);
+
+      expect(headers).toEqual(['Título', 'Texto Principal', 'Ponte para o Próximo', 'prompt_imagem_carrossel']);
+      expect(data.length).toBe(2);
+
+      expect(data[0]['Título']).toBe('Título Principal');
+      expect(data[0]['Texto Principal']).toBe('Texto Principal');
+      expect(data[0]['Ponte para o Próximo']).toBe('CTA Principal');
+      expect(data[0]['id']).toBeDefined();
+
+      expect(data[1]['Título']).toBe('Título Followup 1');
+      expect(data[1]['Texto Principal']).toBe('Texto Followup 1');
+      expect(data[1]['Ponte para o Próximo']).toBe('CTA Followup 1');
     });
   });
 


### PR DESCRIPTION
…ema/solucao exists

- Update convertPostsToCsvData and getMainPostPromptText in campaignUtils.js to convert Main Post + Follow-up posts into short post records.
- Update HomePage.jsx to convert campaign posts directly into records (matching manual creation format) when no problema/solucao exists, while preserving promptText focused on Main Post Conteúdo + CTA.
- Update UI alerts in PostsCurtosStep.jsx.
- Update unit tests in campaignUtils.test.js.